### PR TITLE
Fix: Correctly parse doc comments for type declarations

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -82,7 +82,11 @@ func (s *Scanner) parseGenDecl(decl *ast.GenDecl, info *PackageInfo) {
 	for _, spec := range decl.Specs {
 		switch sp := spec.(type) {
 		case *ast.TypeSpec:
-			info.Types = append(info.Types, s.parseTypeSpec(sp))
+			typeInfo := s.parseTypeSpec(sp)
+			if typeInfo.Doc == "" {
+				typeInfo.Doc = commentText(decl.Doc)
+			}
+			info.Types = append(info.Types, typeInfo)
 
 		case *ast.ValueSpec:
 			if decl.Tok == token.CONST {


### PR DESCRIPTION
The scanner was not correctly associating doc comments with type declarations when the comment was attached to the GenDecl node instead of the TypeSpec node. This change ensures that the GenDecl's doc comment is used if the TypeSpec's doc comment is empty.