### PR TITLE
feat: Allow overriding external type resolution via configuration

### DIFF
--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -18,7 +18,7 @@ func (m *MockResolver) ScanPackageByImport(importPath string) (*PackageInfo, err
 }
 
 func TestScanPackageFeatures(t *testing.T) {
-	s := New()
+	s := New(nil) // Pass nil for ExternalTypeOverride
 	pkgInfo, err := s.ScanPackage(filepath.Join("..", "testdata", "features"), &MockResolver{})
 	if err != nil {
 		t.Fatalf("ScanPackage failed: %v", err)

--- a/testdata/externaltypes/externaltypes.go
+++ b/testdata/externaltypes/externaltypes.go
@@ -1,0 +1,14 @@
+package externaltypes
+
+import "github.com/google/uuid" // This import path is used as a string key
+import "example.com/somepkg"     // This import path is used as a string key
+
+type ObjectWithUUID struct {
+	ID          uuid.UUID `json:"id"`
+	Description string    `json:"description"`
+}
+
+type ObjectWithCustomTime struct {
+	Timestamp somepkg.Time `json:"timestamp"`
+	Name      string       `json:"name"`
+}

--- a/testdata/externaltypes/go.mod
+++ b/testdata/externaltypes/go.mod
@@ -1,0 +1,3 @@
+module example.com/externaltypes
+
+go 1.20


### PR DESCRIPTION
This change introduces a mechanism to specify how types from external (or internal) packages should be interpreted by the scanner. Users can provide a mapping from a fully qualified type name (e.g., "github.com/google/uuid.UUID") to a target Go type string (e.g., "string").

This is useful for:
- Simplifying complex external types to common representations.
- Handling types from packages that are not available during scanning but whose structure is known (e.g. mapping to a primitive).

The following main changes were made:
- Added `ExternalTypeOverride` map to `goscan.Scanner` and `scanner.Scanner`.
- `goscan.Scanner` now has a `SetExternalTypeOverrides` method.
- `scanner.Scanner.parseTypeExpr` now checks these overrides.
- `scanner.FieldType` has an `IsResolvedByConfig` flag.
- `scanner.FieldType.Resolve()` now bypasses resolution if the type was resolved by config.
- Added tests for this new functionality.
- Updated README.md with documentation for this feature.