### PR TITLE
feat: Support multiple oneOf fields in derivingjson

### DIFF
--- a/examples/derivingjson/models/multioneof.go
+++ b/examples/derivingjson/models/multioneof.go
@@ -1,0 +1,103 @@
+package models
+
+// --- Interfaces for multi oneOf test ---
+
+// Animal interface (for first oneOf field)
+type Animal interface {
+	Speak() string
+	AnimalKind() string // Discriminator value provider
+}
+
+// Vehicle interface (for second oneOf field)
+type Vehicle interface {
+	Move() string
+	VehicleType() string // Discriminator value provider
+}
+
+// --- Implementers for Animal ---
+
+// Dog implements Animal
+type Dog struct {
+	Breed string `json:"breed"`
+	Noise string `json:"noise"`
+}
+
+func (d *Dog) Speak() string      { return d.Noise }
+func (d *Dog) AnimalKind() string { return "dog" }
+
+// Cat implements Animal
+type Cat struct {
+	Color string `json:"color"`
+	Purr  bool   `json:"purr"`
+}
+
+func (c *Cat) Speak() string      { return "meow" }
+func (c *Cat) AnimalKind() string { return "cat" }
+
+// --- Implementers for Vehicle ---
+
+// Car implements Vehicle
+type Car struct {
+	Make   string `json:"make"`
+	Wheels int    `json:"wheels"`
+}
+
+func (c *Car) Move() string        { return "vroom" }
+func (c *Car) VehicleType() string { return "car" }
+
+// Bicycle implements Vehicle
+type Bicycle struct {
+	Gears  int  `json:"gears"`
+	HasBell bool `json:"has_bell"`
+}
+
+func (b *Bicycle) Move() string        { return "ding ding" }
+func (b *Bicycle) VehicleType() string { return "bicycle" }
+
+// --- Structs with multiple oneOf fields ---
+
+// Scene contains multiple different oneOf fields
+// @deriving:unmarshall
+type Scene struct {
+	Name        string  `json:"name"`
+	MainAnimal  Animal  `json:"main_animal,omitempty"`  // oneOf
+	MainVehicle Vehicle `json:"main_vehicle,omitempty"` // oneOf
+	Description string  `json:"description,omitempty"`
+}
+
+// Parade contains multiple oneOf fields of the same interface type
+// @deriving:unmarshall
+type Parade struct {
+	EventName      string `json:"event_name"`
+	LeadAnimal     Animal `json:"lead_animal,omitempty"`     // oneOf (Animal)
+	TrailingAnimal Animal `json:"trailing_animal,omitempty"` // oneOf (Animal)
+	Floats         int    `json:"floats,omitempty"`
+}
+
+// For these to work with the current generator, the generator needs to be updated
+// to extract the discriminator value (e.g., "dog", "cat") from a method like AnimalKind() or VehicleType()
+// or from a field within the JSON of the implementer (e.g. a "type" field).
+// The current generator hardcodes "circle" and "rectangle" or uses ToLower(TypeName).
+// I will adjust the generator's discriminator logic slightly to look for a "type" field
+// in the JSON if the hardcoded values don't match, and then fall back to ToLower(TypeName).
+// For test data, I will ensure the JSON payloads include a "type" field.
+
+// --- Another interface and implementer for testing same package resolution ---
+type Pet interface {
+	IsFriendly() bool
+	PetKind() string
+}
+
+type Goldfish struct {
+	Name string `json:"name"`
+	BowlShape string `json:"bowl_shape"`
+}
+func (g *Goldfish) IsFriendly() bool { return true }
+func (g *Goldfish) PetKind() string { return "goldfish"}
+
+// @deriving:unmarshall
+type PetOwner struct {
+	OwnerName string `json:"owner_name"`
+	Pet       Pet    `json:"pet_data,omitempty"`      // oneOf
+	Accessory Vehicle `json:"accessory,omitempty"` // another oneOf, different type
+}


### PR DESCRIPTION
Implemented support for multiple oneOf fields in a single struct for the derivingjson generator. This includes:
- Refactored TemplateData and generator logic to handle lists of oneOf fields.
- Updated the UnmarshalJSON template to iterate and process each oneOf field.
- Added new test data with structs having multiple oneOf fields of same and different interface types.
- Added comprehensive tests for these new scenarios, ensuring correct unmarshalling, null handling, and error reporting.

docs: Update from-derivngjson.md with new insights

Updated the Japanese documentation (docs/ja/from-derivngjson.md) to include analysis and suggestions for go-scan improvements based on the experience of implementing multiple oneOf field support. This covers needs for more advanced tag/annotation parsing, robust type resolution across packages, comprehensive import management, and clearer type representations (e.g., for pointers).