### PR TITLE
Fix: Prevent warnings for built-in types in derivingjson

### DIFF
--- a/examples/derivingjson/generator.go
+++ b/examples/derivingjson/generator.go
@@ -158,7 +158,7 @@ func Generate(pkgPath string) error {
 				if field.Type.PkgName == "" || field.Type.PkgName == pkgInfo.Name {
 					resolvedFieldType = findTypeInPackage(pkgInfo, field.Type.Name)
 				}
-				if resolvedFieldType == nil { // if still nil after local lookup or if external
+				if resolvedFieldType == nil && !field.Type.IsBuiltin { // if still nil after local lookup or if external, and not a builtin
 					fmt.Printf("      Warning: Error resolving field %s type %s (pkg %s): %v. Will proceed if it's an interface for oneOf.\n", field.Name, field.Type.Name, field.Type.PkgName, errResolve)
 				}
 			}

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -343,6 +343,14 @@ func (s *Scanner) parseTypeExpr(expr ast.Expr) *FieldType {
 	switch t := expr.(type) {
 	case *ast.Ident:
 		ft.Name = t.Name
+		// Check if it's a built-in type
+		// https://golang.org/ref/spec#Predeclared_identifiers
+		switch t.Name {
+		case "bool", "byte", "complex64", "complex128", "error", "float32", "float64",
+			"int", "int8", "int16", "int32", "int64", "rune", "string",
+			"uint", "uint8", "uint16", "uint32", "uint64", "uintptr":
+			ft.IsBuiltin = true
+		}
 	case *ast.StarExpr:
 		underlyingType := s.parseTypeExpr(t.X)
 		underlyingType.IsPointer = true


### PR DESCRIPTION
Modified `scanner/scanner.go` and `scanner/models.go` to correctly identify and handle built-in types during type resolution. This prevents unnecessary warnings when running `make` in `examples/derivingjson`.

- Added `IsBuiltin` field to `FieldType` in `scanner/models.go`.
- Updated `parseTypeExpr` in `scanner/scanner.go` to set `IsBuiltin` for Go built-in types.
- Modified `FieldType.Resolve()` in `scanner/models.go` to avoid returning errors for built-in types.
- Adjusted `examples/derivingjson/generator.go` to not print warnings for built-in types that don't resolve to a full `TypeInfo`.