### PR TITLE
refactor: binding package in derivingbind example

### DIFF
--- a/examples/derivingbind/Makefile
+++ b/examples/derivingbind/Makefile
@@ -1,10 +1,13 @@
-.PHONY: all emit-simple clean
+.PHONY: all emit-simple clean test
 
 all: emit-simple
 
 emit-simple:
 	@echo "Generating for testdata/simple"
 	@go run ./ ./testdata/simple
+
+test:
+	go test ./...
 
 clean:
 	@echo "Cleaning generated files..."

--- a/examples/derivingbind/binding/binding.go
+++ b/examples/derivingbind/binding/binding.go
@@ -1,0 +1,200 @@
+// Package binding provides a type-safe, reflect-free, and expression-oriented
+// way to bind data from HTTP requests to Go structs.
+package binding
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/textproto"
+	"strings"
+)
+
+// Source represents the source of a value in an HTTP request.
+type Source string
+
+const (
+	Query  Source = "query"
+	Header Source = "header"
+	Cookie Source = "cookie"
+	Path   Source = "path"
+)
+
+// Requirement specifies whether a value is required or optional.
+type Requirement bool
+
+const (
+	Required Requirement = true
+	Optional Requirement = false
+)
+
+// Parser is a generic function that parses a string into a value of type T.
+// It returns an error if parsing fails.
+type Parser[T any] func(string) (T, error)
+
+// Binding holds the context for a binding operation, including the HTTP request
+// and a function to retrieve path parameters.
+type Binding struct {
+	req       *http.Request
+	pathValue func(string) string
+}
+
+// New creates a new Binding instance from an *http.Request and a function to retrieve path parameters.
+// The pathValue function is typically provided by a routing library (e.g., chi, gorilla/mux).
+func New(req *http.Request, pathValue func(string) string) *Binding {
+	return &Binding{req: req, pathValue: pathValue}
+}
+
+// Lookup is an internal method that retrieves a value and its existence from a given source.
+// It abstracts away the differences in how each source (query, header, etc.) is accessed.
+func (b *Binding) Lookup(source Source, key string) (string, bool) {
+	switch source {
+	case Query:
+		// .Query().Has() is available in Go 1.17+ and checks for key presence.
+		if b.req.URL.Query().Has(key) {
+			return b.req.URL.Query().Get(key), true
+		}
+		return "", false
+	case Header:
+		// Header keys are case-insensitive.
+		canonicalKey := textproto.CanonicalMIMEHeaderKey(key)
+		if vals, ok := b.req.Header[canonicalKey]; ok {
+			// A key's presence, even with an empty value, is considered "exists".
+			if len(vals) > 0 {
+				return vals[0], true
+			}
+			return "", true // e.g., "X-Custom-Header:"
+		}
+		return "", false
+	case Cookie:
+		cookie, err := b.req.Cookie(key)
+		if err == nil { // If err is nil, the cookie exists.
+			return cookie.Value, true
+		}
+		return "", false // e.g., http.ErrNoCookie
+	case Path:
+		if b.pathValue != nil {
+			val := b.pathValue(key)
+			if val != "" {
+				return val, true
+			}
+			return "", false
+		}
+		return "", false
+	}
+	return "", false
+}
+
+// One binds a single value of a non-pointer type (e.g., int, string).
+// 'dest' must be a pointer to the field where the value will be stored (e.g., &r.ID).
+func One[T any](b *Binding, dest *T, source Source, key string, parse Parser[T], req Requirement) error {
+	valStr, ok := b.Lookup(source, key)
+	if !ok {
+		if req == Required {
+			return fmt.Errorf("binding: %s key '%s' is required", source, key)
+		}
+		return nil // Optional and not present is a success.
+	}
+
+	// For optional fields, an empty value is often treated as "not provided".
+	// If you need to handle empty but present values, the logic can be adjusted here.
+	if !ok && req == Optional {
+		return nil
+	}
+
+	val, err := parse(valStr)
+	if err != nil {
+		return fmt.Errorf("binding: failed to parse %s key '%s' with value %q: %w", source, key, valStr, err)
+	}
+
+	*dest = val
+	return nil
+}
+
+// OnePtr binds a single value of a pointer type (e.g., *int, *string).
+// 'dest' must be a pointer to the pointer field (e.g., &r.Name).
+// If the value is optional and not present, the destination pointer is set to nil.
+func OnePtr[T any](b *Binding, dest **T, source Source, key string, parse Parser[T], req Requirement) error {
+	valStr, ok := b.Lookup(source, key)
+	if !ok {
+		if req == Required {
+			return fmt.Errorf("binding: %s key '%s' is required", source, key)
+		}
+		*dest = nil // Optional and not present: set field to nil.
+		return nil
+	}
+
+	val, err := parse(valStr)
+	if err != nil {
+		return fmt.Errorf("binding: failed to parse %s key '%s' with value %q: %w", source, key, valStr, err)
+	}
+
+	*dest = &val // Store the address of the parsed value.
+	return nil
+}
+
+// Slice binds a comma-separated string into a slice of a non-pointer type (e.g., []int, []string).
+// 'dest' must be a pointer to the slice field (e.g., &r.Tags).
+func Slice[T any](b *Binding, dest *[]T, source Source, key string, parse Parser[T], req Requirement) error {
+	valStr, ok := b.Lookup(source, key)
+	if !ok {
+		if req == Required {
+			return fmt.Errorf("binding: %s key '%s' is required", source, key)
+		}
+		*dest = nil
+		return nil
+	}
+
+	itemsStr := strings.Split(valStr, ",")
+	slice := make([]T, 0, len(itemsStr))
+	var errs []error
+
+	for i, itemStr := range itemsStr {
+		trimmed := strings.TrimSpace(itemStr)
+		if trimmed == "" {
+			continue // Skip empty items, e.g., "a,,b"
+		}
+		val, err := parse(trimmed)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("binding: failed to parse item #%d for %s key '%s' with value %q: %w", i, source, key, itemStr, err))
+			continue
+		}
+		slice = append(slice, val)
+	}
+
+	*dest = slice
+	return errors.Join(errs...)
+}
+
+// SlicePtr binds a comma-separated string into a slice of a pointer type (e.g., []*int, []*string).
+// 'dest' must be a pointer to the slice field (e.g., &r.CategoryIDs).
+func SlicePtr[T any](b *Binding, dest *[]*T, source Source, key string, parse Parser[T], req Requirement) error {
+	valStr, ok := b.Lookup(source, key)
+	if !ok {
+		if req == Required {
+			return fmt.Errorf("binding: %s key '%s' is required", source, key)
+		}
+		*dest = nil
+		return nil
+	}
+
+	itemsStr := strings.Split(valStr, ",")
+	slice := make([]*T, 0, len(itemsStr))
+	var errs []error
+
+	for i, itemStr := range itemsStr {
+		trimmed := strings.TrimSpace(itemStr)
+		if trimmed == "" {
+			continue
+		}
+		val, err := parse(trimmed)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("binding: failed to parse item #%d for %s key '%s' with value %q: %w", i, source, key, itemStr, err))
+			continue
+		}
+		slice = append(slice, &val)
+	}
+
+	*dest = slice
+	return errors.Join(errs...)
+}

--- a/examples/derivingbind/binding/binding_test.go
+++ b/examples/derivingbind/binding/binding_test.go
@@ -1,0 +1,258 @@
+package binding_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/podhmo/go-scan/examples/derivingbind/binding"
+	"github.com/podhmo/go-scan/examples/derivingbind/parser"
+)
+
+func newBindingForTest(req *http.Request, pathParams map[string]string) *binding.Binding {
+	var pathValue func(string) string
+	if pathParams != nil {
+		pathValue = func(key string) string {
+			return pathParams[key]
+		}
+	}
+	return binding.New(req, pathValue)
+}
+
+func TestOne(t *testing.T) {
+	t.Run("success from query", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/?id=123", nil)
+		b := newBindingForTest(req, nil)
+
+		var id int
+		err := binding.One(b, &id, binding.Query, "id", parser.Int, binding.Required)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id != 123 {
+			t.Errorf("expected id to be 123, got %d", id)
+		}
+	})
+
+	t.Run("success from header", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("X-API-Key", "secret-key")
+		b := newBindingForTest(req, nil)
+
+		var key string
+		err := binding.One(b, &key, binding.Header, "x-api-key", parser.String, binding.Required)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if key != "secret-key" {
+			t.Errorf("expected key to be 'secret-key', got %q", key)
+		}
+	})
+
+	t.Run("success from cookie", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.AddCookie(&http.Cookie{Name: "session_id", Value: "session-123"})
+		b := newBindingForTest(req, nil)
+
+		var sid string
+		err := binding.One(b, &sid, binding.Cookie, "session_id", parser.String, binding.Required)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sid != "session-123" {
+			t.Errorf("expected sid to be 'session-123', got %q", sid)
+		}
+	})
+
+	t.Run("success from path", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/users/456", nil)
+		params := map[string]string{"userId": "456"}
+		b := newBindingForTest(req, params)
+
+		var uid int
+		err := binding.One(b, &uid, binding.Path, "userId", parser.Int, binding.Required)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if uid != 456 {
+			t.Errorf("expected uid to be 456, got %d", uid)
+		}
+	})
+
+	t.Run("error when required key is missing", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		b := newBindingForTest(req, nil)
+
+		var val string
+		err := binding.One(b, &val, binding.Query, "missing_key", parser.String, binding.Required)
+		if err == nil {
+			t.Fatal("expected an error, but got nil")
+		}
+		expectedMsg := "binding: query key 'missing_key' is required"
+		if err.Error() != expectedMsg {
+			t.Errorf("expected error message %q, got %q", expectedMsg, err.Error())
+		}
+	})
+
+	t.Run("no error when optional key is missing", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		b := newBindingForTest(req, nil)
+
+		var val string = "default"
+		err := binding.One(b, &val, binding.Query, "missing_key", parser.String, binding.Optional)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if val != "default" {
+			t.Errorf("expected val to remain 'default', got %q", val)
+		}
+	})
+
+	t.Run("error on parse failure", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/?id=abc", nil)
+		b := newBindingForTest(req, nil)
+
+		var id int
+		err := binding.One(b, &id, binding.Query, "id", parser.Int, binding.Required)
+		if err == nil {
+			t.Fatal("expected an error, but got nil")
+		}
+		if !errors.Is(err, strconv.ErrSyntax) {
+			t.Errorf("expected error to wrap strconv.ErrSyntax, but it did not")
+		}
+		expectedMsg := `binding: failed to parse query key 'id' with value "abc": strconv.Atoi: parsing "abc": invalid syntax`
+		if err.Error() != expectedMsg {
+			t.Errorf("expected error message %q, got %q", expectedMsg, err.Error())
+		}
+	})
+}
+
+func TestOnePtr(t *testing.T) {
+	t.Run("success binding to pointer", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/?name=gopher", nil)
+		b := newBindingForTest(req, nil)
+
+		var name *string
+		err := binding.OnePtr(b, &name, binding.Query, "name", parser.String, binding.Required)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if name == nil {
+			t.Fatal("expected name to be non-nil")
+		}
+		if *name != "gopher" {
+			t.Errorf("expected name to be 'gopher', got %q", *name)
+		}
+	})
+
+	t.Run("optional key missing results in nil pointer", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		b := newBindingForTest(req, nil)
+
+		// Initialize with a non-nil pointer to check if it's set to nil
+		initialVal := "not-nil"
+		var name *string = &initialVal
+
+		err := binding.OnePtr(b, &name, binding.Query, "name", parser.String, binding.Optional)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if name != nil {
+			t.Errorf("expected name to be nil, got %q", *name)
+		}
+	})
+}
+
+func TestSlice(t *testing.T) {
+	t.Run("success binding slice", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/?ids=1,2,3", nil)
+		b := newBindingForTest(req, nil)
+
+		var ids []int
+		err := binding.Slice(b, &ids, binding.Query, "ids", parser.Int, binding.Required)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 3 {
+			t.Fatalf("expected slice length 3, got %d", len(ids))
+		}
+		if ids[0] != 1 || ids[1] != 2 || ids[2] != 3 {
+			t.Errorf("expected ids [1 2 3], got %v", ids)
+		}
+	})
+
+	t.Run("success with spaces and empty items", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/?tags=go,%20generics,,%20fun%20", nil)
+		b := newBindingForTest(req, nil)
+
+		var tags []string
+		err := binding.Slice(b, &tags, binding.Query, "tags", parser.String, binding.Required)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expected := []string{"go", "generics", "fun"}
+		if len(tags) != len(expected) {
+			t.Fatalf("expected slice length %d, got %d", len(expected), len(tags))
+		}
+		for i := range tags {
+			if tags[i] != expected[i] {
+				t.Errorf("expected tags %v, got %v", expected, tags)
+				break
+			}
+		}
+	})
+
+	t.Run("optional and missing results in nil slice", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		b := newBindingForTest(req, nil)
+
+		ids := []int{99} // pre-fill to check if it's set to nil
+		err := binding.Slice(b, &ids, binding.Query, "ids", parser.Int, binding.Optional)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ids != nil {
+			t.Errorf("expected slice to be nil, got %v", ids)
+		}
+	})
+
+	t.Run("error on partial parse failure", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/?ids=1,two,3", nil)
+		b := newBindingForTest(req, nil)
+
+		var ids []int
+		err := binding.Slice(b, &ids, binding.Query, "ids", parser.Int, binding.Required)
+		if err == nil {
+			t.Fatal("expected an error, but got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to parse item #1") {
+			t.Errorf("error message should contain 'failed to parse item #1', got %q", err.Error())
+		}
+		// The slice should contain the successfully parsed items
+		if len(ids) != 2 || ids[0] != 1 || ids[1] != 3 {
+			t.Errorf("expected successfully parsed items [1 3], got %v", ids)
+		}
+	})
+}
+
+func TestSlicePtr(t *testing.T) {
+	t.Run("success binding pointer slice", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/?ids=10,20", nil)
+		b := newBindingForTest(req, nil)
+
+		var ids []*int
+		err := binding.SlicePtr(b, &ids, binding.Query, "ids", parser.Int, binding.Required)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 2 {
+			t.Fatalf("expected slice length 2, got %d", len(ids))
+		}
+		if *ids[0] != 10 || *ids[1] != 20 {
+			t.Errorf("expected ids [10 20], got [%d %d]", *ids[0], *ids[1])
+		}
+	})
+}

--- a/examples/derivingbind/parser/parsers.go
+++ b/examples/derivingbind/parser/parsers.go
@@ -1,0 +1,32 @@
+// Package parser provides a set of standard parser functions for use with
+// the binding package. These parser convert strings to common Go types.
+package parser
+
+import (
+	"strconv"
+)
+
+// String is a parser for the string type.
+// It always succeeds and returns the input string as is.
+func String(s string) (string, error) {
+	return s, nil
+}
+
+// Int is a parser for the int type.
+// It uses strconv.Atoi for conversion.
+func Int(s string) (int, error) {
+	return strconv.Atoi(s)
+}
+
+// Bool is a parser for the bool type.
+// It uses strconv.ParseBool, which accepts "1", "t", "T", "TRUE", "true", "True",
+// "0", "f", "F", "FALSE", "false", "False".
+func Bool(s string) (bool, error) {
+	return strconv.ParseBool(s)
+}
+
+// Float64 is a parser for the float64 type.
+// It uses strconv.ParseFloat for conversion.
+func Float64(s string) (float64, error) {
+	return strconv.ParseFloat(s, 64)
+}

--- a/examples/derivingbind/parser/parsers_test.go
+++ b/examples/derivingbind/parser/parsers_test.go
@@ -1,0 +1,89 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/podhmo/go-scan/examples/derivingbind/parser"
+)
+
+func TestString(t *testing.T) {
+	val, err := parser.String("hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "hello" {
+		t.Errorf("expected 'hello', got %q", val)
+	}
+}
+
+func TestInt(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		val, err := parser.Int("123")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if val != 123 {
+			t.Errorf("expected 123, got %d", val)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := parser.Int("abc")
+		if err == nil {
+			t.Fatal("expected an error, but got nil")
+		}
+	})
+}
+
+func TestBool(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected bool
+		hasError bool
+	}{
+		{"true", true, false},
+		{"false", false, false},
+		{"1", true, false},
+		{"0", false, false},
+		{"T", true, false},
+		{"F", false, false},
+		{"invalid", false, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			val, err := parser.Bool(tc.input)
+			if tc.hasError {
+				if err == nil {
+					t.Fatal("expected an error, but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if val != tc.expected {
+					t.Errorf("expected %v, got %v", tc.expected, val)
+				}
+			}
+		})
+	}
+}
+
+func TestFloat64(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		val, err := parser.Float64("3.14")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if val != 3.14 {
+			t.Errorf("expected 3.14, got %f", val)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := parser.Float64("not-a-float")
+		if err == nil {
+			t.Fatal("expected an error, but got nil")
+		}
+	})
+}


### PR DESCRIPTION
This pull request introduces a new `binding` package for type-safe data binding from HTTP requests to Go structs, along with a `parser` package for common data type parsers. It also includes comprehensive test coverage for both packages. The key changes are grouped below:

### New `binding` Package
* Added `binding` package to provide a reflect-free, expression-oriented way to bind HTTP request data to Go structs. It supports various sources (`query`, `header`, `cookie`, `path`) and includes methods like `One`, `OnePtr`, `Slice`, and `SlicePtr` for binding single values, pointers, and slices. (`examples/derivingbind/binding/binding.go`)

### New `parser` Package
* Introduced a `parser` package with functions (`String`, `Int`, `Bool`, `Float64`) for converting strings to common Go types, using standard library methods like `strconv`. (`examples/derivingbind/parser/parsers.go`)

### Test Coverage for `binding` Package
* Added extensive tests for the `binding` package, covering scenarios like required/optional keys, missing keys, parsing failures, and successful bindings from different sources (query, header, cookie, path). (`examples/derivingbind/binding/binding_test.go`)

### Test Coverage for `parser` Package
* Added unit tests for all parser functions to validate their correctness and error handling. (`examples/derivingbind/parser/parsers_test.go`)