### PR TITLE
Refactor derivingbind generator to use errors.Join

### DIFF
--- a/examples/derivingbind/bind_method.tmpl
+++ b/examples/derivingbind/bind_method.tmpl
@@ -28,98 +28,70 @@ FieldBindingInfo struct {
 */}}
 func (s *{{.StructName}}) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
-
+	return errors.Join(
 	{{range .Fields}}
-	{{if .IsBody}}
-	// Body binding for field {{.FieldName}} ({{.OriginalFieldTypeString}}) will be handled after other fields.
-	{{else}}
-	{{$bindSource := ""}}
-	{{if eq .BindFrom "query"}}
-		{{$bindSource = "binding.Query"}}
-	{{else if eq .BindFrom "header"}}
-		{{$bindSource = "binding.Header"}}
-	{{else if eq .BindFrom "cookie"}}
-		{{$bindSource = "binding.Cookie"}}
-	{{else if eq .BindFrom "path"}}
-		{{$bindSource = "binding.Path"}}
-	{{end}}
-
-	{{$requiredVar := "binding.Optional"}}
-	{{if .IsRequired}}
-		{{$requiredVar = "binding.Required"}}
-	{{end}}
-
-	{{if .IsSlice}}
-		{{if .IsSliceElementPointer}} // e.g. []*int, []*string - uses binding.SlicePtr
-			if err := binding.SlicePtr(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}); err != nil {
-				errs = append(errs, err)
-			}
-		{{else}} // e.g. []int, []string - uses binding.Slice
-			if err := binding.Slice(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}); err != nil {
-				errs = append(errs, err)
-			}
+		{{if not .IsBody}}
+		{{$bindSource := ""}}
+		{{if eq .BindFrom "query"}}{{$bindSource = "binding.Query"}}
+		{{else if eq .BindFrom "header"}}{{$bindSource = "binding.Header"}}
+		{{else if eq .BindFrom "cookie"}}{{$bindSource = "binding.Cookie"}}
+		{{else if eq .BindFrom "path"}}{{$bindSource = "binding.Path"}}
 		{{end}}
-	{{else}}
-		{{if .IsPointer}} // Pointer to a value, e.g., *int, *string (but not a slice)
-			if err := binding.OnePtr(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}); err != nil {
-				errs = append(errs, err)
-			}
-		{{else}} // Value, e.g., int, string
-			if err := binding.One(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}); err != nil {
-				errs = append(errs, err)
-			}
-		{{end}}
-	{{end}}
-	{{end}}
-	{{end}}
-
-	{{if .NeedsBody}}
-	if req.Body != nil && req.Body != http.NoBody {
-		var bodyHandledBySpecificField = false
-		{{range .Fields}}
-		{{if .IsBody}}
-		// Field {{.FieldName}} (type {{.OriginalFieldTypeString}}) is the target for the entire request body
-		if decErr := json.NewDecoder(req.Body).Decode(&s.{{.FieldName}}); decErr != nil {
-			if decErr != io.EOF { // EOF might be acceptable if body is optional and empty
-				errs = append(errs, fmt.Errorf("binding: failed to decode request body into field {{.FieldName}}: %w", decErr))
-			}
-		}
-		bodyHandledBySpecificField = true
-		goto afterBodyProcessing // Assume only one field can be 'in:"body"'
-		{{end}}
-		{{end}}
-
-		// If no specific field was designated 'in:"body"', decode into the struct 's' itself.
-		if !bodyHandledBySpecificField {
-			if decErr := json.NewDecoder(req.Body).Decode(s); decErr != nil {
-				if decErr != io.EOF { // EOF might be acceptable if body is optional and empty
-					errs = append(errs, fmt.Errorf("binding: failed to decode request body into struct {{.StructName}}: %w", decErr))
-				}
-			}
-		}
-		{{if .HasSpecificBodyFieldTarget}}afterBodyProcessing:{{end}} // Label for goto, only if a specific body field might use it
-	} else {
-		// Check if body was required.
-		// This logic assumes that if 'NeedsBody' is true, and there's a field marked as 'IsBody' and 'IsRequired',
-		// or if the struct itself is implicitly the body and some overall "body required" rule applies (not yet implemented in detail).
-		isStructOrFieldBodyRequired := false
-		{{if not .HasSpecificBodyFieldTarget}}
-			// If struct is implicitly the body target, determine if it's required.
-			// This might need a struct-level "required" annotation for the body.
-			// For now, if NeedsBody is true and no specific field, we might assume optional unless specified.
-			// Let's make it an error only if a *specific* body field was required.
-		{{end}}
-		{{range .Fields}}
-			{{if and .IsBody .IsRequired}}
-			isStructOrFieldBodyRequired = true
+		{{$requiredVar := "binding.Optional"}}{{if .IsRequired}}{{$requiredVar = "binding.Required"}}{{end}}
+		{{if .IsSlice}}
+			{{if .IsSliceElementPointer}}
+			binding.SlicePtr(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}), // Field: {{.FieldName}} ({{.OriginalFieldTypeString}})
+			{{else}}
+			binding.Slice(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}), // Field: {{.FieldName}} ({{.OriginalFieldTypeString}})
+			{{end}}
+		{{else}}
+			{{if .IsPointer}}
+			binding.OnePtr(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}), // Field: {{.FieldName}} ({{.OriginalFieldTypeString}})
+			{{else}}
+			binding.One(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}), // Field: {{.FieldName}} ({{.OriginalFieldTypeString}})
 			{{end}}
 		{{end}}
-		if isStructOrFieldBodyRequired {
-			errs = append(errs, errors.New("binding: request body is required but was not provided or was empty"))
-		}
-	}
+		{{end}}
 	{{end}}
-
-	return errors.Join(errs...)
+	{{if .NeedsBody}}
+		func() error { // Anonymous function to handle body binding logic
+			if req.Body != nil && req.Body != http.NoBody {
+				var bodyHandledBySpecificField = false
+				{{range .Fields}}
+				{{if .IsBody}}
+				// Field {{.FieldName}} (type {{.OriginalFieldTypeString}}) is the target for the entire request body
+				if decErr := json.NewDecoder(req.Body).Decode(&s.{{.FieldName}}); decErr != nil {
+					if decErr != io.EOF { // EOF might be acceptable if body is optional and empty
+						return fmt.Errorf("binding: failed to decode request body into field {{.FieldName}}: %w", decErr)
+					}
+				}
+				bodyHandledBySpecificField = true
+				return nil // Successfully handled specific body field
+				{{end}}
+				{{end}}
+				// If no specific field was designated 'in:"body"', decode into the struct 's' itself.
+				if !bodyHandledBySpecificField {
+					if decErr := json.NewDecoder(req.Body).Decode(s); decErr != nil {
+						if decErr != io.EOF { // EOF might be acceptable if body is optional and empty
+							return fmt.Errorf("binding: failed to decode request body into struct {{.StructName}}: %w", decErr)
+						}
+					}
+				}
+				return nil // Body processed (or EOF ignored)
+			} else {
+				// Check if body was required.
+				isStructOrFieldBodyRequired := false
+				{{range .Fields}}
+					{{if and .IsBody .IsRequired}}
+					isStructOrFieldBodyRequired = true
+					{{end}}
+				{{end}}
+				if isStructOrFieldBodyRequired {
+					return errors.New("binding: request body is required but was not provided or was empty")
+				}
+			}
+			return nil // No body or body not required
+		}(),
+	{{end}}
+	)
 }

--- a/examples/derivingbind/integrationtest/integrationtest_deriving.go
+++ b/examples/derivingbind/integrationtest/integrationtest_deriving.go
@@ -11,738 +11,543 @@ import (
 
 func (s *TestBindStringQueryOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Query, "value", parser.String, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Query, "value", parser.String, binding.Optional), // Field: Value (string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindStringQueryRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Query, "value", parser.String, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Query, "value", parser.String, binding.Required), // Field: Value (string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrStringQueryOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Query, "value", parser.String, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Query, "value", parser.String, binding.Optional), // Field: Value (*string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrStringQueryRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Query, "value", parser.String, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Query, "value", parser.String, binding.Required), // Field: Value (*string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindStringHeaderOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Header, "X-Value", parser.String, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Header, "X-Value", parser.String, binding.Optional), // Field: Value (string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindStringHeaderRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Header, "X-Value", parser.String, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Header, "X-Value", parser.String, binding.Required), // Field: Value (string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrStringHeaderOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.String, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.String, binding.Optional), // Field: Value (*string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrStringHeaderRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.String, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.String, binding.Required), // Field: Value (*string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindStringCookieOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Cookie, "value", parser.String, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Cookie, "value", parser.String, binding.Optional), // Field: Value (string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindStringCookieRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Cookie, "value", parser.String, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Cookie, "value", parser.String, binding.Required), // Field: Value (string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrStringCookieOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Cookie, "value", parser.String, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Cookie, "value", parser.String, binding.Optional), // Field: Value (*string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrStringCookieRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Cookie, "value", parser.String, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Cookie, "value", parser.String, binding.Required), // Field: Value (*string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindStringPathOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Path, "value", parser.String, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Path, "value", parser.String, binding.Optional), // Field: Value (string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindStringPathRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Path, "value", parser.String, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Path, "value", parser.String, binding.Required), // Field: Value (string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrStringPathOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Path, "value", parser.String, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Path, "value", parser.String, binding.Optional), // Field: Value (*string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrStringPathRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Path, "value", parser.String, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Path, "value", parser.String, binding.Required), // Field: Value (*string)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindIntQueryOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Query, "value", parser.Int, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Query, "value", parser.Int, binding.Optional), // Field: Value (int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindIntQueryRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Query, "value", parser.Int, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Query, "value", parser.Int, binding.Required), // Field: Value (int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrIntQueryOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Query, "value", parser.Int, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Query, "value", parser.Int, binding.Optional), // Field: Value (*int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrIntQueryRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Query, "value", parser.Int, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Query, "value", parser.Int, binding.Required), // Field: Value (*int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindIntHeaderOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Header, "X-Value", parser.Int, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Header, "X-Value", parser.Int, binding.Optional), // Field: Value (int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindIntHeaderRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Header, "X-Value", parser.Int, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Header, "X-Value", parser.Int, binding.Required), // Field: Value (int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrIntHeaderOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.Int, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.Int, binding.Optional), // Field: Value (*int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrIntHeaderRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.Int, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.Int, binding.Required), // Field: Value (*int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindIntCookieOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Cookie, "value", parser.Int, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Cookie, "value", parser.Int, binding.Optional), // Field: Value (int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindIntCookieRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Cookie, "value", parser.Int, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Cookie, "value", parser.Int, binding.Required), // Field: Value (int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrIntCookieOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Cookie, "value", parser.Int, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Cookie, "value", parser.Int, binding.Optional), // Field: Value (*int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrIntCookieRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Cookie, "value", parser.Int, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Cookie, "value", parser.Int, binding.Required), // Field: Value (*int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindIntPathOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Path, "value", parser.Int, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Path, "value", parser.Int, binding.Optional), // Field: Value (int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindIntPathRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Path, "value", parser.Int, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Path, "value", parser.Int, binding.Required), // Field: Value (int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrIntPathOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Path, "value", parser.Int, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Path, "value", parser.Int, binding.Optional), // Field: Value (*int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrIntPathRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Path, "value", parser.Int, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Path, "value", parser.Int, binding.Required), // Field: Value (*int)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindBoolQueryOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Query, "value", parser.Bool, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Query, "value", parser.Bool, binding.Optional), // Field: Value (bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindBoolQueryRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Query, "value", parser.Bool, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Query, "value", parser.Bool, binding.Required), // Field: Value (bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrBoolQueryOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Query, "value", parser.Bool, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Query, "value", parser.Bool, binding.Optional), // Field: Value (*bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrBoolQueryRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Query, "value", parser.Bool, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Query, "value", parser.Bool, binding.Required), // Field: Value (*bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindBoolHeaderOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Header, "X-Value", parser.Bool, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Header, "X-Value", parser.Bool, binding.Optional), // Field: Value (bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindBoolHeaderRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Header, "X-Value", parser.Bool, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Header, "X-Value", parser.Bool, binding.Required), // Field: Value (bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrBoolHeaderOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.Bool, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.Bool, binding.Optional), // Field: Value (*bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrBoolHeaderRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.Bool, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.Bool, binding.Required), // Field: Value (*bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindBoolCookieOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Cookie, "value", parser.Bool, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Cookie, "value", parser.Bool, binding.Optional), // Field: Value (bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindBoolCookieRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Cookie, "value", parser.Bool, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Cookie, "value", parser.Bool, binding.Required), // Field: Value (bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrBoolCookieOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Cookie, "value", parser.Bool, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Cookie, "value", parser.Bool, binding.Optional), // Field: Value (*bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrBoolCookieRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Cookie, "value", parser.Bool, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Cookie, "value", parser.Bool, binding.Required), // Field: Value (*bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindBoolPathOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Path, "value", parser.Bool, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Path, "value", parser.Bool, binding.Optional), // Field: Value (bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindBoolPathRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Path, "value", parser.Bool, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Path, "value", parser.Bool, binding.Required), // Field: Value (bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrBoolPathOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Path, "value", parser.Bool, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Path, "value", parser.Bool, binding.Optional), // Field: Value (*bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrBoolPathRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Path, "value", parser.Bool, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Path, "value", parser.Bool, binding.Required), // Field: Value (*bool)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindInt64QueryOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Query, "value", parser.Int64, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Query, "value", parser.Int64, binding.Optional), // Field: Value (int64)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrInt64PathRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Path, "value", parser.Int64, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Path, "value", parser.Int64, binding.Required), // Field: Value (*int64)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindUint32HeaderOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Header, "X-Value", parser.Uint32, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Header, "X-Value", parser.Uint32, binding.Optional), // Field: Value (uint32)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrUint32CookieRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Cookie, "value", parser.Uint32, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Cookie, "value", parser.Uint32, binding.Required), // Field: Value (*uint32)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindFloat64QueryOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Query, "value", parser.Float64, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Query, "value", parser.Float64, binding.Optional), // Field: Value (float64)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrFloat64HeaderRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.Float64, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.Float64, binding.Required), // Field: Value (*float64)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindComplex128CookieOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Cookie, "value", parser.Complex128, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Cookie, "value", parser.Complex128, binding.Optional), // Field: Value (complex128)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrComplex128PathRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Path, "value", parser.Complex128, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Path, "value", parser.Complex128, binding.Required), // Field: Value (*complex128)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindUintptrQueryOptional) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Value, binding.Query, "value", parser.Uintptr, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Value, binding.Query, "value", parser.Uintptr, binding.Optional), // Field: Value (uintptr)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindPtrUintptrHeaderRequired) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.Uintptr, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Value, binding.Header, "X-Value", parser.Uintptr, binding.Required), // Field: Value (*uintptr)
 
-	return errors.Join(errs...)
+	)
 }
 
 func (s *TestBindMixedFields) Bind(req *http.Request, pathVar func(string) string) error {
 	b := binding.New(req, pathVar)
-	var errs []error
+	return errors.Join(
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Name, binding.Query, "name", parser.String, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Name, binding.Query, "name", parser.String, binding.Required), // Field: Name (string)
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.Age, binding.Query, "age", parser.Int, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.Age, binding.Query, "age", parser.Int, binding.Optional), // Field: Age (*int)
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.SessionID, binding.Cookie, "session_id", parser.String, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.SessionID, binding.Cookie, "session_id", parser.String, binding.Required), // Field: SessionID (string)
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.AuthToken, binding.Header, "X-Auth-Token", parser.String, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.AuthToken, binding.Header, "X-Auth-Token", parser.String, binding.Optional), // Field: AuthToken (*string)
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.UserID, binding.Path, "userID", parser.String, binding.Required); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.UserID, binding.Path, "userID", parser.String, binding.Required), // Field: UserID (string)
 
-	// Pointer to a value, e.g., *int, *string (but not a slice)
-	if err := binding.OnePtr(b, &s.IsEnabled, binding.Query, "enabled", parser.Bool, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.OnePtr(b, &s.IsEnabled, binding.Query, "enabled", parser.Bool, binding.Optional), // Field: IsEnabled (*bool)
 
-	// Value, e.g., int, string
-	if err := binding.One(b, &s.Factor, binding.Header, "X-Factor", parser.Float64, binding.Optional); err != nil {
-		errs = append(errs, err)
-	}
+		binding.One(b, &s.Factor, binding.Header, "X-Factor", parser.Float64, binding.Optional), // Field: Factor (float64)
 
-	return errors.Join(errs...)
+	)
 }


### PR DESCRIPTION
The bind_method.tmpl has been updated to generate code that directly uses errors.Join for collecting binding errors, eliminating the need for an intermediate error slice and appends.

Each binding operationFragments (for fields and body) now has a trailing comma, relying on gofmt to handle the final comma for variadic functions like errors.Join. This simplifies the template logic for comma placement considerably.

Regenerated _deriving.go files are included.