### PR TITLE
examples/derivingjson のテンプレートを embed を使う形に修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,5 @@ format:
 test:
 	go test ./...
 	( cd examples/derivingjson && go test ./... )
+	( cd examples/derivingbind && go test ./... )
 .PHONY: test

--- a/examples/derivingbind/binding/binding.go
+++ b/examples/derivingbind/binding/binding.go
@@ -225,7 +225,6 @@ func Slice[T any](b *Binding, dest *[]T, source Source, key string, parse Parser
 		return fmt.Errorf("binding: %s key '%s' is required, but no values found or all values were empty after split", source, key)
 	}
 
-
 	*dest = slice
 	return nil
 }

--- a/examples/derivingbind/integrationtest/integrationtest_deriving.go
+++ b/examples/derivingbind/integrationtest/integrationtest_deriving.go
@@ -4,9 +4,10 @@ package integrationtest
 
 import (
 	"errors"
+	"net/http"
+
 	"github.com/podhmo/go-scan/examples/derivingbind/binding"
 	"github.com/podhmo/go-scan/examples/derivingbind/parser"
-	"net/http"
 )
 
 func (s *TestBindStringQueryOptional) Bind(req *http.Request, pathVar func(string) string) error {

--- a/examples/derivingbind/integrationtest/main_test.go
+++ b/examples/derivingbind/integrationtest/main_test.go
@@ -155,7 +155,7 @@ func TestFuncBindBoolCookieOptional(t *testing.T) {
 		{"false value", ptr("false"), false, false, ""},
 		{"1 value", ptr("1"), true, false, ""},
 		{"0 value", ptr("0"), false, false, ""},
-		{"t value", ptr("t"), true, false, ""}, // strconv.ParseBool standard
+		{"t value", ptr("t"), true, false, ""},  // strconv.ParseBool standard
 		{"f value", ptr("f"), false, false, ""}, // strconv.ParseBool standard
 		{"TRUE value", ptr("TRUE"), true, false, ""},
 		{"FALSE value", ptr("FALSE"), false, false, ""},
@@ -227,7 +227,6 @@ func TestFuncBindPtrBoolCookieRequired(t *testing.T) {
 		})
 	}
 }
-
 
 func TestFuncBindMixedFields(t *testing.T) {
 	type testCase struct {

--- a/examples/derivingbind/integrationtest/models.go
+++ b/examples/derivingbind/integrationtest/models.go
@@ -242,6 +242,7 @@ type TestBindPtrBoolPathOptional struct {
 type TestBindPtrBoolPathRequired struct {
 	Value *bool `in:"path" path:"value" required:"true"`
 }
+
 // TODO: Add other numeric types (int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, uintptr, float32, float64, complex64, complex128)
 // For brevity, I will add a few representative examples for other types.
 // The full list would be very long.

--- a/examples/derivingbind/main.go
+++ b/examples/derivingbind/main.go
@@ -89,8 +89,8 @@ type FieldBindingInfo struct {
 	// IsFloat                 bool   // True if the field is a float type - Will be removed // Removed
 	// IsSigned                bool   // True if the field is a signed integer type - Will be removed // Removed
 	// IsComplex               bool   // True if the field is a complex type - Will be removed // Removed
-	ParserFunc              string // e.g. "parser.Int", "parser.String"
-	IsSliceElementPointer   bool   // True if the slice element is a pointer, e.g. []*int
+	ParserFunc            string // e.g. "parser.Int", "parser.String"
+	IsSliceElementPointer bool   // True if the slice element is a pointer, e.g. []*int
 }
 
 // isGo122orLater checks the go.mod file for the Go version.
@@ -255,7 +255,7 @@ func Generate(ctx context.Context, pkgPath string) error {
 			if currentScannerType.IsSlice {
 				fInfo.IsSlice = true
 				if currentScannerType.Elem != nil {
-					fInfo.SliceElementType = currentScannerType.Elem.String() // e.g., "int", "*string", "pkg.MyType", "*pkg.MyType"
+					fInfo.SliceElementType = currentScannerType.Elem.String()       // e.g., "int", "*string", "pkg.MyType", "*pkg.MyType"
 					fInfo.IsSliceElementPointer = currentScannerType.Elem.IsPointer // Check if the element itself is a pointer
 
 					// Determine the baseTypeForConversion from the slice element
@@ -339,8 +339,8 @@ func Generate(ctx context.Context, pkgPath string) error {
 			if bindFrom != "body" {
 				allFileImports["github.com/podhmo/go-scan/examples/derivingbind/binding"] = ""
 				allFileImports["github.com/podhmo/go-scan/examples/derivingbind/parser"] = ""
-				needsImportNetHTTP = true // For req *http.Request in Bind method signature
-				needsImportErrors = true  // For errors.Join
+				needsImportNetHTTP = true   // For req *http.Request in Bind method signature
+				needsImportErrors = true    // For errors.Join
 				if fInfo.ParserFunc == "" { // Should not happen if logic above is correct for non-body
 					fmt.Printf("      Skipping field %s: No parser function assigned for non-body binding.\n", field.Name)
 					continue

--- a/examples/derivingbind/testdata/simple/models_test.go
+++ b/examples/derivingbind/testdata/simple/models_test.go
@@ -708,13 +708,13 @@ func TestBindTestExtendedTypesBind(t *testing.T) {
 	ptrToString := func(s string) *string { return &s }
 
 	tests := []struct {
-		name        string
-		request     *http.Request
-		pathVars    map[string]string
+		name           string
+		request        *http.Request
+		pathVars       map[string]string
 		requestCookies []*http.Cookie // Added field for cookies
-		expected    TestExtendedTypesBind
-		wantErr     bool
-		errContains []string // Substrings to check for in the error message
+		expected       TestExtendedTypesBind
+		wantErr        bool
+		errContains    []string // Substrings to check for in the error message
 	}{
 		{
 			name: "all values present and correct",
@@ -797,9 +797,9 @@ func TestBindTestExtendedTypesBind(t *testing.T) {
 			request: &http.Request{
 				URL: parseURL(t, "/?reqQStrSlice=val"), Header: http.Header{"X-Reqint": []string{"99"}},
 			},
-		requestCookies: []*http.Cookie{{Name: "ckFloat64", Value: "not-a-float"}},
-			wantErr:     true,
-			errContains: []string{"binding: failed to parse cookie key 'ckFloat64' with value \"not-a-float\""},
+			requestCookies: []*http.Cookie{{Name: "ckFloat64", Value: "not-a-float"}},
+			wantErr:        true,
+			errContains:    []string{"binding: failed to parse cookie key 'ckFloat64' with value \"not-a-float\""},
 		},
 		{
 			name: "path parameter slice (current behavior test - likely takes as single string or not at all)",
@@ -811,7 +811,7 @@ func TestBindTestExtendedTypesBind(t *testing.T) {
 				QueryInt8: 1, RequiredHeaderInt: 1, RequiredQueryStringSlice: []string{"ok"},
 				PathStringSlice: []string{"elem1,elem2"},
 			},
-			wantErr: true, // Due to missing qStrEmptyReq and qIntEmptyReq
+			wantErr:     true, // Due to missing qStrEmptyReq and qIntEmptyReq
 			errContains: []string{"binding: query key 'qStrEmptyReq' is required", "binding: query key 'qIntEmptyReq' is required"},
 		},
 		// Add more tests for:
@@ -1024,13 +1024,13 @@ func TestBindExtendedTypes(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		request     *http.Request
-		pathVars    map[string]string
+		name           string
+		request        *http.Request
+		pathVars       map[string]string
 		requestCookies []*http.Cookie // Added
-		expected    TestExtendedTypesBind
-		wantErr     bool
-		errContains []string // Substrings to check for in the error message
+		expected       TestExtendedTypesBind
+		wantErr        bool
+		errContains    []string // Substrings to check for in the error message
 	}{
 		{
 			name: "all values present and correct",
@@ -1223,13 +1223,13 @@ func TestBindExtendedTypes(t *testing.T) {
 
 func TestBindNewTypes(t *testing.T) {
 	tests := []struct {
-		name        string
-		request     *http.Request
-		pathVars    map[string]string
+		name           string
+		request        *http.Request
+		pathVars       map[string]string
 		requestCookies []*http.Cookie // Added field for cookies
-		expected    TestNewTypesBind
-		wantErr     bool
-		errContains []string
+		expected       TestNewTypesBind
+		wantErr        bool
+		errContains    []string
 	}{
 		{
 			name: "all new types present and correct",
@@ -1326,8 +1326,8 @@ func TestBindNewTypes(t *testing.T) {
 			},
 			// Add a cookie with an invalid complex128 slice
 			requestCookies: []*http.Cookie{{Name: "cComplex128-Slice", Value: "1+1i,bad-complex,2+2i"}},
-			wantErr: true,
-			errContains: []string{"binding: failed to parse item #1 from value \"bad-complex\" for cookie key 'cComplex128-Slice': strconv.ParseComplex: parsing \"bad-complex\": invalid syntax"},
+			wantErr:        true,
+			errContains:    []string{"binding: failed to parse item #1 from value \"bad-complex\" for cookie key 'cComplex128-Slice': strconv.ParseComplex: parsing \"bad-complex\": invalid syntax"},
 		},
 		// TODO: Add tests for pointer slices of new types with missing/empty values
 		// TODO: Add tests for empty strings for complex types (should error)

--- a/examples/derivingbind/testdata/simple/simple_deriving.go
+++ b/examples/derivingbind/testdata/simple/simple_deriving.go
@@ -6,10 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/podhmo/go-scan/examples/derivingbind/binding"
-	"github.com/podhmo/go-scan/examples/derivingbind/parser"
 	"io"
 	"net/http"
+
+	"github.com/podhmo/go-scan/examples/derivingbind/binding"
+	"github.com/podhmo/go-scan/examples/derivingbind/parser"
 )
 
 func (s *ComprehensiveBind) Bind(req *http.Request, pathVar func(string) string) error {

--- a/examples/derivingjson/main.go
+++ b/examples/derivingjson/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"embed"
 	"fmt"
 	"go/format"
 	"log/slog"
@@ -15,6 +16,9 @@ import (
 	goscan "github.com/podhmo/go-scan"
 	"github.com/podhmo/go-scan/scanner"
 )
+
+//go:embed unmarshal.tmpl
+var templateFile embed.FS
 
 func main() {
 	ctx := context.Background() // Or your application's context
@@ -79,58 +83,6 @@ type OneOfTypeMapping struct {
 	JSONValue string // The value in the discriminator field (e.g., "circle", "user_created")
 	GoType    string // The concrete Go type (e.g., "*shapes.Circle", "*events.UserCreatedEvent")
 }
-
-const unmarshalJSONTemplate = `
-func (s *{{.StructName}}) UnmarshalJSON(data []byte) error {
-	// Define an alias type to prevent infinite recursion with UnmarshalJSON.
-	type Alias {{.StructName}}
-	aux := &struct {
-		{{range .OneOfFields}}
-		{{.FieldName}} json.RawMessage ` + "`json:\"{{.JSONTag}}\"`" + `
-		{{end}}
-		// All other fields will be handled by the standard unmarshaler via the Alias.
-		*Alias
-	}{
-		Alias: (*Alias)(s),
-	}
-
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return fmt.Errorf("failed to unmarshal into aux struct for {{.StructName}}: %w", err)
-	}
-
-	{{range $oneOfField := .OneOfFields}}
-	// Process {{$oneOfField.FieldName}}
-	if aux.{{$oneOfField.FieldName}} != nil && string(aux.{{$oneOfField.FieldName}}) != "null" {
-		var discriminatorDoc struct {
-			Type string ` + "`json:\"{{$.DiscriminatorFieldJSONName}}\"`" + ` // Discriminator field
-		}
-		if err := json.Unmarshal(aux.{{$oneOfField.FieldName}}, &discriminatorDoc); err != nil {
-			return fmt.Errorf("could not detect type from field '{{$oneOfField.JSONTag}}' (content: %s): %w", string(aux.{{$oneOfField.FieldName}}), err)
-		}
-
-		switch discriminatorDoc.Type {
-		{{range .Implementers}}
-		case "{{.JSONValue}}":
-			var content {{.GoType}}
-			if err := json.Unmarshal(aux.{{$oneOfField.FieldName}}, &content); err != nil {
-				return fmt.Errorf("failed to unmarshal '{{$oneOfField.JSONTag}}' as {{.GoType}} for type '{{.JSONValue}}' (content: %s): %w", string(aux.{{$oneOfField.FieldName}}), err)
-			}
-			s.{{$oneOfField.FieldName}} = content
-		{{end}}
-		default:
-			if discriminatorDoc.Type == "" {
-				return fmt.Errorf("discriminator field '{{$.DiscriminatorFieldJSONName}}' missing or empty in '{{$oneOfField.JSONTag}}' (content: %s)", string(aux.{{$oneOfField.FieldName}}))
-			}
-			return fmt.Errorf("unknown data type '%s' for field '{{$oneOfField.JSONTag}}' (content: %s)", discriminatorDoc.Type, string(aux.{{$oneOfField.FieldName}}))
-		}
-	} else {
-		s.{{$oneOfField.FieldName}} = nil // Explicitly set to nil if null or empty
-	}
-	{{end}}
-
-	return nil
-}
-`
 
 func findTypeInPackage(pkgInfo *scanner.PackageInfo, typeName string) *scanner.TypeInfo {
 	for _, t := range pkgInfo.Types {
@@ -408,7 +360,7 @@ func Generate(ctx context.Context, pkgPath string) error {
 		// var interfaceActualImportPath string
 		// ... (old logic for single oneOfInterfaceDef) ...
 
-		tmpl, err := template.New("unmarshal").Parse(unmarshalJSONTemplate)
+		tmpl, err := template.ParseFS(templateFile, "unmarshal.tmpl")
 		if err != nil {
 			return fmt.Errorf("failed to parse template: %w", err)
 		}

--- a/examples/derivingjson/testdata/separated/models/models_deriving.go
+++ b/examples/derivingjson/testdata/separated/models/models_deriving.go
@@ -5,6 +5,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/podhmo/go-scan/examples/derivingjson/testdata/separated/shapes"
 )
 

--- a/examples/derivingjson/unmarshal.tmpl
+++ b/examples/derivingjson/unmarshal.tmpl
@@ -1,0 +1,72 @@
+// TemplateData:
+//   PackageName                string
+//   StructName                 string
+//   OtherFields                []FieldInfo
+//   OneOfFields                []OneOfFieldDetail
+//   Imports                    map[string]string
+//   DiscriminatorFieldJSONName string
+//
+// FieldInfo:
+//   Name    string
+//   Type    string
+//   JSONTag string
+//
+// OneOfFieldDetail:
+//   FieldName    string
+//   FieldType    string
+//   JSONTag      string
+//   Implementers []OneOfTypeMapping
+//
+// OneOfTypeMapping:
+//   JSONValue string
+//   GoType    string
+
+func (s *{{.StructName}}) UnmarshalJSON(data []byte) error {
+	// Define an alias type to prevent infinite recursion with UnmarshalJSON.
+	type Alias {{.StructName}}
+	aux := &struct {
+		{{range .OneOfFields}}
+		{{.FieldName}} json.RawMessage ` + "`json:\"{{.JSONTag}}\"`" + `
+		{{end}}
+		// All other fields will be handled by the standard unmarshaler via the Alias.
+		*Alias
+	}{
+		Alias: (*Alias)(s),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return fmt.Errorf("failed to unmarshal into aux struct for {{.StructName}}: %w", err)
+	}
+
+	{{range $oneOfField := .OneOfFields}}
+	// Process {{$oneOfField.FieldName}}
+	if aux.{{$oneOfField.FieldName}} != nil && string(aux.{{$oneOfField.FieldName}}) != "null" {
+		var discriminatorDoc struct {
+			Type string ` + "`json:\"{{$.DiscriminatorFieldJSONName}}\"`" + ` // Discriminator field
+		}
+		if err := json.Unmarshal(aux.{{$oneOfField.FieldName}}, &discriminatorDoc); err != nil {
+			return fmt.Errorf("could not detect type from field '{{$oneOfField.JSONTag}}' (content: %s): %w", string(aux.{{$oneOfField.FieldName}}), err)
+		}
+
+		switch discriminatorDoc.Type {
+		{{range .Implementers}}
+		case "{{.JSONValue}}":
+			var content {{.GoType}}
+			if err := json.Unmarshal(aux.{{$oneOfField.FieldName}}, &content); err != nil {
+				return fmt.Errorf("failed to unmarshal '{{$oneOfField.JSONTag}}' as {{.GoType}} for type '{{.JSONValue}}' (content: %s): %w", string(aux.{{$oneOfField.FieldName}}), err)
+			}
+			s.{{$oneOfField.FieldName}} = content
+		{{end}}
+		default:
+			if discriminatorDoc.Type == "" {
+				return fmt.Errorf("discriminator field '{{$.DiscriminatorFieldJSONName}}' missing or empty in '{{$oneOfField.JSONTag}}' (content: %s)", string(aux.{{$oneOfField.FieldName}}))
+			}
+			return fmt.Errorf("unknown data type '%s' for field '{{$oneOfField.JSONTag}}' (content: %s)", discriminatorDoc.Type, string(aux.{{$oneOfField.FieldName}}))
+		}
+	} else {
+		s.{{$oneOfField.FieldName}} = nil // Explicitly set to nil if null or empty
+	}
+	{{end}}
+
+	return nil
+}


### PR DESCRIPTION
- examples/derivingjson/main.go から unmarshalJSONTemplate 定数を削除
- examples/derivingjson/unmarshal.tmpl を作成し、テンプレート内容を移動
- examples/derivingjson/main.go で embed を使い unmarshal.tmpl を読み込むように修正
- Makefile の test ターゲットで examples/derivingbind のテストも実行するように修正