### PR TITLE
feat(derivingjson): Support multiple file inputs and cross-package ge…

### DIFF
--- a/examples/derivingjson/README.md
+++ b/examples/derivingjson/README.md
@@ -21,16 +21,21 @@ This tool aims to generate an `UnmarshalJSON` method for such container structs,
 2.  Run `derivingjson` from the command line, specifying the target package path.
 
     ```bash
-    go run examples/derivingjson/*.go <path_to_target_package>
+    go run examples/derivingjson/main.go <file_path_1.go> [file_path_2.go ...]
     # Or after building
-    # ./derivingjson <path_to_target_package>
+    # ./derivingjson <file_path_1.go> [file_path_2.go ...]
     ```
 
-    Example:
+    Example (single file, implies processing its package):
     ```bash
-    go run examples/derivingjson/*.go ./examples/derivingjson/testdata/simple
+    go run examples/derivingjson/main.go ./examples/derivingjson/testdata/simple/models.go
     ```
-3.  A file named like `xxx_deriving.go`, containing the implemented `UnmarshalJSON` method, will be generated in the specified package.
+
+    Example (multiple files from different packages):
+    ```bash
+    go run examples/derivingjson/main.go ./examples/derivingjson/testdata/separated/models/models.go ./examples/derivingjson/testdata/separated/shapes/shapes.go
+    ```
+3.  A file named like `packagename_deriving.go`, containing the implemented `UnmarshalJSON` method, will be generated in the package directory of each processed Go file.
 
 ## Disclaimer
 

--- a/examples/derivingjson/testdata/separated/models/models_deriving.go
+++ b/examples/derivingjson/testdata/separated/models/models_deriving.go
@@ -5,7 +5,6 @@ package models
 import (
 	"encoding/json"
 	"fmt"
-
 	"github.com/podhmo/go-scan/examples/derivingjson/testdata/separated/shapes"
 )
 

--- a/examples/derivingjson/unmarshal.tmpl
+++ b/examples/derivingjson/unmarshal.tmpl
@@ -1,32 +1,9 @@
-// TemplateData:
-//   PackageName                string
-//   StructName                 string
-//   OtherFields                []FieldInfo
-//   OneOfFields                []OneOfFieldDetail
-//   Imports                    map[string]string
-//   DiscriminatorFieldJSONName string
-//
-// FieldInfo:
-//   Name    string
-//   Type    string
-//   JSONTag string
-//
-// OneOfFieldDetail:
-//   FieldName    string
-//   FieldType    string
-//   JSONTag      string
-//   Implementers []OneOfTypeMapping
-//
-// OneOfTypeMapping:
-//   JSONValue string
-//   GoType    string
-
 func (s *{{.StructName}}) UnmarshalJSON(data []byte) error {
 	// Define an alias type to prevent infinite recursion with UnmarshalJSON.
 	type Alias {{.StructName}}
 	aux := &struct {
 		{{range .OneOfFields}}
-		{{.FieldName}} json.RawMessage ` + "`json:\"{{.JSONTag}}\"`" + `
+		{{.FieldName}} json.RawMessage {{printf "%sjson:\"%s\"%s" "`" .JSONTag "`"}}
 		{{end}}
 		// All other fields will be handled by the standard unmarshaler via the Alias.
 		*Alias
@@ -42,7 +19,7 @@ func (s *{{.StructName}}) UnmarshalJSON(data []byte) error {
 	// Process {{$oneOfField.FieldName}}
 	if aux.{{$oneOfField.FieldName}} != nil && string(aux.{{$oneOfField.FieldName}}) != "null" {
 		var discriminatorDoc struct {
-			Type string ` + "`json:\"{{$.DiscriminatorFieldJSONName}}\"`" + ` // Discriminator field
+			Type string {{printf "%sjson:\"%s\"%s" "`" $.DiscriminatorFieldJSONName "`"}} // Discriminator field
 		}
 		if err := json.Unmarshal(aux.{{$oneOfField.FieldName}}, &discriminatorDoc); err != nil {
 			return fmt.Errorf("could not detect type from field '{{$oneOfField.JSONTag}}' (content: %s): %w", string(aux.{{$oneOfField.FieldName}}), err)


### PR DESCRIPTION
…neration

Modifies `derivingjson` to accept multiple Go source files as command-line arguments. This allows processing types from different packages in a single run.

Key changes:
- The `main` function now iterates over input file paths, determines the package directory for each, and calls the `Generate` function once per unique package directory.
- The `Generate` function itself was already capable of handling cross-package type resolution and import generation, so minimal changes were needed there.
- Corrected issues in `unmarshal.tmpl`:
    - Removed leftover debug comments.
    - Fixed struct tag generation to prevent formatting errors.
- Updated `examples/derivingjson/README.md` to reflect the new usage.