### PR TITLE
feat: Allow derivingbind to process multiple files across different p…

### DIFF
--- a/examples/derivingbind/Makefile
+++ b/examples/derivingbind/Makefile
@@ -5,21 +5,20 @@ all: generate-simple integrationtest-emit
 # Renamed emit-simple to generate-simple for clarity
 generate-simple:
 	@echo "Generating for testdata/simple"
-	@go run main.go ./testdata/simple
+	@go run main.go ./testdata/simple/models.go
 
-integrationtest-emit:
-	@echo "Generating for integrationtest"
-	@go run main.go ./integrationtest
+GENERATE_TARGETS := ./integrationtest/models.go ./anotherpkg/models_another.go
+
+integrationtest-emit: # This target name is now a bit misleading, but keeping for consistency unless asked to change.
+	@echo "Generating for integrationtest and anotherpkg"
+	@go run main.go $(GENERATE_TARGETS)
 
 test: generate-simple integrationtest-emit
 	@echo "Running main tests..."
-	@go test ./...
-	@echo "Testing testdata/simple..."
-	@(cd testdata/simple && go test .)
-	@echo "Testing integrationtest..."
-	@(cd integrationtest && go test .)
+	@go test ./... # This should cover all sub-packages including anotherpkg
 
 clean:
 	@echo "Cleaning generated files..."
 	@rm -f testdata/simple/simple_deriving.go
 	@rm -f integrationtest/integrationtest_deriving.go
+	@rm -f anotherpkg/anotherpkg_deriving.go

--- a/examples/derivingbind/anotherpkg/models_another.go
+++ b/examples/derivingbind/anotherpkg/models_another.go
@@ -1,0 +1,8 @@
+package anotherpkg
+
+// @derivng:binding
+type AnotherModel struct {
+	ItemName  string `in:"query" query:"item_name" required:"true"`
+	Quantity  *int   `in:"query" query:"quantity"`
+	IsSpecial bool   `in:"header" header:"X-Special"`
+}

--- a/examples/derivingbind/anotherpkg/models_another_test.go
+++ b/examples/derivingbind/anotherpkg/models_another_test.go
@@ -1,0 +1,101 @@
+package anotherpkg
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Helper to create pointers for test cases
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func TestAnotherModel_Bind(t *testing.T) {
+	tests := []struct {
+		name        string
+		queryParams string
+		headers     map[string]string
+		want        AnotherModel
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "all present",
+			queryParams: "item_name=gizmo&quantity=10",
+			headers:     map[string]string{"X-Special": "true"},
+			want: AnotherModel{
+				ItemName:  "gizmo",
+				Quantity:  ptr(10),
+				IsSpecial: true,
+			},
+			expectError: false,
+		},
+		{
+			name:        "required item_name missing",
+			queryParams: "quantity=5",
+			headers:     map[string]string{"X-Special": "false"},
+			expectError: true,
+			errorMsg:    "binding: query key 'item_name' is required",
+		},
+		{
+			name:        "optional quantity missing, header missing",
+			queryParams: "item_name=widget",
+			// No X-Special header
+			want: AnotherModel{
+				ItemName:  "widget",
+				Quantity:  nil, // Default for *int
+				IsSpecial: false, // Default for bool
+			},
+			expectError: false,
+		},
+		{
+			name:        "quantity invalid",
+			queryParams: "item_name=thing&quantity=lots",
+			headers:     map[string]string{"X-Special": "true"},
+			expectError: true,
+			errorMsg:    "binding: failed to parse query key 'quantity' with value \"lots\": strconv.Atoi: parsing \"lots\": invalid syntax",
+		},
+		{
+			name:        "isSpecial invalid",
+			queryParams: "item_name=stuff",
+			headers:     map[string]string{"X-Special": "maybe"},
+			expectError: true,
+			errorMsg:    "binding: failed to parse header key 'X-Special' with value \"maybe\": strconv.ParseBool: parsing \"maybe\": invalid syntax",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/?"+tt.queryParams, nil)
+			for key, val := range tt.headers {
+				req.Header.Set(key, val)
+			}
+
+			var data AnotherModel
+			// The pathValueExtractor is not used by these fields, so it can be nil or a dummy.
+			err := data.Bind(req, func(s string) string { return "" })
+
+			if (err != nil) != tt.expectError {
+				t.Errorf("Bind() error = %v, wantErr %v", err, tt.expectError)
+				return
+			}
+
+			if tt.expectError {
+				if err == nil || !strings.Contains(err.Error(), tt.errorMsg) {
+					t.Errorf("Bind() expected error containing %q, got %v", tt.errorMsg, err)
+				}
+			} else {
+				if data.ItemName != tt.want.ItemName {
+					t.Errorf("Bind() ItemName = %q, want %q", data.ItemName, tt.want.ItemName)
+				}
+				if (data.Quantity == nil && tt.want.Quantity != nil) || (data.Quantity != nil && tt.want.Quantity == nil) || (data.Quantity != nil && tt.want.Quantity != nil && *data.Quantity != *tt.want.Quantity) {
+					t.Errorf("Bind() Quantity = %v, want %v", data.Quantity, tt.want.Quantity)
+				}
+				if data.IsSpecial != tt.want.IsSpecial {
+					t.Errorf("Bind() IsSpecial = %v, want %v", data.IsSpecial, tt.want.IsSpecial)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
…ackages

The `derivingbind` tool has been updated to accept multiple .go files as input arguments. This allows for generating binding methods for structs located in different files and different packages within a single execution.

Key changes:
- Modified `main.go` to process multiple file arguments, grouping them by package directory.
- Refactored the generation logic (`GenerateFiles`) to use `goscan.ScanPackageFiles` for parsing specific files within a package.
- Output files are now correctly placed in their respective package directories, named as `[packagename]_deriving.go`.
- Updated the Makefile to reflect the new command-line usage (file paths instead of directory paths).
- Added a new test package (`anotherpkg`) to verify multi-package generation and testing.
- Ensured existing tests are compatible with the changes.