### PR TITLE
Update Makefiles for root and examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
+.PHONY: all test format clean
+
+all:
+	go build ./...
+
 format:
 	go run golang.org/x/tools/cmd/goimports@latest -w $(shell find . -name '*.go')
-.PHONY: format
 
 test:
 	go test ./...
 	( cd examples/derivingjson && go test ./... )
 	( cd examples/derivingbind && go test ./... )
-.PHONY: test
+
+clean:
+	go clean -cache -testcache # General Go clean
+	# Example-specific cleaning should be done within their respective Makefiles
+	# or by explicitly calling make -C examples/<example_dir> clean
+	@echo "Root clean done. For example-specific cleaning, cd into example dir and run make clean."


### PR DESCRIPTION
- Added 'all' and 'clean' targets to the root Makefile.
- Root 'test' target calls 'go test ./...' in example subdirectories.
- Ensured 'make', 'make test', 'make clean' work as expected in root and individual example directories (derivingjson, derivingbind).
- Removed the intermediate 'examples/Makefile' as per user feedback.