### PR TITLE
Refactor GoFile.Imports handling and update examples

### DIFF
--- a/examples/derivingjson/testdata/separated/models/models_deriving.go
+++ b/examples/derivingjson/testdata/separated/models/models_deriving.go
@@ -5,7 +5,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/podhmo/go-scan/examples/derivingjson/testdata/separated/shapes"
+	shapes "github.com/podhmo/go-scan/examples/derivingjson/testdata/separated/shapes"
 )
 
 func (s *Container) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
- Modified `GoFile.Imports` to consistently use import path as key and alias as value (empty string for no alias).
- Updated `SaveGoFile` to correctly generate import statements based on the new `GoFile.Imports` contract, removing the previous heuristic for alias generation.
- Added `TestSaveGoFile_Imports` to verify various import scenarios (no alias, with alias, alias same as package name, sorted imports).
- Confirmed that `examples/derivingjson/main.go` and `examples/derivingbind/main.go` are compatible with the changes without modification to their import collection logic.
- Ensured `make` and `make test` pass in both `examples/derivingjson` and `examples/derivingbind` directories.