### PR TITLE
feat: Implement ToplevelStructs as Go 1.23 iterator

### DIFF
--- a/astwalk/astwalk.go
+++ b/astwalk/astwalk.go
@@ -1,0 +1,43 @@
+package astwalk
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+// ToplevelStructs returns an iterator function for top-level struct type definitions
+// in the given AST file.
+// This function is designed to be used with Go 1.23's range-over-function feature.
+// Example:
+//
+//	for typeSpec := range ToplevelStructs(fset, file) {
+//		// use typeSpec
+//	}
+func ToplevelStructs(fset *token.FileSet, file *ast.File) func(yield func(*ast.TypeSpec) bool) {
+	return func(yield func(*ast.TypeSpec) bool) {
+		if file == nil {
+			return
+		}
+
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok {
+				continue
+			}
+			if genDecl.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				typeSpec, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				if _, isStruct := typeSpec.Type.(*ast.StructType); isStruct {
+					if !yield(typeSpec) {
+						return // Stop iteration if yield returns false
+					}
+				}
+			}
+		}
+	}
+}

--- a/astwalk/astwalk_test.go
+++ b/astwalk/astwalk_test.go
@@ -1,0 +1,234 @@
+package astwalk
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	// "slices" // For comparing slices if needed, though we primarily collect and compare.
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestToplevelStructs_Iterator(t *testing.T) {
+	tests := []struct {
+		name              string
+		source            string
+		expectedSpecNames []string // Expected names of TypeSpecs yielded
+		stopAfterN        int      // Test early exit: stop after yielding N items (0 means iterate all)
+		expectEarlyExit   bool     // Whether an early exit is expected
+	}{
+		{
+			name:              "nil file",
+			source:            "", // Will result in nil file for this specific test setup
+			expectedSpecNames: []string{},
+		},
+		{
+			name:   "empty source",
+			source: `package test`,
+			expectedSpecNames: []string{},
+		},
+		{
+			name: "only structs",
+			source: `
+package test
+type Struct1 struct{}
+type Struct2 struct { Field int }`,
+			expectedSpecNames: []string{"Struct1", "Struct2"},
+		},
+		{
+			name: "mixed types",
+			source: `
+package test
+type Struct1 struct{}
+type Alias1 int
+func Func1() {}
+type Interface1 interface{}
+type Struct2 struct{}
+type (
+	Struct3 struct{}
+	Alias2 string
+)
+`,
+			expectedSpecNames: []string{"Struct1", "Struct2", "Struct3"},
+		},
+		{
+			name:   "no structs",
+			source: `package test; type Alias1 int; func Func1() {}; type Interface1 interface{}`,
+			expectedSpecNames: []string{},
+		},
+		{
+			name: "early exit after 1 struct",
+			source: `
+package test
+type StructA struct{}
+type StructB struct{}
+type StructC struct{}`,
+			expectedSpecNames: []string{"StructA"},
+			stopAfterN:        1,
+			expectEarlyExit:   true,
+		},
+		{
+			name: "early exit after 2 structs",
+			source: `
+package test
+type S1 struct{}
+type S2 struct{}
+type S3 struct{}`,
+			expectedSpecNames: []string{"S1", "S2"},
+			stopAfterN:        2,
+			expectEarlyExit:   true,
+		},
+		{
+			name: "stopAfterN larger than actual structs (no early exit)",
+			source: `
+package test
+type X struct{}
+type Y struct{}`,
+			expectedSpecNames: []string{"X", "Y"},
+			stopAfterN:        5,
+			expectEarlyExit:   false,
+		},
+		{
+			name: "stopAfterN is 0 (iterate all)",
+			source: `
+package test
+type Alpha struct{}
+type Beta struct{}`,
+			expectedSpecNames: []string{"Alpha", "Beta"},
+			stopAfterN:        0,
+			expectEarlyExit:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var file *ast.File
+			var fset *token.FileSet
+			collectedNames := []string{}
+			iterations := 0
+
+			if tt.name == "nil file" {
+				// Test with nil file explicitly for the iterator
+				// The iterator function itself handles nil file and should not panic.
+				// The loop `for range ToplevelStructs(nil, nil)` should simply not execute.
+				for range ToplevelStructs(nil, nil) {
+					t.Error("Iterator for nil file yielded an item, expected none")
+				}
+				// Check if expectedSpecNames is also empty for nil file case.
+				if len(tt.expectedSpecNames) != 0 {
+					t.Errorf("Expected spec names for nil file case should be empty, got %v", tt.expectedSpecNames)
+				}
+				return // End this test case
+			}
+
+			fset = token.NewFileSet()
+			var err error
+			file, err = parser.ParseFile(fset, "", tt.source, parser.ParseComments)
+			if err != nil {
+				if tt.source == "package test" && len(tt.expectedSpecNames) == 0 {
+					// Valid empty file
+				} else {
+					t.Fatalf("Failed to parse source: %v", err)
+				}
+			}
+
+			// Using the range-over-function syntax
+			for typeSpec := range ToplevelStructs(fset, file) {
+				iterations++
+				collectedNames = append(collectedNames, typeSpec.Name.Name)
+				if tt.stopAfterN > 0 && iterations == tt.stopAfterN {
+					// To test early exit, the `yield` function in the iterator needs to return `false`.
+					// The current ToplevelStructs signature is `func(yield func(*ast.TypeSpec) bool)`
+					// The range-over-function syntax implies `yield` returns `true` to continue.
+					// To stop it, the `yield` itself would have to be designed to return `false`.
+					// The test here simulates the *consumer* stopping.
+					// The iterator itself stops if `yield` returns false.
+					// Let's refine the iterator to accept a yield that can signal stop.
+					// No, the current test structure is testing the *consumer* breaking the loop.
+					// The `ToplevelStructs` is `func(yield func(V) bool)`.
+					// The `for item := range iterFunc` will break if `yield` returns `false`.
+					// So, the `stopAfterN` logic should be inside the yield passed to the iterator if we were to test that.
+					// However, the current structure is: the test *breaks* the loop.
+					// This doesn't directly test if the *iterator* correctly stops if `yield` returns false.
+					// Let's adjust the test for `ToplevelStructs` to test its reaction to `yield` returning `false`.
+
+					// For now, this test assumes the consumer breaks.
+					// To test the iterator's early exit capability, we'd call it directly:
+					// ToplevelStructs(fset, file)(func(ts *ast.TypeSpec) bool { ... return false; })
+					break
+				}
+			}
+
+			if diff := cmp.Diff(tt.expectedSpecNames, collectedNames); diff != "" {
+				t.Errorf("ToplevelStructs() yielded unexpected struct names (-want +got):\n%s", diff)
+			}
+
+			// Test the iterator's own early exit mechanism
+			if tt.expectEarlyExit {
+				yieldCount := 0
+				ToplevelStructs(fset, file)(func(ts *ast.TypeSpec) bool {
+					yieldCount++
+					if yieldCount == tt.stopAfterN {
+						return false // Signal iterator to stop
+					}
+					return true
+				})
+				if yieldCount != tt.stopAfterN {
+					t.Errorf("Iterator did not stop early as expected. Expected %d yields, got %d", tt.stopAfterN, yieldCount)
+				}
+			} else { // Should iterate all if not expecting early exit by iterator's control
+				controlYieldCount := 0
+				expectedTotalYields := len(tt.expectedSpecNames)
+				// If stopAfterN was set but larger than total, it means the consumer would not break early.
+				if tt.stopAfterN > 0 && tt.stopAfterN < expectedTotalYields {
+					// This case is covered by the main loop test.
+				} else {
+					ToplevelStructs(fset, file)(func(ts *ast.TypeSpec) bool {
+						controlYieldCount++
+						return true // Always continue
+					})
+					if controlYieldCount != len(tt.expectedSpecNames) {
+						t.Errorf("Iterator did not yield all items when not signalled to stop early. Expected %d, got %d", len(tt.expectedSpecNames), controlYieldCount)
+					}
+				}
+			}
+		})
+	}
+}
+
+// Helper to collect all items from an iterator for simpler comparison if needed.
+func collect[T any](iter func(yield func(T) bool)) []T {
+	var items []T
+	iter(func(item T) bool {
+		items = append(items, item)
+		return true
+	})
+	return items
+}
+
+// TestToplevelStructs_Collect demonstrates using a helper to collect results.
+func TestToplevelStructs_Collect(t *testing.T) {
+	fset := token.NewFileSet()
+	source := `package demo; type S1 struct{}; type S2 struct{}; type A int`
+	file, err := parser.ParseFile(fset, "", source, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	specs := collect(ToplevelStructs(fset, file))
+	if len(specs) != 2 {
+		t.Errorf("Expected 2 specs, got %d", len(specs))
+	}
+	expectedNames := []string{"S1", "S2"}
+	gotNames := make([]string, len(specs))
+	for i, s := range specs {
+		gotNames[i] = s.Name.Name
+	}
+	if diff := cmp.Diff(expectedNames, gotNames); diff != "" {
+		t.Errorf("Collected specs mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// Ensure slices import is available if used directly, e.g. for slices.Equal
+// var _ = slices.Contains

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -40,3 +40,42 @@ go test ./models
 Please do not delete the `go.mod` file located in example directories (like `examples/derivingjson/go.mod`). These are specifically set up to ensure that the examples can be built and tested as if they were separate modules, which is crucial for acceptance testing of the main library's features from an external perspective.
 
 This approach ensures that the tests accurately reflect how an external consumer would use the library and helps catch integration issues that might not be apparent when testing everything within a single module context.
+
+## Adopting Go 1.23 Experimental Iterator Functions (Range-Over-Function)
+
+### Context
+
+For the `astwalk` package, specifically the `ToplevelStructs` function, a decision was made to return an iterator function compatible with Go 1.23's experimental "range-over-function" feature. The function signature is `func(fset *token.FileSet, file *ast.File) func(yield func(*ast.TypeSpec) bool)`.
+
+### Rationale
+
+The primary motivation for adopting this experimental feature was to explore modern Go idioms and provide a potentially more ergonomic and efficient way to iterate over AST nodes, especially when the number of nodes could be large.
+
+- **Ergonomics**: The `for ... range` syntax over a function call can be more readable and idiomatic Go compared to manually managing a callback or channel-based iteration.
+- **Efficiency**: Iterators can be more memory-efficient as they process items one by one, avoiding the need to allocate a slice for all items upfront. This is particularly beneficial when dealing with large source files or when the consumer might only need a subset of the items.
+- **Lazy Evaluation**: The work to find the next item is only done when the consumer requests it.
+
+### Decision Process & Alternatives Considered
+
+1.  **Returning a Slice (`[]*ast.TypeSpec`)**: This was the initial, more conventional approach.
+    - *Pros*: Simple to implement and understand. Widely compatible with all Go versions.
+    - *Cons*: Less memory-efficient for large datasets as it requires allocating memory for all struct type specifications at once. The caller receives all data even if only a few items are needed.
+
+2.  **Callback-based Iterator (`func(fset *token.FileSet, file *ast.File, yield func(*ast.TypeSpec) bool)`)**: A function that takes a callback `yield` which is called for each item.
+    - *Pros*: More memory-efficient than returning a slice. Allows early exit if the `yield` function returns `false`. Compatible with older Go versions.
+    - *Cons*: Can be slightly less ergonomic to use compared to `for...range`.
+
+3.  **Channel-based Iterator (`func(fset *token.FileSet, file *ast.File) <-chan *ast.TypeSpec`)**: A function that returns a channel from which items can be received.
+    - *Pros*: Enables concurrent processing if desired. Familiar pattern in Go.
+    - *Cons*: Can be slower due to channel overhead. More complex to implement correctly (e.g., ensuring the goroutine producing items on the channel always exits).
+
+4.  **Go 1.23 Range-Over-Function (Chosen)**:
+    - *Pros*: Combines the ergonomic `for...range` syntax with the efficiency of lazy evaluation and potential for early exit. Represents a forward-looking approach.
+    - *Cons*:
+        - **Experimental**: As of Go 1.22/1.23, this feature is experimental. This means its API or behavior could change in future Go versions, or it might even be removed (though less likely for popular features).
+        - **Go Version Dependency**: Requires Go 1.23+ (or a Go version that supports the specific `GOEXPERIMENT` flag, e.g., `GOEXPERIMENT=rangefunc`). This limits the usability of the `astwalk` package for projects using older Go versions.
+        - **Build/Test Complexity**: May require setting `GOEXPERIMENT=rangefunc` during builds or tests, adding a slight complexity to the development workflow if not using Go 1.23 toolchain by default.
+
+### Conclusion
+
+The decision to use the Go 1.23 iterator pattern for `ToplevelStructs` was made with the understanding of its experimental nature and the Go version constraint. It serves as an exploration of new language features within this project. If broader compatibility with older Go versions becomes a critical requirement, this function might need to be refactored or an alternative provided. For now, it aligns with a forward-looking development approach. The `go.mod` file for the module has been updated to `go 1.23`.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/podhmo/go-scan
 
-go 1.21
+go 1.23
+
+require github.com/google/go-cmp v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=


### PR DESCRIPTION
This commit introduces the `astwalk` package with a `ToplevelStructs` function that leverages Go 1.23's experimental range-over-function feature. This function iterates over AST declarations and yields top-level struct type specifications.

Key changes:
- Created `astwalk/astwalk.go` with the iterator function.
- Created `astwalk/astwalk_test.go` with tests for the iterator, including early exit scenarios.
- Updated `go.mod` to `go 1.23` to support this feature.
- Documented the decision-making process for adopting this experimental feature in `docs/knowledge.md`.

Using this experimental feature allows for more ergonomic and potentially more efficient iteration over AST nodes, aligning with modern Go idioms. Testing requires `GOEXPERIMENT=rangefunc` if not using a Go 1.23+ toolchain that enables it by default.