### PR TITLE
Refactor: Add methods for tags and annotations to scanner.TypeInfo an…

### DIFF
--- a/docs/ja/from-derivingbind.md
+++ b/docs/ja/from-derivingbind.md
@@ -26,8 +26,8 @@
     `@derivng:binding` を持つ構造体を `go-scan` レベルでフィルタリングできれば、ジェネレータ側のコードはよりシンプルになります。
 
 *   **フィールドタグの高度な解析とクエリ (提案2)**:
-    `in:"query:user_id"` のようなタグから `"query"` (種別) と `"user_id"` (名前) を簡単に抽出できるAPI (`FieldInfo.TagValue("in", "key")` や `FieldInfo.TagSubValue("in")`) があれば、タグ解析ロジックが大幅に簡略化されます。現状は `strings.SplitN` などで自前処理しています。
-    構造体Docコメントの `in:"body"` のようなアノテーションも同様に、タグ解析の仕組みでサポートされると便利です。
+    `in:"query" query:"user_id"` のようなタグから `"query"` (種別) と `"user_id"` (名前) を簡単に抽出するために、`scanner.FieldInfo` に `TagValue(tagName string) string` メソッドが追加されました。これを利用して、ジェネレータ側で `bindFrom := field.TagValue("in")` および `bindName := field.TagValue(bindFrom)` のようにして必要な情報を取得できます。これにより、以前の自前のタグ解析ロジックが大幅に簡略化されます。
+    構造体Docコメントの `in:"body"` のようなアノテーションは、`TypeInfo.Annotation(name string) (value string, ok bool)` メソッドで取得した値を解析することで対応可能です。
 
 *   **型名の正規化/変換支援 (提案4)**:
     今回は直接的なニーズは少なかったものの、例えばOpenAPIスキーマ名との連携などを考えると、Goのフィールド名を `camelCase` や `snake_case` のパラメータ名に変換するユーティリティは役立ちます。

--- a/docs/ja/from-derivngjson.md
+++ b/docs/ja/from-derivngjson.md
@@ -55,14 +55,16 @@
     }
     ```
 
-*   **`go-scan` への提案機能**:
-    `scanner.FieldInfo` に、パース済みのタグ情報を保持する構造（例: `map[string]string`）や、特定のタグキーに対する値（オプション部分を除いたもの）を簡単に取得できるヘルパーメソッドを提供します。さらに、特定のタグキーと値を持つフィールドを `TypeInfo` から直接検索できる機能も有用です。
+*   **`go-scan` への提案機能 (一部実装済み)**:
+    `scanner.FieldInfo` に、特定のタグキーに対する値（オプション部分を除いたもの）を簡単に取得できるヘルパーメソッド `TagValue(tagName string) string` が追加されました。これにより、例えば `jsonTagValue := field.TagValue("json")` のようにして `"name"` (omitempty等は除外) を取得できます。
+    パース済みのタグ情報を保持する汎用的な構造（例: `map[string]string`）や、特定のタグキーと値を持つフィールドを `TypeInfo` から直接検索する機能は、引き続き有用な提案となります。
 
     ```go
-    // 提案するAPIのイメージ
+    // 実装されたAPIの例
     // jsonTagValue := field.TagValue("json") // "name" (omitempty等は除外)
+
+    // 引き続き提案するAPIのイメージ
     // allJsonOptions := field.TagOptions("json") // []string{"omitempty"}
-    //
     // discriminatorField := typeInfo.FindFieldWithTagValue("json", "type")
     ```
 

--- a/examples/derivingbind/go.mod
+++ b/examples/derivingbind/go.mod
@@ -1,6 +1,8 @@
 module github.com/podhmo/go-scan/examples/derivingbind
 
-go 1.21
+go 1.23
+
+toolchain go1.24.3
 
 require github.com/podhmo/go-scan v0.0.0
 

--- a/examples/derivingjson/go.mod
+++ b/examples/derivingjson/go.mod
@@ -1,6 +1,8 @@
 module github.com/podhmo/go-scan/examples/derivingjson
 
-go 1.21
+go 1.23
+
+toolchain go1.24.3
 
 require github.com/podhmo/go-scan v0.0.0
 

--- a/examples/derivingjson/main.go
+++ b/examples/derivingjson/main.go
@@ -9,7 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"reflect"
+	// "reflect" // No longer needed
 	"strings"
 	"text/template"
 
@@ -160,7 +160,8 @@ func Generate(ctx context.Context, pkgPath string) error {
 		if typeInfo.Kind != scanner.StructKind || typeInfo.Struct == nil {
 			continue
 		}
-		if typeInfo.Doc == "" || !strings.Contains(typeInfo.Doc, unmarshalAnnotation) {
+		// Use the new Annotation method to check for the unmarshal annotation
+		if _, ok := typeInfo.Annotation("deriving:unmarshall"); !ok {
 			continue
 		}
 
@@ -177,16 +178,8 @@ func Generate(ctx context.Context, pkgPath string) error {
 		}
 
 		for _, field := range typeInfo.Struct.Fields {
-			jsonTag := ""
-			if field.Tag != "" {
-				tag := reflect.StructTag(field.Tag)
-				jsonTagVal := tag.Get("json")
-				if commaIdx := strings.Index(jsonTagVal, ","); commaIdx != -1 {
-					jsonTag = jsonTagVal[:commaIdx]
-				} else {
-					jsonTag = jsonTagVal
-				}
-			}
+			// Use the new TagValue method
+			jsonTag := field.TagValue("json")
 
 			resolvedFieldType, errResolve := field.Type.Resolve(ctx)
 			if errResolve != nil {


### PR DESCRIPTION
…d scanner.FieldInfo

- Add `TagValue(tagName string) string` to `scanner.FieldInfo` to retrieve values from struct field tags.
- Add `Annotation(name string) (string, bool)` to `scanner.TypeInfo` to retrieve values from doc comment annotations.
- Refactor `examples/derivingjson/main.go` and `examples/derivingbind/main.go` to use these new methods.
- Remove `BindTag()` from `scanner.FieldInfo` to keep it generic; specific logic now resides in `derivingbind` example.
- Ensure all tests pass after changes (including running `go mod tidy` where necessary).
- Update Japanese documentation to reflect these API changes.