### PR TITLE
feat: Implement integer and boolean support

### DIFF
--- a/examples/minigo/object.go
+++ b/examples/minigo/object.go
@@ -33,15 +33,13 @@ type String struct {
 func (s *String) Type() ObjectType { return STRING_OBJ }
 func (s *String) Inspect() string  { return s.Value } // For simple strings, Inspect is just the value.
 
-// --- Integer Object (Example for future) ---
-/*
+// --- Integer Object ---
 type Integer struct {
-    Value int64
+	Value int64
 }
 
 func (i *Integer) Type() ObjectType { return INTEGER_OBJ }
 func (i *Integer) Inspect() string  { return fmt.Sprintf("%d", i.Value) }
-*/
 
 // --- Boolean Object ---
 type Boolean struct {

--- a/examples/minigo/todo.md
+++ b/examples/minigo/todo.md
@@ -6,12 +6,15 @@ This document outlines future enhancements and features for the MiniGo interpret
 
 -   **Assignment Statements (`ast.AssignStmt`)**: Implement evaluation for assignment statements (e.g., `x = "new_value"` or `x = y + 1`). This is crucial for variable manipulation after declaration. (Failed tests in `TestInterpreterEntryPoint` highlight this).
 -   **Global Variable Evaluation**: Implement a mechanism to evaluate and register global variable declarations (top-level `var` statements) before or alongside executing the entry point function. (Failed tests in `TestVariableDeclarationAndStringLiteral` highlight this).
--   **Integer Literals and Arithmetic**:
-    -   Add `INTEGER_OBJ` to `object.go`.
-    -   Support parsing and evaluation of integer literals in `interpreter.go`.
-    -   Implement arithmetic operations (`+`, `-`, `*`, `/`, `%`) for integers in `evalBinaryExpr`.
-    -   Add comparison operators (`<`, `>`, `<=`, `>=`) for integers.
--   **Boolean Literals**: Support `true` and `false` as keywords or literals if not already covered by `Boolean` object (currently, `Boolean` objects are only produced by comparisons).
+-   **Integer Literals and Arithmetic**: [COMPLETED]
+    -   Add `INTEGER_OBJ` to `object.go`. [COMPLETED]
+    -   Support parsing and evaluation of integer literals in `interpreter.go`. [COMPLETED]
+    -   Implement arithmetic operations (`+`, `-`, `*`, `/`, `%`) for integers in `evalBinaryExpr`. [COMPLETED]
+    -   Add comparison operators (`<`, `>`, `<=`, `>=`, `==`, `!=`) for integers. [COMPLETED]
+-   **Boolean Literals**: [COMPLETED] Support `true` and `false` as identifiers evaluating to Boolean objects. [COMPLETED]
+    -   Add `BOOLEAN_OBJ` to `object.go`. [COMPLETED]
+    -   Implement comparison operators (`==`, `!=`) for booleans. [COMPLETED]
+    -   Implement unary `!` (NOT) operator for booleans. [COMPLETED]
 -   **If Expressions/Statements**: Implement `if`/`else if`/`else` control flow. This will require evaluation of a condition to a `Boolean` object.
 -   **Function Calls (`ast.CallExpr`)**:
     -   Support calling user-defined functions. This involves:
@@ -23,14 +26,14 @@ This document outlines future enhancements and features for the MiniGo interpret
     -   Support calling built-in functions (e.g., `len()`, `println()`). Requires `BUILTIN_OBJ`.
 -   **Return Statements (`ast.ReturnStmt`)**: Implement handling of `return` statements to exit functions and return values. This will likely involve a `ReturnValue` wrapper object.
 -   **Error Handling**:
-    -   Improve error reporting with more precise location information (using `token.FileSet` to convert `token.Pos` to line/column).
+    -   Improve error reporting with more precise location information (using `token.FileSet` to convert `token.Pos` to line/column). [PARTIALLY DONE - `pos` is passed to some error messages]
     -   Introduce an `ERROR_OBJ` to propagate runtime errors as objects within the interpreter, allowing for potential recovery or inspection.
 -   **More Data Types**:
     -   `NULL_OBJ` and `null` literal.
     -   Arrays/Slices.
     -   Maps (Hashes).
 -   **String Concatenation**: Support `+` operator for string concatenation in `evalStringBinaryExpr`.
--   **Comments**: Ensure comments are correctly ignored (currently handled by `go/parser`).
+-   **Comments**: Ensure comments are correctly ignored (currently handled by `go/parser`). [VERIFIED]
 
 ## Interpreter & Tooling Enhancements
 


### PR DESCRIPTION
This commit introduces support for integer and boolean types in the MiniGo interpreter.

Features added:
- Integer literals (decimal, hex) and Integer objects.
- Boolean literals (`true`, `false`) and Boolean objects.
- Arithmetic operations for integers: +, -, *, /, % (with division by zero checks).
- Comparison operations for integers: ==, !=, <, >, <=, >=.
- Comparison operations for booleans: ==, !=.
- Unary minus (-) for integers.
- Unary logical NOT (!) for booleans.
- Handling of parenthesized expressions (`ast.ParenExpr`).

The `object.go` file was updated with `Integer` type. The `interpreter.go` file was significantly enhanced to parse and evaluate these new types and operations, including adding `evalIntegerBinaryExpr`, `evalBooleanBinaryExpr`, and `evalUnaryExpr` helper functions, and updating `eval` and `evalBinaryExpr`. Error handling for type mismatches and undefined operations for these new types has been included.

Comprehensive tests were added in `interpreter_test.go` covering literals, operations, comparisons, unary operators, parentheses, and error conditions for integers and booleans. The `todo.md` file has been updated to reflect these changes.