### PR TITLE
Implement string concatenation and fmt/strings builtins

### DIFF
--- a/examples/minigo/builtin_fmt.go
+++ b/examples/minigo/builtin_fmt.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	// "strings" // Not used directly here, but often related
+)
+
+// evalFmtSprintf handles the execution of a fmt.Sprintf call.
+// It expects the first argument to be a format string (String object)
+// and subsequent arguments to be the values to format.
+func evalFmtSprintf(args ...Object) (Object, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("fmt.Sprintf expects at least one argument (format string)")
+	}
+
+	formatStringObj, ok := args[0].(*String)
+	if !ok {
+		return nil, fmt.Errorf("first argument to fmt.Sprintf must be a STRING, got %s", args[0].Type())
+	}
+	formatString := formatStringObj.Value
+
+	// Convert remaining MiniGo objects to Go native types for Sprintf.
+	// This is a simplification. A more robust solution would handle various MiniGo types.
+	nativeArgs := make([]interface{}, len(args)-1)
+	for i, arg := range args[1:] {
+		switch obj := arg.(type) {
+		case *String:
+			nativeArgs[i] = obj.Value
+		case *Integer:
+			nativeArgs[i] = obj.Value
+		case *Boolean:
+			nativeArgs[i] = obj.Value
+		// Add other types as needed
+		default:
+			return nil, fmt.Errorf("unsupported type %s for fmt.Sprintf argument at index %d", obj.Type(), i+1)
+		}
+	}
+
+	// Perform the Sprintf operation using Go's native fmt.Sprintf.
+	// Note: This is a direct call to Go's fmt.Sprintf. Security implications
+	// (like format string vulnerabilities) from user-provided format strings
+	// are relevant if MiniGo were used in a sensitive context.
+	// For this example, we assume valid and safe usage.
+	result := fmt.Sprintf(formatString, nativeArgs...)
+	return &String{Value: result}, nil
+}
+
+// Helper to create a BuiltinFunction object for fmt.Sprintf
+func newFmtSprintfBuiltin() *BuiltinFunction {
+	return &BuiltinFunction{
+		Fn: func(env *Environment, args ...Object) (Object, error) { // Modified signature
+			return evalFmtSprintf(args...)
+		},
+		Name: "fmt.Sprintf",
+	}
+}
+
+// Example of how it might be registered in the interpreter setup:
+// interpreter.globalEnv.Define("fmt.Sprintf", newFmtSprintfBuiltin())
+// (Actual registration will be handled in interpreter.go as per the plan)
+//
+// To make "fmt" itself a namespace or package-like structure,
+// we might need a more complex object type, like a Module or Struct,
+// that can hold other functions/variables.
+// For now, we'll register "fmt.Sprintf" as a flat function name.
+//
+// A more advanced way could be:
+// fmtModule := NewModule("fmt")
+// fmtModule.Define("Sprintf", &BuiltinFunction{Fn: evalFmtSprintf, Name: "Sprintf"})
+// env.Define("fmt", fmtModule)
+// Then calls would be like `fmt.Sprintf(...)` parsed as `Ident{Name:"fmt"}` Dot `Ident{Name:"Sprintf"}`.
+// Current plan is to treat "fmt.Sprintf" as a single identifier for simplicity.
+
+func (i *Interpreter) registerBuiltinFmt(env *Environment) {
+	// We need a way to make `fmt.Sprintf` callable.
+	// This could be by defining a global variable `fmt.Sprintf` that holds a BuiltinFunction object.
+	// Or, more elaborately, by handling `ast.SelectorExpr` (e.g., `fmt.Sprintf`)
+	// where `fmt` is an object (perhaps a module or map) that has a `Sprintf` method/key.
+
+	// For simplicity with the current plan (treating "fmt.Sprintf" as a single identifier for the CallExpr's Fun):
+	// We'll need to ensure that when `ast.CallExpr` has `Fun` as an `ast.Ident` with name "fmt.Sprintf",
+	// our `evalIdentifier` or `evalCallExpr` can find this built-in.
+
+	// The plan step 4 mentions: "グローバル環境または適切な場所に、fmt.Sprintf ... を登録する処理を追加します。"
+	// This registration will happen in NewInterpreter or a similar setup function.
+	// This file (builtin_fmt.go) defines the *implementation* of the function.
+
+	// No direct registration code here, as it depends on the BuiltinFunction object type
+	// and the interpreter's environment structure, which are defined/modified in other steps.
+	// This file provides the `evalFmtSprintf` function that will be wrapped.
+}
+
+// GetBuiltinFmtFunctions returns a map of fmt built-in functions.
+// This allows the interpreter to easily register them.
+func GetBuiltinFmtFunctions() map[string]*BuiltinFunction {
+	return map[string]*BuiltinFunction{
+		"fmt.Sprintf": {
+			Fn: func(env *Environment, args ...Object) (Object, error) { // Matching new signature
+				return evalFmtSprintf(args...)
+			},
+			Name: "fmt.Sprintf",
+		},
+		// Add other fmt functions here if needed, e.g., fmt.Println
+		// "fmt.Println": { /* ... */ },
+	}
+}
+
+// Notes on original longer comments that were removed:
+// - The removed comments discussed potential fmt.Println implementation,
+//   BuiltinFunction signatures, error handling, type checking, string representation
+//   for Sprintf, and how "fmt.Sprintf" might be parsed (Ident vs SelectorExpr).
+// - These are useful design considerations but were causing build errors as
+//   they were not fully commented out or were placed outside function bodies.
+// - For brevity and to fix the build, they have been removed. The core logic
+//   of GetBuiltinFmtFunctions and evalFmtSprintf remains.

--- a/examples/minigo/builtin_strings.go
+++ b/examples/minigo/builtin_strings.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// evalStringsJoin handles the execution of a strings.Join call.
+// For MiniGo, due to the lack of explicit array types yet, we'll adopt a convention:
+// strings.Join(str1, str2, ..., strN, separator) will join str1 through strN using separator.
+// This differs from Go's strings.Join(array, separator).
+func evalStringsJoin(args ...Object) (Object, error) {
+	if len(args) < 2 {
+		// Needs at least one string to "join" (which would be itself) and a separator,
+		// or effectively, at least two args for our convention: element1, separator.
+		// Or, if we interpret it as str1, str2, ..., sep, then len must be >= 2.
+		// Let's say: at least one element and one separator.
+		return nil, fmt.Errorf("strings.Join expects at least two arguments (elements to join and a separator), got %d", len(args))
+	}
+
+	separatorObj, ok := args[len(args)-1].(*String)
+	if !ok {
+		return nil, fmt.Errorf("last argument to strings.Join (separator) must be a STRING, got %s", args[len(args)-1].Type())
+	}
+	separator := separatorObj.Value
+
+	elementsToJoin := args[:len(args)-1]
+	if len(elementsToJoin) == 0 {
+		// This case means only a separator was provided, which is an invalid use
+		// according to our convention (e.g. strings.Join(","))
+		return nil, fmt.Errorf("strings.Join requires at least one element to join before the separator")
+	}
+
+	stringElements := make([]string, len(elementsToJoin))
+	for i, arg := range elementsToJoin {
+		strObj, ok := arg.(*String)
+		if !ok {
+			return nil, fmt.Errorf("argument %d to strings.Join (element to join) must be a STRING, got %s", i, arg.Type())
+		}
+		stringElements[i] = strObj.Value
+	}
+
+	result := strings.Join(stringElements, separator)
+	return &String{Value: result}, nil
+}
+
+// GetBuiltinStringsFunctions returns a map of built-in functions related to strings.
+func GetBuiltinStringsFunctions() map[string]*BuiltinFunction {
+	return map[string]*BuiltinFunction{
+		"strings.Join": {
+			Fn: func(env *Environment, args ...Object) (Object, error) {
+				// env is not used by strings.Join, but the signature requires it.
+				return evalStringsJoin(args...)
+			},
+			Name: "strings.Join",
+		},
+		// Add other strings functions here if needed, e.g., strings.HasPrefix, strings.Contains
+		// "strings.ToUpper": {
+		// 	Fn: func(env *Environment, args ...Object) (Object, error) {
+		// 		if len(args) != 1 {
+		// 			return nil, fmt.Errorf("strings.ToUpper expects exactly one argument")
+		// 		}
+		// 		strObj, ok := args[0].(*String)
+		// 		if !ok {
+		// 			return nil, fmt.Errorf("argument to strings.ToUpper must be a STRING, got %s", args[0].Type())
+		// 		}
+		// 		return &String{Value: strings.ToUpper(strObj.Value)}, nil
+		// 	},
+		// 	Name: "strings.ToUpper",
+		// },
+	}
+}
+
+// Notes on original longer comments that were removed:
+// - The removed comments discussed the variadic nature of the current strings.Join
+//   implementation as a workaround for MiniGo's lack of array/slice types.
+// - It also outlined how a more Go-idiomatic strings.Join (taking an array/slice
+//   and a separator) would be implemented once MiniGo has those features.
+// - These comments were causing build errors and have been removed for brevity.
+//   The core logic of GetBuiltinStringsFunctions and evalStringsJoin remains.

--- a/examples/minigo/object.go
+++ b/examples/minigo/object.go
@@ -14,7 +14,7 @@ const (
 	RETURN_VALUE_OBJ ObjectType = "RETURN_VALUE" // Special type to wrap return values
 	ERROR_OBJ        ObjectType = "ERROR"        // To wrap errors as objects
 	// FUNCTION_OBJ     // For user-defined functions
-	// BUILTIN_OBJ      // For built-in functions
+	BUILTIN_FUNCTION_OBJ ObjectType = "BUILTIN_FUNCTION" // For built-in functions
 )
 
 // Object is the interface that all value types in our interpreter will implement.
@@ -109,3 +109,28 @@ func (s *String) Compare(other Object) (int, error) {
 // - Implement `ReturnValue` and `Error` wrapper objects for flow control and error handling.
 // - Implement `Hashable` interface for objects that can be keys in a hash map.
 // - Implement `Callable` interface for function objects.
+
+// --- BuiltinFunction Object ---
+
+// BuiltinFunctionType defines the signature for Go functions that can be used as built-ins.
+// It takes the current evaluation environment (in case the built-in needs to interact with it,
+// e.g., to resolve other variables or call other MiniGo functions, though most won't need it)
+// and a variable number of Object arguments, returning an Object or an error.
+type BuiltinFunctionType func(env *Environment, args ...Object) (Object, error)
+
+// BuiltinFunction represents a function that is implemented in Go and exposed to MiniGo.
+type BuiltinFunction struct {
+	Fn   BuiltinFunctionType
+	Name string // Name of the built-in function, primarily for inspection/debugging.
+}
+
+func (bf *BuiltinFunction) Type() ObjectType { return BUILTIN_FUNCTION_OBJ }
+func (bf *BuiltinFunction) Inspect() string {
+	if bf.Name != "" {
+		return fmt.Sprintf("<builtin function %s>", bf.Name)
+	}
+	return "<builtin function>"
+}
+
+// Ensure BuiltinFunction implements the Object interface.
+var _ Object = (*BuiltinFunction)(nil)


### PR DESCRIPTION
- Added support for the `+` operator for string concatenation.
- Implemented `fmt.Sprintf` and `strings.Join` as built-in functions.
  - `fmt.Sprintf` wraps the native Go `fmt.Sprintf`.
  - `strings.Join` is a custom implementation for MiniGo, taking variadic string arguments and a final separator argument, due to the current lack of array/slice types.
- Added `BuiltinFunction` object type to `object.go`.
- Added `evalSelectorExpr` to `interpreter.go` to handle function calls like `pkg.Func`.
- Updated `interpreter_test.go` with comprehensive tests for these new features and related error handling.
- Refactored test helpers and specific test cases for clarity and correctness, especially around environment setup for evaluating expressions with variables and built-ins.