### PR TITLE
feat: include examples/minigo tests in make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ test:
 	go test ./...
 	( cd examples/derivingjson && go test ./... )
 	( cd examples/derivingbind && go test ./... )
+	( cd examples/minigo && go test ./... )
 
 clean:
 	go clean -cache -testcache # General Go clean

--- a/examples/minigo/interpreter.go
+++ b/examples/minigo/interpreter.go
@@ -53,7 +53,7 @@ func formatErrorWithContext(fset *token.FileSet, pos token.Pos, originalErr erro
 	} else {
 		errMsg = fmt.Sprintf("%s\n  Details: %v", errMsg, originalErr)
 	}
-	return fmt.Errorf(errMsg)
+	return fmt.Errorf("%s", errMsg) // Use %s to treat errMsg as a string literal
 }
 
 // parseInt64 is a helper function to parse a string to an int64.

--- a/examples/minigo/interpreter_test.go
+++ b/examples/minigo/interpreter_test.go
@@ -187,41 +187,41 @@ func TestFormattedErrorHandling(t *testing.T) {
 			source: `
 package main
 func main() {
-	a := 10
-	b := 0
-	c := a / b // Error on this line
+	var a = 10
+	var b = 0
+	var c = a / b // Error on this line
 }`,
 			entryPoint:  "main",
-			expectedMsg: []string{"division by zero", "c := a / b", "line 6"}, // Filename will vary
+			expectedMsg: []string{"division by zero", "var c = a / b", "line 6"}, // Filename will vary
 		},
 		{
 			name: "undefined variable with context",
 			source: `
 package main
 func main() {
-	x := y + 1 // Error: y is not defined
+	var x = y + 1 // Error: y is not defined
 }`,
 			entryPoint:  "main",
-			expectedMsg: []string{"identifier not found: y", "x := y + 1", "line 4"},
+			expectedMsg: []string{"identifier not found: y", "var x = y + 1", "line 4"},
 		},
 		{
 			name: "type mismatch in binary operation with context",
 			source: `
 package main
 func main() {
-	a := 10
-	s := "hello"
-	r := a + s // Error: type mismatch
+	var a = 10
+	var s = "hello"
+	var r = a + s // Error: type mismatch
 }`,
 			entryPoint:  "main",
-			expectedMsg: []string{"type mismatch or unsupported operation", "INTEGER + STRING", "r := a + s", "line 6"},
+			expectedMsg: []string{"type mismatch or unsupported operation", "INTEGER + STRING", "var r = a + s", "line 6"},
 		},
 		{
 			name: "calling non-function with context",
 			source: `
 package main
 func main() {
-	x := 123
+	var x = 123
 	x() // Error: x is not a function
 }`,
 			entryPoint:  "main",


### PR DESCRIPTION
- Added test execution for examples/minigo to the test target of the Makefile
- Fixed the call to fmt.Errorf in examples/minigo/interpreter.go
- Fixed the test cases in examples/minigo/interpreter_test.go to match the current specifications of the interpreter