### PR TITLE
Fix: minigo interpreter and tests

### DIFF
--- a/examples/minigo/interpreter.go
+++ b/examples/minigo/interpreter.go
@@ -71,7 +71,7 @@ func formatErrorWithContext(fset *token.FileSet, pos token.Pos, originalErr erro
 	if baseErrMsg != "" {
 		return fmt.Errorf("%s\n  Details: %s", detailMsg, baseErrMsg)
 	}
-	return fmt.Errorf("%s", errMsg) // Use %s to treat errMsg as a string literal
+	return fmt.Errorf("%s", detailMsg) // Use %s to treat detailMsg as a string literal
 }
 
 // parseInt64 is a helper function to parse a string to an int64.

--- a/examples/minigo/interpreter_test.go
+++ b/examples/minigo/interpreter_test.go
@@ -1124,7 +1124,7 @@ func main() { result = earlyReturn(10); }`,
 			source: `
 package main
 var result int
-func earlyReturnInElse(val) {
+func earlyReturnInElse(val int) {
 	if val == 5 {
 		x := 10; // just some statement
 	} else {


### PR DESCRIPTION
- Fixed a compile error in interpreter.go caused by an undefined variable.
- Corrected a test case in interpreter_test.go where a function was called with an incorrect number of arguments by adding the expected type to the function parameter.