### PR TITLE
Integrate go-scan into minigo and enable AST access

### DIFF
--- a/examples/minigo/go.mod
+++ b/examples/minigo/go.mod
@@ -4,4 +4,6 @@ go 1.24
 
 //他のexamplesディレクトリを参考にreplaceディレクティブを追加
 //ローカルのgo-scanパッケージを参照するようにします。
-replace github.com/go-scan/go-scan => ../../go-scan
+replace github.com/go-scan/go-scan => ../..
+
+require github.com/go-scan/go-scan v0.0.0-00010101000000-000000000000

--- a/examples/minigo/todo.md
+++ b/examples/minigo/todo.md
@@ -62,13 +62,13 @@
 - [ ] `findFunction` in `interpreter.go` might be dead code now.
 
 ## go-scan Integration
-- [ ] **Integrate `go-scan` for initial parsing phase**
-  - [ ] Modify `LoadAndRun` to use `go-scan`'s `Scanner` to get `PackageInfo`.
-  - [ ] Adapt `minigo` to extract function definitions (`*ast.FuncDecl` or body) from `PackageInfo` (or `*ast.File` if provided by `go-scan`).
-  - [ ] Adapt `minigo` to extract global variable declarations from `PackageInfo` (or `*ast.File` if provided by `go-scan`).
-  - [ ] Ensure error reporting (`formatErrorWithContext`) correctly uses `FileSet` and positional info from `go-scan`.
+- [x] **Integrate `go-scan` for initial parsing phase**
+  - [x] Modify `LoadAndRun` to use `go-scan`'s `Scanner` to get `PackageInfo`.
+  - [x] Adapt `minigo` to extract function definitions (`*ast.FuncDecl` or body) from `PackageInfo` (or `*ast.File` if provided by `go-scan`).
+  - [x] Adapt `minigo` to extract global variable declarations from `PackageInfo` (or `*ast.File` if provided by `go-scan`).
+  - [x] Ensure error reporting (`formatErrorWithContext`) correctly uses `FileSet` and positional info from `go-scan`.
 - [ ] **Contribute to or discuss `go-scan` enhancements**
-  - [ ] Propose/discuss `PackageInfo` retaining `*ast.File` for scanned files.
+  - [x] Propose/discuss `PackageInfo` retaining `*ast.File` for scanned files. (Implemented)
   - [ ] Propose/discuss `FunctionInfo` directly referencing `*ast.FuncDecl`.
   - [ ] Propose/discuss `PackageInfo` aggregating global variable declarations.
 - [ ] **Investigate `go-scan`'s Lazy Import (`PackageResolver`) for multi-file/package support in `minigo` (Future)**

--- a/scanner/models.go
+++ b/scanner/models.go
@@ -35,6 +35,7 @@ type PackageInfo struct {
 	Constants  []*ConstantInfo
 	Functions  []*FunctionInfo
 	Fset       *token.FileSet // Added: Fileset for position information
+	AstFiles   map[string]*ast.File // Added: Parsed AST for each file
 }
 
 // ExternalTypeOverride defines a mapping from a fully qualified type name

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -74,9 +74,10 @@ func (s *Scanner) ScanFiles(ctx context.Context, filePaths []string, pkgDirPath 
 	}
 
 	info := &PackageInfo{
-		Path:  pkgDirPath, // Physical directory path
-		Fset:  s.fset,     // Use the shared FileSet
-		Files: make([]string, 0, len(filePaths)),
+		Path:     pkgDirPath, // Physical directory path
+		Fset:     s.fset,     // Use the shared FileSet
+		Files:    make([]string, 0, len(filePaths)),
+		AstFiles: make(map[string]*ast.File), // Initialize AstFiles
 	}
 	var firstPackageName string
 
@@ -96,6 +97,7 @@ func (s *Scanner) ScanFiles(ctx context.Context, filePaths []string, pkgDirPath 
 		}
 
 		info.Files = append(info.Files, filePath) // Store absolute file path
+		info.AstFiles[filePath] = fileAst         // Store AST
 		slog.DebugContext(ctx, "Processing file for package", slog.String("filePath", filePath), slog.String("packageName", info.Name))
 		s.buildImportLookup(fileAst)
 		slog.DebugContext(ctx, "Built import lookup", slog.String("filePath", filePath), slog.Any("imports", s.importLookup))


### PR DESCRIPTION
- Modified go-scan to store *ast.File in PackageInfo.
- Updated minigo's interpreter to use go-scan for parsing.
- Adjusted minigo's go.mod for correct local replace directive.
- Updated minigo's todo.md to reflect completed tasks.