### PR TITLE
Update minigo to use podhmo/go-scan

### DIFF
--- a/examples/minigo/go.mod
+++ b/examples/minigo/go.mod
@@ -4,6 +4,6 @@ go 1.24
 
 //他のexamplesディレクトリを参考にreplaceディレクティブを追加
 //ローカルのgo-scanパッケージを参照するようにします。
-replace github.com/go-scan/go-scan => ../..
+replace github.com/podhmo/go-scan => ../..
 
-require github.com/go-scan/go-scan v0.0.0-00010101000000-000000000000
+require github.com/podhmo/go-scan v0.0.0-00010101000000-000000000000

--- a/examples/minigo/interpreter.go
+++ b/examples/minigo/interpreter.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-scan/go-scan/scanner" // Using go-scan
+	"github.com/podhmo/go-scan/scanner" // Using go-scan
 )
 
 // formatErrorWithContext creates a detailed error message including file, line, column, and source code.

--- a/examples/minigo/main.go
+++ b/examples/minigo/main.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	// "github.com/go-scan/go-scan/scanner" // Will be used later
+	// "github.com/podhmo/go-scan/scanner" // Will be used later
 )
 
 func main() {


### PR DESCRIPTION
- Modified go.mod to require and replace github.com/podhmo/go-scan.
- Updated import paths in interpreter.go and main.go to use github.com/podhmo/go-scan/scanner.