### PR TITLE
feat: Store *ast.FuncDecl in FunctionInfo and use in minigo

### DIFF
--- a/examples/minigo/interpreter.go
+++ b/examples/minigo/interpreter.go
@@ -131,24 +131,26 @@ func (i *Interpreter) LoadAndRun(filename string, entryPoint string) error {
 	}
 	i.FileSet = pkgInfo.Fset // Use the FileSet from go-scan
 
-	// Process top-level declarations (functions and global vars) from the ASTs
-	for _, fileAst := range pkgInfo.AstFiles { // Iterate through all scanned files' ASTs
-		// Store all function declarations first
-		for _, declNode := range fileAst.Decls {
-			if fnDecl, ok := declNode.(*ast.FuncDecl); ok {
-				_, evalErr := i.evalFuncDecl(fnDecl, i.globalEnv)
-				if evalErr != nil {
-					return evalErr // evalFuncDecl should use i.FileSet for errors
-				}
-			}
+	// Process functions from PackageInfo.Functions
+	for _, funcInfo := range pkgInfo.Functions {
+		if funcInfo.Node == nil {
+			// This should not happen if go-scan is working correctly
+			return formatErrorWithContext(i.FileSet, token.NoPos, fmt.Errorf("function info for '%s' is missing AST node", funcInfo.Name), "Interpreter setup error")
 		}
-		// Then evaluate global variable declarations
+		_, evalErr := i.evalFuncDecl(funcInfo.Node, i.globalEnv)
+		if evalErr != nil {
+			return evalErr
+		}
+	}
+
+	// Process global variable declarations from the ASTs
+	// This part still needs to iterate over AstFiles and Decls, as go-scan doesn't explicitly list global vars yet.
+	for _, fileAst := range pkgInfo.AstFiles {
 		for _, declNode := range fileAst.Decls {
 			if genDecl, ok := declNode.(*ast.GenDecl); ok && genDecl.Tok == token.VAR {
 				tempDeclStmt := &ast.DeclStmt{Decl: genDecl}
 				_, evalErr := i.eval(tempDeclStmt, i.globalEnv)
 				if evalErr != nil {
-					// formatErrorWithContext will use i.FileSet
 					return formatErrorWithContext(i.FileSet, genDecl.Pos(), evalErr, "Error evaluating global variable declaration")
 				}
 			}

--- a/examples/minigo/todo.md
+++ b/examples/minigo/todo.md
@@ -67,8 +67,8 @@
   - [x] Adapt `minigo` to extract function definitions (`*ast.FuncDecl` or body) from `PackageInfo` (or `*ast.File` if provided by `go-scan`).
   - [x] Adapt `minigo` to extract global variable declarations from `PackageInfo` (or `*ast.File` if provided by `go-scan`).
   - [x] Ensure error reporting (`formatErrorWithContext`) correctly uses `FileSet` and positional info from `go-scan`.
-- [ ] **Contribute to or discuss `go-scan` enhancements**
+- [x] **Contribute to or discuss `go-scan` enhancements**
   - [x] Propose/discuss `PackageInfo` retaining `*ast.File` for scanned files. (Implemented)
-  - [ ] Propose/discuss `FunctionInfo` directly referencing `*ast.FuncDecl`.
+  - [x] Propose/discuss `FunctionInfo` directly referencing `*ast.FuncDecl`. (Implemented)
   - [ ] Propose/discuss `PackageInfo` aggregating global variable declarations.
 - [ ] **Investigate `go-scan`'s Lazy Import (`PackageResolver`) for multi-file/package support in `minigo` (Future)**

--- a/scanner/models.go
+++ b/scanner/models.go
@@ -293,6 +293,7 @@ type FunctionInfo struct {
 	Receiver   *FieldInfo
 	Parameters []*FieldInfo
 	Results    []*FieldInfo
+	Node       *ast.FuncDecl // Added: AST node for the function declaration
 }
 
 // var _ = strings.Builder{} // This helper is no longer needed as "strings" is directly imported.

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -299,6 +299,7 @@ func (s *Scanner) parseFuncDecl(f *ast.FuncDecl, absFilePath string) *FunctionIn
 	funcInfo.Name = f.Name.Name
 	funcInfo.FilePath = absFilePath
 	funcInfo.Doc = commentText(f.Doc)
+	funcInfo.Node = f // Populate the Node field
 	if f.Recv != nil && len(f.Recv.List) > 0 {
 		recvField := f.Recv.List[0]
 		var recvName string


### PR DESCRIPTION
This change enhances go-scan's FunctionInfo to store the *ast.FuncDecl node directly. This simplifies the process for consumers like minigo to access function bodies and other AST-level details without needing to re-traverse the ASTs from PackageInfo.AstFiles.

- Modified FunctionInfo in scanner/models.go to include `Node *ast.FuncDecl`.
- Updated scanner/scanner.go to populate this new field.
- Refactored examples/minigo/interpreter.go to use `FunctionInfo.Node` when processing function declarations.
- Updated examples/minigo/todo.md to reflect this change.

All tests pass for both go-scan and minigo.