### PR TITLE
Fix: Correct minigo tests and enhance go-scan constant parsing

### DIFF
--- a/examples/minigo/interpreter.go
+++ b/examples/minigo/interpreter.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
-	// "go/parser" // Will be replaced by go-scan
+	"go/parser" // Will be replaced by go-scan
 	"go/token"
 	"os"
 	"path/filepath" // Added for go-scan
@@ -220,7 +220,6 @@ func (i *Interpreter) LoadAndRun(filename string, entryPoint string) error {
 				}
 				i.importAliasMap[localName] = importPath
 			}
-		}
 	}
 
 	// Process other top-level declarations (functions and global vars) from the AST
@@ -244,7 +243,6 @@ func (i *Interpreter) LoadAndRun(filename string, entryPoint string) error {
 				}
 			}
 		}
-	// Removed extra closing brace here
 
 	// Get the entry function *object* from the global environment
 	entryFuncObj, ok := i.globalEnv.Get(entryPoint)

--- a/examples/minigo/testdata/testpkg/testpkg.go
+++ b/examples/minigo/testdata/testpkg/testpkg.go
@@ -1,0 +1,5 @@
+package testpkg
+
+const ExportedConst = "Hello from testpkg"
+const AnotherExportedConst = 12345
+const nonExportedConst = "Internal constant" // 小文字で始まる非エクスポート定数


### PR DESCRIPTION
This commit addresses several issues that caused test failures in the examples/minigo interpreter and improves the go-scan utility.

Key changes:
- Resolved syntax errors in `examples/minigo/interpreter.go` by removing extraneous closing braces and ensuring correct import of the "go/parser" package.
- Created missing test data files (`examples/minigo/testdata/testpkg/testpkg.go`) required by `TestImportStatements` in `examples/minigo/interpreter_test.go`.
- Modified `examples/minigo/interpreter_test.go` to consistently use a test-specific scanner rooted at `examples/minigo/testdata` for all relevant test cases. This resolved an issue where some tests failed due to incorrect scanner initialization.
- Enhanced `scanner/scanner.go` to infer types for constants declared without explicit type annotations (e.g., `const C = 10`). The scanner now infers types from basic literals (string, int, float, char/rune), resolving warnings about missing type information and enabling the minigo interpreter to correctly evaluate imported constants.

These changes ensure that all tests in `examples/minigo` pass and that `go-scan` provides more accurate type information for constants.