### PR TITLE
Update go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,10 +19,10 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.22'
+        go-version: '1.24'
 
     - name: Build
       run: go build -v ./...
 
     - name: Test
-      run: go test ./...
+      run: make test


### PR DESCRIPTION
This pull request updates the Go version used in the CI workflow and modifies the testing command to use a `Makefile` target instead of directly invoking `go test`.

Updates to CI workflow:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL22-R28): Changed the Go version from `1.22` to `1.24` in the `Set up Go` step to ensure compatibility with the latest features and improvements.
* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL22-R28): Updated the `Test` step to use `make test` instead of `go test ./...`, allowing for more flexible and centralized test management via the `Makefile`.