### PR TITLE
Fix: Handle blank imports by ignoring them in minigo

### DIFF
--- a/examples/minigo/README.md
+++ b/examples/minigo/README.md
@@ -95,7 +95,7 @@ The following import forms are **not currently supported** by `minigo` and will 
 -   **Dot Imports:** `import . "my/pkg"`
     -   This form, which would bring all exported symbols from `my/pkg` into the current file's namespace, is not supported.
 -   **Blank Imports for Execution:** `import _ "my/pkg"`
-    -   While Go uses blank imports for their side effects (e.g., `init` functions), `minigo` does not currently support package initialization via `init` functions. Therefore, blank imports are treated as an error as they would have no effect in the current `minigo` execution model and cannot be used to access symbols.
+    -   While Go uses blank imports for their side effects (e.g., `init` functions), `minigo` does not currently support package initialization via `init` functions. Therefore, blank imports are **ignored** by `minigo` as they would have no effect in the current execution model and cannot be used to access symbols.
 
 These limitations are in place to simplify the initial implementation of package imports.
 

--- a/examples/minigo/interpreter.go
+++ b/examples/minigo/interpreter.go
@@ -205,7 +205,8 @@ func (i *Interpreter) LoadAndRun(filename string, entryPoint string) error {
 			if impSpec.Name != nil {
 				localName = impSpec.Name.Name
 				if localName == "_" {
-					return formatErrorWithContext(i.FileSet, impSpec.Name.Pos(), errors.New("blank imports are not supported"), "")
+					// Blank imports are ignored, do not add to importAliasMap
+					continue
 				}
 				if localName == "." {
 					return formatErrorWithContext(i.FileSet, impSpec.Name.Pos(), errors.New("dot imports are not supported"), "")

--- a/examples/minigo/interpreter_test.go
+++ b/examples/minigo/interpreter_test.go
@@ -177,15 +177,17 @@ func main() {
 			expectedErrorMsgSubstr: "dot imports are not supported",
 		},
 		{
-			name: "disallowed blank import",
+			name: "blank import is ignored",
 			source: `
 package main
 import _ "mytestmodule/testpkg"
+var resultInt int // Add a dummy variable to check execution
 func main() {
+	resultInt = 1 // Ensure main runs
 }`,
 			entryPoint:             "main",
-			expectError:            true,
-			expectedErrorMsgSubstr: "blank imports are not supported",
+			expectError:            false, // Should not error
+			expectedGlobalVarValue: map[string]interface{}{"resultInt": int64(1)},
 		},
 		{
 			name: "alias conflict",


### PR DESCRIPTION
Previously, blank imports (`import _ "package"`) in minigo scripts would cause an error. This change modifies the interpreter to ignore these imports, as they are intended for side effects which minigo doesn't currently support, and they don't provide symbols to be used.

The README.md has been updated to reflect this change, and the corresponding test case in `interpreter_test.go` has been modified to ensure blank imports no longer cause an error and the script executes successfully.