### PR TITLE
Refactor: Remove inappropriate context.Background() calls in examples…

### DIFF
--- a/examples/minigo/interpreter_test.go
+++ b/examples/minigo/interpreter_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	// "path/filepath" // For joining paths - No longer needed due to hardcoded paths
 	// "runtime"       // For runtime.Caller - No longer needed
@@ -235,7 +236,7 @@ func main() {
 			}
 			interpreter.sharedScanner = testSpecificScanner
 
-			err := interpreter.LoadAndRun(filename, tt.entryPoint)
+			err := interpreter.LoadAndRun(context.Background(), filename, tt.entryPoint)
 
 			if tt.expectError {
 				if err == nil {

--- a/examples/minigo/main.go
+++ b/examples/minigo/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -36,7 +37,7 @@ func main() {
 	interpreter := NewInterpreter()
 	// Store the initial environment, which might be useful for inspection or a REPL later.
 	// For now, LoadAndRun creates its own scope for the main function.
-	err = interpreter.LoadAndRun(filename, *entryPoint)
+	err = interpreter.LoadAndRun(context.Background(), filename, *entryPoint)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error running interpreter: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
…/minigo

This commit refactors the examples/minigo package to eliminate inappropriate uses of context.Background() outside of main.go and test files.

- Modified relevant functions in interpreter.go to accept context.Context as an argument.
- Updated calling sites in main.go and interpreter_test.go to pass the context accordingly.