### PR TITLE
feat(locator): support go.mod replace directives

### DIFF
--- a/locator/locator.go
+++ b/locator/locator.go
@@ -8,10 +8,20 @@ import (
 	"strings"
 )
 
+// ReplaceDirective represents a single replace directive in a go.mod file.
+type ReplaceDirective struct {
+	OldPath    string
+	OldVersion string // Empty if not specified
+	NewPath    string
+	NewVersion string // Empty if it's a local path or not specified
+	IsLocal    bool
+}
+
 // Locator helps find the module root and resolve package import paths.
 type Locator struct {
 	modulePath string
 	rootDir    string
+	replaces   []ReplaceDirective
 }
 
 // New creates a new Locator by searching for a go.mod file.
@@ -27,14 +37,24 @@ func New(startPath string) (*Locator, error) {
 		return nil, err
 	}
 
-	modPath, err := getModulePath(filepath.Join(rootDir, "go.mod"))
+	goModFilePath := filepath.Join(rootDir, "go.mod")
+	modPath, err := getModulePath(goModFilePath)
 	if err != nil {
 		return nil, err
+	}
+
+	replaces, err := getReplaceDirectives(goModFilePath)
+	if err != nil {
+		// It's okay if parsing replace directives fails, just log it or handle as a warning
+		// For now, we'll proceed without them.
+		// TODO: Add proper logging or error handling strategy.
+		fmt.Fprintf(os.Stderr, "warning: could not parse replace directives in %s: %v\n", goModFilePath, err)
 	}
 
 	return &Locator{
 		modulePath: modPath,
 		rootDir:    rootDir,
+		replaces:   replaces,
 	}, nil
 }
 
@@ -49,8 +69,131 @@ func (l *Locator) ModulePath() string {
 }
 
 // FindPackageDir converts an import path to a physical directory path.
+// It now considers replace directives.
 func (l *Locator) FindPackageDir(importPath string) (string, error) {
-	// Try with the current module context first
+	// 1. Check replace directives
+	for _, r := range l.replaces {
+		// Check if the importPath matches the OldPath of a replace directive.
+		// This handles cases like:
+		// replace old.module/path => ./local/path
+		// replace old.module/path => new.module/path v1.2.3
+		// replace old.module/path/subpkg => ./local/path/subpkg (implicit if old.module/path is replaced)
+		//
+		// We need to check if importPath starts with r.OldPath, and if so,
+		// construct the new potential import path or local path.
+		if strings.HasPrefix(importPath, r.OldPath) {
+			remainingPath := strings.TrimPrefix(importPath, r.OldPath)
+			if remainingPath != "" && !strings.HasPrefix(remainingPath, "/") {
+				// This ensures we are matching a full path component, e.g. "old.mod/pkg" vs "old.modpkg"
+				continue
+			}
+			remainingPath = strings.TrimPrefix(remainingPath, "/")
+
+			if r.IsLocal {
+				// Local replacement: construct the full local path
+				// The r.NewPath is relative to l.rootDir
+				var localCandidatePath string
+				if filepath.IsAbs(r.NewPath) {
+					localCandidatePath = filepath.Join(r.NewPath, remainingPath)
+				} else {
+					localCandidatePath = filepath.Join(l.rootDir, r.NewPath, remainingPath)
+				}
+
+				absLocalCandidatePath, err := filepath.Abs(localCandidatePath)
+				if err != nil {
+					// Problematic path, skip
+					// fmt.Fprintf(os.Stderr, "warning: could not get absolute path for replaced local path %s: %v\n", localCandidatePath, err)
+					continue
+				}
+				// Temporary debug was here
+
+				stat, statErr := os.Stat(absLocalCandidatePath)
+				// Temporary debug was here
+
+				if statErr == nil && stat.IsDir() {
+					return absLocalCandidatePath, nil
+				}
+				// If local replacement doesn't exist, we might fall through or error.
+				// For now, if a replace rule matched, we prioritize its outcome.
+				// If it doesn't lead to a valid dir, this specific rule fails.
+				// We could opt to error here if the replace rule was specific and not found.
+				// Or, allow falling through to other rules or default resolution.
+				// Current Go behavior: if a replace directive applies, it's used. If the target is invalid, it's an error.
+				// So, if we found a matching replace, and it leads to a non-existent local path, we should probably error.
+				// However, to allow for multiple replace rules, we'll continue and error at the end if nothing is found.
+				// Let's refine this: if a specific replace rule (OldPath matches importPath exactly) fails, it's an error.
+				// If it's a prefix match (importPath is a sub-package), and the sub-package doesn't exist, that's also an error for this rule.
+				// The original plan was to only do one level. Let's stick to that for now.
+				// If a matching replace directive is found and the local path is invalid, we error out for this path.
+				// This means we don't fall back to other resolution methods if a specific replace was attempted.
+				// return "", fmt.Errorf("replaced import path %q (to local %s) could not be resolved: directory does not exist or is not a directory", importPath, absLocalCandidatePath)
+				// Let's allow falling through for now to see if other rules or the default mechanism works.
+				// This might need adjustment based on expected go tool behavior.
+				// For now, if a local replacement points to a non-existent dir, we just continue to the next rule or default logic.
+			} else {
+				// Module-to-module replacement: construct the new import path
+				newImportPath := r.NewPath
+				if remainingPath != "" {
+					newImportPath = r.NewPath + "/" + remainingPath
+				}
+
+				// Here, we need to resolve this newImportPath.
+				// This could be complex if it's outside the current module context,
+				// or if it itself is subject to another replace.
+				// For simplicity, let's assume this newImportPath should be resolvable
+				// within the standard GOPATH/GOROOT or relative to the current module if it matches modulePath.
+				// This part is tricky because `FindPackageDir` is designed for the current module context.
+				// A replaced module path might point to something outside the current module's structure.
+				// The `go list -m -json <pkg>` command would be more robust for this.
+				// However, we are trying to implement this within go-scan's locator.
+
+				// If the new import path matches the current module path, resolve it locally.
+				if strings.HasPrefix(newImportPath, l.modulePath) {
+					relPath := strings.TrimPrefix(newImportPath, l.modulePath)
+					candidatePath := filepath.Join(l.rootDir, relPath)
+					if stat, err := os.Stat(candidatePath); err == nil && stat.IsDir() {
+						return candidatePath, nil
+					}
+				}
+				// TODO: How to handle replaced paths that are *not* part of the current module?
+				// This would typically involve looking into GOPATH/pkg/mod or GOROOT.
+				// For now, if a module replace points outside, and it's not the main module,
+				// this basic locator might not find it.
+				// We can log a warning or acknowledge this limitation.
+				// fmt.Fprintf(os.Stderr, "warning: replaced import path %s (from %s) is outside current module scope and may not be found by this locator\n", newImportPath, importPath)
+
+				// For now, we will attempt to resolve it as if it were a top-level import,
+				// which means it must match the current modulePath if it's to be found by *this* Locator instance.
+				// This is a simplification. A full resolver would check GOPATH/GOROOT.
+				// If we simply call l.FindPackageDir(newImportPath) recursively, we risk infinite loops if not careful.
+				// Let's try a direct resolution attempt based on the newImportPath relative to modulePath.
+				// This is what the original logic below does.
+				// Fall through to the original logic, but with newImportPath.
+				// This is still not quite right for external modules.
+				// The current structure of Locator is tied to a single module.
+				//
+				// Let's simplify: if it's a module-to-module replace, and the new module path
+				// is the *same* as our current module path, then we resolve it.
+				// Otherwise, we state it's outside our current capability.
+				if strings.HasPrefix(newImportPath, l.modulePath) {
+					relPath := strings.TrimPrefix(newImportPath, l.modulePath)
+					candidatePath := filepath.Join(l.rootDir, relPath)
+					if stat, err := os.Stat(candidatePath); err == nil && stat.IsDir() {
+						return candidatePath, nil
+					}
+				} else {
+					// If the replaced path points to a different module, this simple locator cannot find it
+					// unless that different module's path is passed to a *new* Locator instance for that module.
+					// For the current request, we can't resolve it if it's truly external.
+					// We will let it fall through, and it will likely fail unless another rule matches,
+					// or the original importPath itself matches the current module (which it wouldn't if a replace rule was hit).
+					// This implies that module-to-module replaces that point to *other* modules are not fully supported by this iteration.
+				}
+			}
+		}
+	}
+
+	// 2. Try with the current module context first (original logic)
 	if strings.HasPrefix(importPath, l.modulePath) {
 		relPath := strings.TrimPrefix(importPath, l.modulePath)
 		candidatePath := filepath.Join(l.rootDir, relPath)
@@ -60,6 +203,7 @@ func (l *Locator) FindPackageDir(importPath string) (string, error) {
 		}
 	}
 
+	// If no replace directive matched and led to a path, and the original logic failed, then error.
 	return "", fmt.Errorf("import path %q could not be resolved. Current module is %q (root: %s)", importPath, l.modulePath, l.rootDir)
 }
 
@@ -104,4 +248,139 @@ func getModulePath(goModPath string) (string, error) {
 	}
 
 	return "", fmt.Errorf("module path not found in %s", goModPath)
+}
+
+// getReplaceDirectives reads replace directives from a go.mod file.
+func getReplaceDirectives(goModPath string) ([]ReplaceDirective, error) {
+	file, err := os.Open(goModPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not open %s: %w", goModPath, err)
+	}
+	defer file.Close()
+
+	var directives []ReplaceDirective
+	scanner := bufio.NewScanner(file)
+	inReplaceBlock := false
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if strings.HasPrefix(line, "//") { // Skip comments
+			continue
+		}
+
+		if line == "" { // Skip empty lines
+			continue
+		}
+
+		if strings.HasPrefix(line, "replace") {
+			if strings.Contains(line, "(") {
+				inReplaceBlock = true
+				line = strings.TrimSpace(strings.TrimPrefix(line, "replace"))
+				line = strings.TrimSpace(strings.TrimPrefix(line, "("))
+				// Process first line if it's not just "replace ("
+				if line != "" {
+					directive, err := parseReplaceLine(line)
+					if err != nil {
+						// TODO: Log or handle individual line parsing errors more gracefully
+						// For now, skip malformed lines.
+						fmt.Fprintf(os.Stderr, "warning: skipping malformed replace directive line: %q in %s: %v\n", line, goModPath, err)
+						continue
+					}
+					directives = append(directives, directive)
+				}
+				continue
+			} else {
+				// Single line replace
+				contentParts := strings.Fields(line) // line is "replace old [v] => new [v]"
+				if len(contentParts) < 1 {           // Should not happen if HasPrefix("replace") is true and line is trimmed
+					continue
+				}
+				directiveLine := strings.Join(contentParts[1:], " ") // "old [v] => new [v]"
+
+				// parseReplaceLine will check for "=>"
+				directive, err := parseReplaceLine(directiveLine)
+				if err != nil {
+					// Log the original line for better context if parsing fails
+					fmt.Fprintf(os.Stderr, "warning: skipping malformed single-line replace directive content: %q (from line: %q) in %s: %v\n", directiveLine, line, goModPath, err)
+					continue
+				}
+				directives = append(directives, directive)
+				// No need for 'continue' here as it's the end of the 'if strings.HasPrefix(line, "replace")' block's else path
+			}
+		} else if inReplaceBlock { // Ensure this is 'else if' or structure appropriately
+			if line == ")" {
+				inReplaceBlock = false
+				continue
+			}
+			directive, err := parseReplaceLine(line)
+			if err != nil {
+				// fmt.Fprintf(os.Stderr, "warning: skipping malformed replace directive line: %q in %s: %v\n", line, goModPath, err)
+				continue
+			}
+			directives = append(directives, directive)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading %s: %w", goModPath, err)
+	}
+
+	return directives, nil
+}
+
+// parseReplaceLine parses a single line of a replace directive.
+// Example inputs:
+// "old.module/path => new.module/path v1.2.3"
+// "old.module/path v0.0.0 => new.module/path v1.2.3"
+// "old.module/path => ./local/path"
+// "old.module/path v1.0.0 => ./local/path"
+func parseReplaceLine(line string) (ReplaceDirective, error) {
+	parts := strings.Fields(line)
+	arrowIndex := -1
+	for i, p := range parts {
+		if p == "=>" {
+			arrowIndex = i
+			break
+		}
+	}
+
+	if arrowIndex == -1 || arrowIndex == 0 || arrowIndex == len(parts)-1 {
+		return ReplaceDirective{}, fmt.Errorf("malformed replace directive line: %q (missing or misplaced '=>')", line)
+	}
+
+	var dir ReplaceDirective
+	oldParts := parts[:arrowIndex]
+	newParts := parts[arrowIndex+1:]
+
+	dir.OldPath = oldParts[0]
+	if len(oldParts) > 1 {
+		dir.OldVersion = oldParts[1]
+	}
+
+	newPathOrModule := newParts[0]
+	if strings.HasPrefix(newPathOrModule, "./") || strings.HasPrefix(newPathOrModule, "../") || filepath.IsAbs(newPathOrModule) {
+		dir.IsLocal = true
+		dir.NewPath = newPathOrModule
+		if len(newParts) > 1 {
+			// This case should ideally not happen for local paths as per go.mod spec,
+			// but we'll capture it if present.
+			// The go command itself might error on such go.mod.
+			return ReplaceDirective{}, fmt.Errorf("local replacement path %q should not have a version: %q", dir.NewPath, line)
+		}
+	} else {
+		dir.IsLocal = false
+		dir.NewPath = newPathOrModule
+		if len(newParts) > 1 {
+			dir.NewVersion = newParts[1]
+		} else {
+			// If it's not local and no version is specified, it's an error according to go.mod replace spec
+			// unless it's a wildcard replacement (oldpath => newpath vX.Y.Z),
+			// but our parsing targets specific versions or local paths.
+			// For "oldmodule => newmodule", a version is required for newmodule.
+			return ReplaceDirective{}, fmt.Errorf("non-local replacement path %q requires a version: %q", dir.NewPath, line)
+		}
+	}
+
+	return dir, nil
 }

--- a/locator/locator_test.go
+++ b/locator/locator_test.go
@@ -3,87 +3,354 @@ package locator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
-func setupTestModule(t *testing.T, modulePath string) (string, func()) {
+// setupTestModuleWithContent creates a temporary module structure for testing.
+// It writes the given goModContent to a go.mod file in the root of the temporary module.
+// It also creates any specified subdirectories within the module.
+// Returns the root directory of the module, a path to start lookup from (a sub-directory or root), and a cleanup function.
+func setupTestModuleWithContent(t *testing.T, goModContent string, subDirsToCreate []string) (string, string, func()) {
 	t.Helper()
 	rootDir, err := os.MkdirTemp("", "locator-test-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 
-	goModContent := "module " + modulePath
 	goModPath := filepath.Join(rootDir, "go.mod")
 	if err := os.WriteFile(goModPath, []byte(goModContent), 0644); err != nil {
+		os.RemoveAll(rootDir) // cleanup before fatal
 		t.Fatalf("Failed to write go.mod: %v", err)
 	}
 
-	// Create a subdirectory to test lookup from a nested path
-	subDir := filepath.Join(rootDir, "internal", "api")
-	if err := os.MkdirAll(subDir, 0755); err != nil {
-		t.Fatalf("Failed to create sub dir: %v", err)
+	for _, p := range subDirsToCreate {
+		fullPath := filepath.Join(rootDir, p)
+		if err := os.MkdirAll(fullPath, 0755); err != nil {
+			os.RemoveAll(rootDir) // cleanup before fatal
+			t.Fatalf("Failed to create sub dir %s: %v", fullPath, err)
+		}
 	}
 
-	return subDir, func() {
+	var startLookupPath string
+	if len(subDirsToCreate) > 0 {
+		// Use the first created subdirectory for lookup tests, good for testing upward search for go.mod
+		startLookupPath = filepath.Join(rootDir, subDirsToCreate[0])
+	} else {
+		startLookupPath = rootDir
+	}
+
+	return rootDir, startLookupPath, func() {
 		os.RemoveAll(rootDir)
 	}
 }
 
+// setupTestModule is a simplified version for compatibility with old tests.
+func setupTestModule(t *testing.T, modulePath string) (string, func()) {
+	t.Helper()
+	// This setup implies "internal/api" is created and used as the start path for New()
+	_, startPath, cleanup := setupTestModuleWithContent(t, "module "+modulePath, []string{filepath.Join("internal", "api")})
+	return startPath, cleanup // startPath is rootDir/internal/api
+}
+
 func TestNew(t *testing.T) {
-	modulePath := "example.com/myproject"
-	startPath, cleanup := setupTestModule(t, modulePath)
+	moduleName := "example.com/myproject"
+	// startLookupPath will be .../locator-test-XYZ/internal/api
+	startLookupPath, cleanup := setupTestModule(t, moduleName)
 	defer cleanup()
 
-	l, err := New(startPath)
+	l, err := New(startLookupPath)
 	if err != nil {
 		t.Fatalf("New() returned an error: %v", err)
 	}
 
-	expectedRootDir := filepath.Dir(filepath.Dir(startPath))
-	if l.RootDir() != expectedRootDir {
-		t.Errorf("Expected root dir %q, got %q", expectedRootDir, l.RootDir())
+	// Expected rootDir is where go.mod is, which is two levels above startLookupPath
+	expectedRootDir, _ := filepath.Abs(filepath.Dir(filepath.Dir(startLookupPath)))
+	actualRootDir, _ := filepath.Abs(l.RootDir())
+
+	if actualRootDir != expectedRootDir {
+		t.Errorf("Expected root dir %q, got %q", expectedRootDir, actualRootDir)
 	}
 
-	if l.ModulePath() != modulePath {
-		t.Errorf("Expected module path %q, got %q", modulePath, l.ModulePath())
+	if l.ModulePath() != moduleName {
+		t.Errorf("Expected module path %q, got %q", moduleName, l.ModulePath())
 	}
 }
 
 func TestFindPackageDir(t *testing.T) {
-	modulePath := "example.com/myproject"
-	startPath, cleanup := setupTestModule(t, modulePath)
+	moduleName := "example.com/myproject"
+	// startLookupPath will be .../locator-test-XYZ/internal/api
+	startLookupPath, cleanup := setupTestModule(t, moduleName)
 	defer cleanup()
 
-	l, err := New(startPath)
+	// moduleActualRootDir is where go.mod is.
+	moduleActualRootDir := filepath.Dir(filepath.Dir(startLookupPath))
+
+	l, err := New(startLookupPath)
 	if err != nil {
 		t.Fatalf("New() returned an error: %v", err)
 	}
 
 	tests := []struct {
+		name        string
 		importPath  string
-		expectedRel string
+		expectedRel string // Relative to moduleActualRootDir
 		expectErr   bool
 	}{
-		{"example.com/myproject/internal/api", "internal/api", false},
-		{"example.com/myproject", "", false},
-		{"example.com/otherproject/api", "", true},
+		{"standard_subpackage", "example.com/myproject/internal/api", filepath.Join("internal", "api"), false},
+		{"standard_root", "example.com/myproject", "", false},
+		{"other_project", "example.com/otherproject/api", "", true}, // Cannot find other project
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.importPath, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			dir, err := l.FindPackageDir(tt.importPath)
 
 			if (err != nil) != tt.expectErr {
-				t.Fatalf("FindPackageDir() error = %v, expectErr %v", err, tt.expectErr)
+				t.Fatalf("FindPackageDir() error = %v, expectErr %v. Import path: %s", err, tt.expectErr, tt.importPath)
 			}
 
 			if !tt.expectErr {
-				expectedPath := filepath.Join(l.RootDir(), tt.expectedRel)
-				if dir != expectedPath {
-					t.Errorf("Expected path %q, got %q", expectedPath, dir)
+				expectedPath := filepath.Join(moduleActualRootDir, tt.expectedRel)
+				absExpected, _ := filepath.Abs(expectedPath)
+				absGot, _ := filepath.Abs(dir)
+				if absGot != absExpected {
+					t.Errorf("Expected path %q, got %q for import %q", absExpected, absGot, tt.importPath)
 				}
 			}
 		})
 	}
 }
+
+// TestFindPackageDirWithReplace tests the FindPackageDir method with various replace directives.
+func TestFindPackageDirWithReplace(t *testing.T) {
+	mainModulePath := "example.com/mainmodule"
+
+	// Create a master temporary directory for tests that might use absolute paths for replacement
+	masterTmpDir, err := os.MkdirTemp("", "locator-master-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create master temp dir: %v", err)
+	}
+	defer os.RemoveAll(masterTmpDir)
+
+	// Prepare an absolute path target for one of the tests
+	absReplaceDir := filepath.Join(masterTmpDir, "absreplacement", "another")
+	absReplaceSubPkgDir := filepath.Join(absReplaceDir, "pkg")
+	if err := os.MkdirAll(absReplaceSubPkgDir, 0755); err != nil {
+		t.Fatalf("Failed to create absolute replacement target dir %s: %v", absReplaceSubPkgDir, err)
+	}
+
+	testCases := []struct {
+		name              string
+		goModContent      string
+		subDirsToCreate   []string // Relative to module root for the primary module being set up
+		importPath        string
+		expectedFoundPath string // Expected absolute path, or relative to the setup module's root
+		expectErr         bool
+	}{
+		{
+			name: "replace_with_local_relative_path",
+			goModContent: `
+module example.com/mainmodule
+go 1.16
+replace example.com/replacedmodule => ./local/replacedmodule
+`,
+			subDirsToCreate:   []string{filepath.Join("local", "replacedmodule", "pkg")},
+			importPath:        "example.com/replacedmodule/pkg",
+			expectedFoundPath: filepath.Join("local", "replacedmodule", "pkg"), // Relative to module root
+			expectErr:         false,
+		},
+		{
+			name: "replace_with_local_path_root",
+			goModContent: `
+module example.com/mainmodule
+go 1.16
+replace example.com/replacedmodule => ./local/replacedmodule
+`,
+			subDirsToCreate:   []string{filepath.Join("local", "replacedmodule")},
+			importPath:        "example.com/replacedmodule",
+			expectedFoundPath: filepath.Join("local", "replacedmodule"),
+			expectErr:         false,
+		},
+		{
+			name: "replace_with_local_path_version_on_old",
+			goModContent: `
+module example.com/mainmodule
+go 1.16
+replace example.com/replacedmodule v1.0.0 => ./local/versionedreplacedmodule
+`,
+			subDirsToCreate:   []string{filepath.Join("local", "versionedreplacedmodule", "subpkg")},
+			importPath:        "example.com/replacedmodule/subpkg",
+			expectedFoundPath: filepath.Join("local", "versionedreplacedmodule", "subpkg"),
+			expectErr:         false,
+		},
+		{
+			name: "replace_with_local_absolute_path",
+			goModContent: `
+module example.com/mainmodule
+go 1.16
+replace example.com/another => ` + absReplaceDir + `
+`,
+			subDirsToCreate:   []string{}, // No subdirs needed in the main module for this
+			importPath:        "example.com/another/pkg",
+			expectedFoundPath: absReplaceSubPkgDir, // This is an absolute path
+			expectErr:         false,
+		},
+		{
+			name: "replace_module_with_another_module_path_within_same_project",
+			goModContent: `
+module example.com/mainmodule
+go 1.16
+replace example.com/oldinternal => example.com/mainmodule/newinternal v1.0.0
+`,
+			subDirsToCreate:   []string{filepath.Join("newinternal", "api")},
+			importPath:        "example.com/oldinternal/api",
+			expectedFoundPath: filepath.Join("newinternal", "api"), // Relative to module root
+			expectErr:         false,
+		},
+		{
+			name: "replace_target_local_path_does_not_exist",
+			goModContent: `
+module example.com/mainmodule
+go 1.16
+replace example.com/nonexistent => ./does/not/exist
+`,
+			subDirsToCreate:   []string{},
+			importPath:        "example.com/nonexistent/pkg",
+			expectedFoundPath: "",
+			// Current behavior: if a replace rule matches, but target is invalid, FindPackageDir continues
+			// and then fails at the end if no other rule or default logic finds the path.
+			// This might need to be stricter: if a replace rule applies, its target *must* be valid.
+			// For now, this will result in an error because ./does/not/exist/pkg won't be found.
+			expectErr: true,
+		},
+		{
+			name: "no_matching_replace_directive_falls_back_to_module_path",
+			goModContent: `
+module example.com/mainmodule
+go 1.16
+replace example.com/foo => ./bar
+`,
+			subDirsToCreate:   []string{"actualpkg"}, // Subdir of mainmodule
+			importPath:        "example.com/mainmodule/actualpkg",
+			expectedFoundPath: "actualpkg", // Relative to module root
+			expectErr:         false,
+		},
+		{
+			name: "replace_in_block_form_finds_alpha",
+			goModContent: `
+module example.com/mainmodule
+go 1.16
+replace (
+	example.com/alpha => ./local/alpha
+	example.com/beta v1.0.0 => ./local/betaversioned
+)
+`,
+			subDirsToCreate:   []string{filepath.Join("local", "alpha"), filepath.Join("local", "betaversioned", "sub")},
+			importPath:        "example.com/alpha",
+			expectedFoundPath: filepath.Join("local", "alpha"),
+			expectErr:         false,
+		},
+		{
+			name: "replace_in_block_form_finds_beta_subpackage",
+			goModContent: `
+module example.com/mainmodule
+go 1.16
+replace (
+	example.com/alpha => ./local/alpha
+	example.com/beta v1.0.0 => ./local/betaversioned
+)
+`,
+			subDirsToCreate:   []string{filepath.Join("local", "alpha"), filepath.Join("local", "betaversioned", "sub")},
+			importPath:        "example.com/beta/sub",
+			expectedFoundPath: filepath.Join("local", "betaversioned", "sub"),
+			expectErr:         false,
+		},
+		{
+			name: "replace_to_external_module_not_in_current_locator_scope_fails_gracefully",
+			goModContent: `
+module example.com/mainmodule
+go 1.16
+replace example.com/currenttomodule => example.com/someothermodule v1.0.0
+`,
+			subDirsToCreate:   []string{},
+			importPath:        "example.com/currenttomodule/pkg",
+			expectedFoundPath: "",
+			expectErr:         true, // Because someothermodule is not mainmodule and locator is scoped
+		},
+		{
+			name: "replace_old_path_is_prefix_of_import_path",
+			goModContent: `
+module example.com/mainmodule
+go 1.16
+replace example.com/prefixmod => ./local/prefixmod
+`,
+			subDirsToCreate:   []string{filepath.Join("local", "prefixmod", "sub", "pkg")},
+			importPath:        "example.com/prefixmod/sub/pkg",
+			expectedFoundPath: filepath.Join("local", "prefixmod", "sub", "pkg"),
+			expectErr:         false,
+		},
+		{
+			name: "replace_old_path_is_prefix_of_import_path_targetting_root_of_replacement",
+			goModContent: `
+module example.com/mainmodule
+go 1.16
+replace example.com/prefixmod => ./local/prefixmod
+`,
+			subDirsToCreate:   []string{filepath.Join("local", "prefixmod")}, // only root of replacement exists
+			importPath:        "example.com/prefixmod",
+			expectedFoundPath: filepath.Join("local", "prefixmod"),
+			expectErr:         false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			// Ensure module path in goModContent is consistent for tests assuming mainModulePath
+			var currentGoModContent string
+			if strings.HasPrefix(strings.TrimSpace(tt.goModContent), "module ") {
+				currentGoModContent = tt.goModContent
+			} else {
+				currentGoModContent = "module " + mainModulePath + "\n" + tt.goModContent
+			}
+
+			moduleRootDir, startLookupPath, cleanup := setupTestModuleWithContent(t, currentGoModContent, tt.subDirsToCreate)
+			defer cleanup()
+
+			l, err := New(startLookupPath)
+			if err != nil {
+				// This might indicate an issue with go.mod parsing in New() if the go.mod was intended to be valid.
+				t.Fatalf("Test %q: New() returned an error: %v. go.mod content:\n%s", tt.name, err, currentGoModContent)
+			}
+
+			dir, err := l.FindPackageDir(tt.importPath)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("Test %q: FindPackageDir() error = %v, expectErr %v. Import path: %s", tt.name, err, tt.expectErr, tt.importPath)
+			}
+
+			if !tt.expectErr && err == nil { // Only check path if no error was expected and no error occurred
+				var expectedPathAbs string
+				if filepath.IsAbs(tt.expectedFoundPath) {
+					expectedPathAbs = tt.expectedFoundPath
+				} else {
+					expectedPathAbs = filepath.Join(moduleRootDir, tt.expectedFoundPath)
+				}
+				// Normalize paths for comparison
+				absExpected, _ := filepath.Abs(expectedPathAbs)
+				absGot, _ := filepath.Abs(dir)
+
+				if absGot != absExpected {
+					t.Errorf("Test %q: For import %q, expected path %q, got %q", tt.name, tt.importPath, absExpected, absGot)
+				}
+			} else if !tt.expectErr && err != nil {
+				t.Errorf("Test %q: For import %q, expected success, but got error: %v", tt.name, tt.importPath, err)
+			} else if tt.expectErr && err == nil {
+				t.Errorf("Test %q: For import %q, expected error, but got path: %s", tt.name, tt.importPath, dir)
+			}
+		})
+	}
+}
+
+// TODO: Add tests for getReplaceDirectives specifically if complex parsing logic needs unit testing.
+// For now, its behavior is indirectly tested via TestFindPackageDirWithReplace.


### PR DESCRIPTION
This commit enhances the locator to understand and apply `go.mod` replace directives when finding package directories.

Key changes:
- Added `ReplaceDirective` struct and parsing logic (`getReplaceDirectives`, `parseReplaceLine`) to read replace rules from `go.mod`.
- Modified `Locator.FindPackageDir` to consider these replace directives.
  - Supports local filesystem path replacements (relative and absolute).
  - Supports module-to-module path replacements if the target is within the same main module's scope.
- Added comprehensive test cases for various `replace` directive scenarios in `locator_test.go`.
- Fixed a bug in parsing single-line `replace` directives that include an old version.