### PR TITLE
feat: Add generics support to go-scan

### DIFF
--- a/examples/minigo/interpreter.go
+++ b/examples/minigo/interpreter.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
+
 	// "go/parser" // Will be replaced by go-scan
 	"go/token"
 	"os"
@@ -13,7 +14,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/podhmo/go-scan" // Using top-level go-scan
+	goscan "github.com/podhmo/go-scan"  // Using top-level go-scan
 	"github.com/podhmo/go-scan/scanner" // No longer directly needed for minigo's use of ConstantInfo
 )
 
@@ -95,7 +96,7 @@ type Interpreter struct {
 	// This helps in resolving relative imports if go.mod is not present or
 	// for files not part of a clear module structure.
 	currentFileDir string
-	sharedScanner    *goscan.Scanner // Renamed from scn, used for resolving imports. Can be pre-configured for tests.
+	sharedScanner  *goscan.Scanner // Renamed from scn, used for resolving imports. Can be pre-configured for tests.
 	ModuleRoot     string          // Optional: Explicitly set module root directory for scanner initialization.
 }
 
@@ -257,12 +258,12 @@ func (i *Interpreter) LoadAndRun(ctx context.Context, filename string, entryPoin
 	// Get the entry function *object* from the global environment
 	entryFuncObj, ok := i.globalEnv.Get(entryPoint)
 	if !ok {
-	    return formatErrorWithContext(i.FileSet, token.NoPos, fmt.Errorf("entry point function '%s' not found in global environment", entryPoint), "Setup error")
+		return formatErrorWithContext(i.FileSet, token.NoPos, fmt.Errorf("entry point function '%s' not found in global environment", entryPoint), "Setup error")
 	}
 
 	userEntryFunc, ok := entryFuncObj.(*UserDefinedFunction)
 	if !ok {
-	    return formatErrorWithContext(i.FileSet, token.NoPos, fmt.Errorf("entry point '%s' is not a user-defined function (type: %s)", entryPoint, entryFuncObj.Type()), "Setup error")
+		return formatErrorWithContext(i.FileSet, token.NoPos, fmt.Errorf("entry point '%s' is not a user-defined function (type: %s)", entryPoint, entryFuncObj.Type()), "Setup error")
 	}
 
 	fmt.Printf("Executing entry point function: %s\n", entryPoint)
@@ -282,7 +283,6 @@ func (i *Interpreter) LoadAndRun(ctx context.Context, filename string, entryPoin
 	}
 	return nil
 }
-
 
 func (i *Interpreter) applyUserDefinedFunction(ctx context.Context, fn *UserDefinedFunction, args []Object, callPos token.Pos) (Object, error) {
 	// Use the FileSet associated with the function for error reporting within its context.
@@ -630,7 +630,7 @@ func (i *Interpreter) evalSelectorExpr(ctx context.Context, node *ast.SelectorEx
 					Name:       fInfo.Name, // Use the original function name
 					Parameters: params,
 					Body:       fInfo.AstDecl.Body,
-					Env:        env, // Or perhaps a new env derived from global? For simplicity, use current env.
+					Env:        env,                    // Or perhaps a new env derived from global? For simplicity, use current env.
 					FileSet:    i.sharedScanner.Fset(), // Use the scanner's fset for this imported function
 				}
 				env.Define(localPkgName+"."+fInfo.Name, importedFunc)

--- a/examples/minigo/interpreter_test.go
+++ b/examples/minigo/interpreter_test.go
@@ -3,12 +3,13 @@ package main
 import (
 	"context"
 	"os"
+
 	// "path/filepath" // For joining paths - No longer needed due to hardcoded paths
 	// "runtime"       // For runtime.Caller - No longer needed
 	"strings"
 	"testing"
 
-	"github.com/podhmo/go-scan" // For goscan.New
+	goscan "github.com/podhmo/go-scan" // For goscan.New
 )
 
 // Helper function to create a temporary Go source file for testing within a specific base directory.
@@ -282,6 +283,7 @@ func main() {
 		})
 	}
 }
+
 // Note: Other test functions (TestFormattedErrorHandling, etc.) were here.
 // For brevity in this step, they are omitted but would need similar scanner
 // setup if they rely on go.mod discovery through goscan.New().

--- a/examples/minigo/main.go
+++ b/examples/minigo/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+
 	// "github.com/podhmo/go-scan/scanner" // Will be used later
 
 	"github.com/podhmo/go-scan/examples/minigo/stringutils"

--- a/examples/minigo/object.go
+++ b/examples/minigo/object.go
@@ -12,16 +12,16 @@ type ObjectType string
 
 // Define all possible object types our interpreter will handle.
 const (
-	STRING_OBJ       ObjectType = "STRING"
-	INTEGER_OBJ      ObjectType = "INTEGER"      // Example for future use
-	BOOLEAN_OBJ      ObjectType = "BOOLEAN"      // Example for future use
-	NULL_OBJ         ObjectType = "NULL"         // Example for future use
-	RETURN_VALUE_OBJ ObjectType = "RETURN_VALUE" // Special type to wrap return values
-	ERROR_OBJ        ObjectType = "ERROR"        // To wrap errors as objects
-	FUNCTION_OBJ     ObjectType = "FUNCTION"     // For user-defined functions
+	STRING_OBJ           ObjectType = "STRING"
+	INTEGER_OBJ          ObjectType = "INTEGER"          // Example for future use
+	BOOLEAN_OBJ          ObjectType = "BOOLEAN"          // Example for future use
+	NULL_OBJ             ObjectType = "NULL"             // Example for future use
+	RETURN_VALUE_OBJ     ObjectType = "RETURN_VALUE"     // Special type to wrap return values
+	ERROR_OBJ            ObjectType = "ERROR"            // To wrap errors as objects
+	FUNCTION_OBJ         ObjectType = "FUNCTION"         // For user-defined functions
 	BUILTIN_FUNCTION_OBJ ObjectType = "BUILTIN_FUNCTION" // For built-in functions
-	BREAK_OBJ        ObjectType = "BREAK"        // For break statements
-	CONTINUE_OBJ     ObjectType = "CONTINUE"      // For continue statements
+	BREAK_OBJ            ObjectType = "BREAK"            // For break statements
+	CONTINUE_OBJ         ObjectType = "CONTINUE"         // For continue statements
 )
 
 // Object is the interface that all value types in our interpreter will implement.
@@ -60,7 +60,7 @@ func (b *Boolean) Inspect() string  { return fmt.Sprintf("%t", b.Value) }
 var (
 	TRUE     = &Boolean{Value: true}
 	FALSE    = &Boolean{Value: false}
-	NULL     = &Null{}               // Global instance for Null
+	NULL     = &Null{}              // Global instance for Null
 	BREAK    = &BreakStatement{}    // Singleton instance for Break
 	CONTINUE = &ContinueStatement{} // Singleton instance for Continue
 )
@@ -99,7 +99,6 @@ type Error struct {
 func (e *Error) Type() ObjectType { return ERROR_OBJ }
 func (e *Error) Inspect() string  { return "ERROR: " + e.Message }
 func (e *Error) Error() string    { return e.Message } // Implement error interface
-
 
 // --- Comparability ---
 // Some objects can be compared. This interface can be implemented by types
@@ -143,7 +142,7 @@ type UserDefinedFunction struct {
 	Name       string // Optional: for debugging and representation
 	Parameters []*ast.Ident
 	Body       *ast.BlockStmt
-	Env        *Environment // Closure: the environment where the function was defined
+	Env        *Environment   // Closure: the environment where the function was defined
 	FileSet    *token.FileSet // FileSet for error reporting context
 }
 
@@ -174,7 +173,6 @@ func (rv *ReturnValue) Inspect() string {
 	}
 	return rv.Value.Inspect() // Or fmt.Sprintf("return %s", rv.Value.Inspect())
 }
-
 
 // --- BuiltinFunction Object ---
 

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -66,7 +66,7 @@ func (s *Scanner) ScanPackage(ctx context.Context, dirPath string, resolver Pack
 
 // ScanFiles parses a specific list of .go files and returns PackageInfo.
 // pkgDirPath is the absolute directory path for this package, used for PackageInfo.Path.
-func (s *Scanner) ScanFiles(ctx context.Context, filePaths []string, pkgDirPath string, resolver PackageResolver) (*PackageInfo, error) {
+func (s *Scanner) ScanFiles(ctx context.Context, filePaths []string, pkgDirPath string, resolver PackageResolver) (*PackageInfo, error) { // Added ctx to parseFuncDecl call
 	s.resolver = resolver // Ensure resolver is set for this scanning operation.
 
 	if len(filePaths) == 0 {
@@ -109,7 +109,7 @@ func (s *Scanner) ScanFiles(ctx context.Context, filePaths []string, pkgDirPath 
 				s.parseGenDecl(ctx, d, info, filePath) // Pass context
 			case *ast.FuncDecl:
 				slog.DebugContext(ctx, "Processing FuncDecl", slog.String("name", d.Name.Name), slog.String("filePath", filePath))
-				info.Functions = append(info.Functions, s.parseFuncDecl(d, filePath))
+				info.Functions = append(info.Functions, s.parseFuncDecl(ctx, d, filePath, info)) // Pass ctx and pkgInfo
 			}
 		}
 	}
@@ -186,7 +186,7 @@ func (s *Scanner) parseGenDecl(ctx context.Context, decl *ast.GenDecl, info *Pac
 
 					var finalFieldType *FieldType
 					if sp.Type != nil { // Explicit type is present
-						finalFieldType = s.parseTypeExpr(sp.Type)
+						finalFieldType = s.parseTypeExpr(ctx, sp.Type, nil) // Pass ctx and nil for currentTypeParams
 					} else { // No explicit type, use inferred type
 						finalFieldType = inferredFieldType
 					}
@@ -214,25 +214,79 @@ func (s *Scanner) parseTypeSpec(ctx context.Context, sp *ast.TypeSpec, absFilePa
 		Doc:      commentText(sp.Doc),
 		Node:     sp,
 	}
+
+	// Parse type parameters if they exist (Go 1.18+)
+	if sp.TypeParams != nil {
+		typeInfo.TypeParams = s.parseTypeParamList(ctx, sp.TypeParams.List)
+	}
+
 	switch t := sp.Type.(type) {
 	case *ast.StructType:
 		typeInfo.Kind = StructKind
-		typeInfo.Struct = s.parseStructType(t) // parseStructType does not log with context yet
-	case *ast.InterfaceType: // Added case for interface types
+		typeInfo.Struct = s.parseStructType(ctx, t, typeInfo.TypeParams) // Pass ctx and type params for context
+	case *ast.InterfaceType:
 		typeInfo.Kind = InterfaceKind
-		typeInfo.Interface = s.parseInterfaceType(ctx, t)
+		// Interfaces themselves cannot have type parameters in the same way structs/funcs do,
+		// but their methods might involve types that are generic or type parameters from an outer scope.
+		// However, sp.TypeParams would be for the interface itself if it were allowed.
+		// For now, we assume interface definitions don't have sp.TypeParams in a way that affects `s.parseInterfaceType` directly for the interface's own params.
+		typeInfo.Interface = s.parseInterfaceType(ctx, t, typeInfo.TypeParams) // Pass type params for context
 	case *ast.FuncType:
 		typeInfo.Kind = FuncKind
-		typeInfo.Func = s.parseFuncType(t) // parseFuncType does not log with context
+		// A type alias to a func type, e.g. "type MyFunc[T any] func(T) T"
+		// The type parameters for `MyFunc` are on `sp.TypeParams`.
+		// The parameters/results of the func type `t` might use these type parameters.
+		typeInfo.Func = s.parseFuncType(ctx, t, typeInfo.TypeParams) // Pass ctx and type params for context
+		// Note: If `typeInfo.Func.TypeParams` is to be filled, it should come from `sp.TypeParams`.
+		// `parseFuncType` might need to be adjusted or this assignment handled differently.
+		// For a type alias `type MyFunc[T any] = func(p T) T`, `sp.TypeParams` defines `[T any]`.
+		// `t` is `func(p T) T`. `parseFuncType` needs to know about `T` from `sp.TypeParams`.
+		// Let's ensure `parseFuncType` correctly uses the passed `currentTypeParams`.
+		// If `typeInfo.Func` is to have its own `TypeParams` field mirroring `typeInfo.TypeParams`,
+		// this needs explicit assignment or `parseFuncType` needs to set it based on context.
+		// For now, `typeInfo.TypeParams` holds the params for the TypeSpec.
 	default:
 		typeInfo.Kind = AliasKind
-		typeInfo.Underlying = s.parseTypeExpr(sp.Type) // sp.Type is correct here for alias
+		// For aliases like `type MySlice[T any] []T`, `sp.TypeParams` holds `[T any]`.
+		// `sp.Type` (the RHS) is `[]T`. `parseTypeExpr` needs to know about `T`.
+		typeInfo.Underlying = s.parseTypeExpr(ctx, sp.Type, typeInfo.TypeParams) // Pass ctx and type params
 	}
 	return typeInfo
 }
 
+// parseTypeParamList parses a list of ast.Field representing type parameters.
+func (s *Scanner) parseTypeParamList(ctx context.Context, typeParamFields []*ast.Field) []*TypeParamInfo {
+	var params []*TypeParamInfo
+	if typeParamFields == nil {
+		return nil
+	}
+	for _, typeParamField := range typeParamFields { // Each ast.Field in TypeParams.List
+		constraintExpr := typeParamField.Type
+		var constraintFieldType *FieldType
+		if constraintExpr != nil {
+			// When parsing constraints, these type parameters are not yet in scope for themselves.
+			// Pass nil or an empty list for currentTypeParams for now.
+			// Outer scope type parameters could be relevant if nested generics were common,
+			// but for typical Go usage, nil is safe here.
+			constraintFieldType = s.parseTypeExpr(ctx, constraintExpr, nil) // Pass ctx, No currentTypeParams for the constraint itself
+			if constraintFieldType != nil {
+				constraintFieldType.IsConstraint = true
+			}
+		}
+		// typeParamField.Names contains the actual type parameter names (e.g., T, K, V)
+		for _, nameIdent := range typeParamField.Names {
+			params = append(params, &TypeParamInfo{
+				Name:       nameIdent.Name,
+				Constraint: constraintFieldType,
+			})
+		}
+	}
+	return params
+}
+
 // parseInterfaceType parses an interface type.
-func (s *Scanner) parseInterfaceType(ctx context.Context, it *ast.InterfaceType) *InterfaceInfo {
+// It now accepts currentTypeParams for resolving type parameter references in method signatures.
+func (s *Scanner) parseInterfaceType(ctx context.Context, it *ast.InterfaceType, currentTypeParams []*TypeParamInfo) *InterfaceInfo {
 	if it.Methods == nil || len(it.Methods.List) == 0 {
 		return &InterfaceInfo{Methods: []*MethodInfo{}} // Empty interface
 	}
@@ -240,52 +294,58 @@ func (s *Scanner) parseInterfaceType(ctx context.Context, it *ast.InterfaceType)
 		Methods: make([]*MethodInfo, 0, len(it.Methods.List)),
 	}
 	for _, field := range it.Methods.List {
-		// Interface methods can be:
-		// 1. Method signature: Name + Type (which is *ast.FuncType)
-		// 2. Embedded interface: Type (which is an *ast.Ident or *ast.SelectorExpr referring to another interface)
 		if len(field.Names) > 0 { // Method signature
 			methodName := field.Names[0].Name
 			funcType, ok := field.Type.(*ast.FuncType)
 			if !ok {
-				// This case should ideally not happen for a valid Go interface method.
-				// Skip or log an error if it does.
 				slog.WarnContext(ctx, "Expected FuncType for interface method, skipping", slog.String("method_name", methodName), slog.String("got_type", fmt.Sprintf("%T", field.Type)))
 				continue
 			}
 			methodInfo := &MethodInfo{
 				Name: methodName,
+				// The `currentTypeParams` for `parseFuncType` here should be those of the *interface's* scope,
+				// if interfaces could be generic themselves in this way.
+				// Since they can't, `currentTypeParams` refers to an outer scope (e.g. a generic type embedding this interface def).
+				// Or, if this interface is a constraint in a generic func/type, `currentTypeParams` are from that func/type.
+				// For `type Stringer[T any] interface { String(T) string }`, `T` is from `Stringer`.
+				// Go doesn't support this directly on interface decls, but this structure allows it if AST did.
+				// What `parseFuncType` returns is a `FunctionInfo`, we need to extract params/results.
+				// Let's make a helper or inline parsing of params/results.
 			}
-			if funcType.Params != nil {
-				methodInfo.Parameters = s.parseFieldList(funcType.Params.List)
-			}
-			if funcType.Results != nil {
-				methodInfo.Results = s.parseFieldList(funcType.Results.List)
-			}
+			parsedFuncDetails := s.parseFuncType(ctx, funcType, currentTypeParams) // Pass ctx and currentTypeParams
+			methodInfo.Parameters = parsedFuncDetails.Parameters
+			methodInfo.Results = parsedFuncDetails.Results
+
 			interfaceInfo.Methods = append(interfaceInfo.Methods, methodInfo)
 		} else {
-			// Embedded interface: field.Type is the name of the embedded interface
-			// We need to resolve this type to get its methods and add them to the current interface.
-			// This requires the resolver and potentially looking up the type.
-			// For now, we will store the name of the embedded interface.
-			// A more complete implementation would recursively resolve and inline methods.
-			embeddedTypeName := s.parseTypeExpr(field.Type)
-			// TODO: Handle embedded interfaces by resolving and merging their methods.
-			// For now, we can represent it as a special kind of "method" or skip.
-			// Let's skip direct handling of embedded interfaces for now to simplify,
-			// as `goscan.Implements` will need to handle this when comparing.
-			// Or, we can add a placeholder if needed for `Implements` to recognize it.
-			// For `derivingjson`, direct method signatures are the primary concern.
-			slog.InfoContext(ctx, "Embedded interface found, its methods are not recursively parsed in this version.", slog.String("interface_name", embeddedTypeName.Name))
+			// Embedded interface or type constraint element
+			// e.g. `interface { MyInterface; ~int; comparable }`
+			// field.Type is the expression (Ident, SelectorExpr for MyInterface; BinaryExpr for ~int)
+			embeddedType := s.parseTypeExpr(ctx, field.Type, currentTypeParams) // Pass ctx and currentTypeParams
+			// TODO: Handle embedded interfaces/constraints more explicitly if needed.
+			// For now, we represent it as a "method" with this type.
+			// This might need a dedicated field in InterfaceInfo or MethodInfo.
+			// For `derivingjson`, we primarily care about actual methods.
+			// If it's a constraint element like `~int` or `comparable`, `embeddedType.IsConstraint` should be true.
+			// We can add it as a special "method" or to a new list of "ConstraintElements".
+			// Let's create a placeholder method for now.
+			interfaceInfo.Methods = append(interfaceInfo.Methods, &MethodInfo{
+				Name:       fmt.Sprintf("embedded_%s", embeddedType.String()), // Placeholder name
+				Parameters: nil,                                               // Not a real method signature in the same way
+				Results:    []*FieldInfo{{Type: embeddedType}},                // Store the type here
+			})
+			slog.InfoContext(ctx, "Embedded interface/constraint in interface definition", slog.String("type", embeddedType.String()))
 		}
 	}
 	return interfaceInfo
 }
 
 // parseStructType parses a struct type.
-func (s *Scanner) parseStructType(st *ast.StructType) *StructInfo {
+// It now accepts currentTypeParams for resolving type parameter references in field types.
+func (s *Scanner) parseStructType(ctx context.Context, st *ast.StructType, currentTypeParams []*TypeParamInfo) *StructInfo {
 	structInfo := &StructInfo{}
 	for _, field := range st.Fields.List {
-		fieldType := s.parseTypeExpr(field.Type)
+		fieldType := s.parseTypeExpr(ctx, field.Type, currentTypeParams) // Pass ctx and currentTypeParams
 		var tag string
 		if field.Tag != nil {
 			tag = strings.Trim(field.Tag.Value, "`")
@@ -317,99 +377,257 @@ func (s *Scanner) parseStructType(st *ast.StructType) *StructInfo {
 }
 
 // parseFuncDecl parses a function declaration.
-func (s *Scanner) parseFuncDecl(f *ast.FuncDecl, absFilePath string) *FunctionInfo {
-	funcInfo := s.parseFuncType(f.Type)
+func (s *Scanner) parseFuncDecl(ctx context.Context, f *ast.FuncDecl, absFilePath string, pkgInfo *PackageInfo) *FunctionInfo {
+	var funcOwnTypeParams []*TypeParamInfo // Renamed from currentTypeParams to avoid confusion
+	if f.Type.TypeParams != nil {
+		funcOwnTypeParams = s.parseTypeParamList(ctx, f.Type.TypeParams.List) // Pass ctx
+	}
+
+	// Initial parse of func type to get its basic structure (params, results)
+	// At this stage, for method parameters/results, type parameter context might be incomplete.
+	// We use funcOwnTypeParams here, which are type parameters of the function/method itself.
+	funcInfo := s.parseFuncType(ctx, f.Type, funcOwnTypeParams) // Use funcOwnTypeParams
+
 	funcInfo.Name = f.Name.Name
 	funcInfo.FilePath = absFilePath
 	funcInfo.Doc = commentText(f.Doc)
-	funcInfo.AstDecl = f // Populate the new field
-	if f.Recv != nil && len(f.Recv.List) > 0 {
+	funcInfo.AstDecl = f
+	funcInfo.TypeParams = funcOwnTypeParams // Assign parsed type parameters of the function itself
+
+	if f.Recv != nil && len(f.Recv.List) > 0 { // This is a method
 		recvField := f.Recv.List[0]
 		var recvName string
 		if len(recvField.Names) > 0 {
 			recvName = recvField.Names[0].Name
 		}
+
+		// Attempt to find the receiver's base type information in the current package
+		var receiverBaseTypeParams []*TypeParamInfo
+		// First, parse the receiver expression to get its name and any explicit type arguments
+		// Pass funcOwnTypeParams as current context, though receiver type args usually refer to struct's params.
+		// This initial parse helps identify the structure.
+		parsedRecvFieldType := s.parseTypeExpr(ctx, recvField.Type, funcOwnTypeParams)
+
+		if parsedRecvFieldType != nil {
+			baseRecvTypeName := parsedRecvFieldType.Name
+			if parsedRecvFieldType.IsPointer && parsedRecvFieldType.Elem != nil {
+				baseRecvTypeName = parsedRecvFieldType.Elem.Name
+			}
+			// Remove package qualifier if present, assuming methods are on types in the same package for now.
+			if parts := strings.Split(baseRecvTypeName, "."); len(parts) > 1 {
+				baseRecvTypeName = parts[len(parts)-1]
+			}
+
+			if pkgInfo != nil { // pkgInfo is passed to parseFuncDecl
+				for _, ti := range pkgInfo.Types {
+					if ti.Name == baseRecvTypeName {
+						receiverBaseTypeParams = ti.TypeParams // These are the TPs of the struct (e.g. T from List[T])
+						// Now, re-parse the receiver type with its own struct's type parameters as context
+						// so that T in *List[T] can be marked as IsTypeParam.
+						parsedRecvFieldType = s.parseTypeExpr(ctx, recvField.Type, receiverBaseTypeParams)
+						break
+					}
+				}
+			}
+		}
+
 		funcInfo.Receiver = &FieldInfo{
 			Name: recvName,
-			Type: s.parseTypeExpr(recvField.Type),
+			Type: parsedRecvFieldType, // Use the re-parsed (or initially parsed if not found) receiver field type
 		}
+
+		// For parameters and results of the method, the context includes:
+		// 1. Type parameters from the receiver's base type (struct).
+		// 2. Type parameters from the method itself.
+		methodScopeTypeParams := append([]*TypeParamInfo{}, receiverBaseTypeParams...)
+		methodScopeTypeParams = append(methodScopeTypeParams, funcOwnTypeParams...) // funcOwnTypeParams are from the method itself.
+
+		// Re-parse params and results with the correct combined scope
+		// The original f.Type (which is *ast.FuncType) is used.
+		reparsedFuncSignature := s.parseFuncType(ctx, f.Type, methodScopeTypeParams)
+		funcInfo.Parameters = reparsedFuncSignature.Parameters
+		funcInfo.Results = reparsedFuncSignature.Results
 	}
 	return funcInfo
 }
 
 // parseFuncType parses a function type (signature).
-func (s *Scanner) parseFuncType(ft *ast.FuncType) *FunctionInfo {
+// It now accepts ctx and currentTypeParams for resolving type parameter references in params/results.
+func (s *Scanner) parseFuncType(ctx context.Context, ft *ast.FuncType, currentTypeParams []*TypeParamInfo) *FunctionInfo {
 	funcInfo := &FunctionInfo{}
+	// Type parameters for a bare func type (e.g., in `type F = func[T any](p T) T`)
+	// are part of ft.TypeParams. These are distinct from type parameters of a wrapping TypeSpec or FuncDecl.
+	// If `currentTypeParams` is passed from a FuncDecl, those are the ones in scope for resolving
+	// types within this signature. If `ft.TypeParams` also exists (e.g. generic func type alias),
+	// then `ft.TypeParams` would define new params for *this specific func type's scope*.
+	// The plan is to modify `parseFuncType` to take `currentTypeParams` from the *outer* scope (FuncDecl/TypeSpec).
+	// If `ft` itself has `TypeParams` (e.g. `type F = func[X any](p X) X`), these should be parsed and
+	// *added* to `currentTypeParams` for the scope of `ft.Params` and `ft.Results`.
+	// For now, the provided `currentTypeParams` are from the FuncDecl or TypeSpec.
+
+	// If ft.TypeParams is not nil, it means this is a generic func type directly.
+	// Example: var myFunc func[T any](t T)
+	// These would be parsed here and become the `funcInfo.TypeParams`.
+	// However, the current plan implies `funcInfo.TypeParams` are set by `parseFuncDecl` from `f.Type.TypeParams`.
+	// Let's stick to `currentTypeParams` being those from the *enclosing* declaration for now.
+	// If `ft.TypeParams` are present, they define parameters for *this* literal func type.
+	// This detail needs careful handling based on how Go AST represents this vs. FuncDecl.
+	// For `func MyFunc[T any](p T){}`, `f.Type.TypeParams` is `[T any]`. `f.Type` is the `*ast.FuncType`.
+	// The `*ast.FuncType` node itself also has a `TypeParams` field.
+	// `f.Type.TypeParams` refers to the type parameters of the function declaration.
+	// `ft.TypeParams` (where ft is *ast.FuncType) are the type parameters specific to that func type node.
+	// Typically, for a FuncDecl, `f.Type.TypeParams` is the source of truth.
+
 	if ft.Params != nil {
-		funcInfo.Parameters = s.parseFieldList(ft.Params.List)
+		funcInfo.Parameters = s.parseFieldList(ctx, ft.Params.List, currentTypeParams)
 	}
 	if ft.Results != nil {
-		funcInfo.Results = s.parseFieldList(ft.Results.List)
+		funcInfo.Results = s.parseFieldList(ctx, ft.Results.List, currentTypeParams)
 	}
 	return funcInfo
 }
 
 // parseFieldList parses a list of fields (parameters or results).
-func (s *Scanner) parseFieldList(fields []*ast.Field) []*FieldInfo {
+// It now accepts ctx and currentTypeParams for resolving type parameter references.
+func (s *Scanner) parseFieldList(ctx context.Context, fields []*ast.Field, currentTypeParams []*TypeParamInfo) []*FieldInfo {
 	var result []*FieldInfo
 	for _, field := range fields {
-		fieldType := s.parseTypeExpr(field.Type)
+		fieldType := s.parseTypeExpr(ctx, field.Type, currentTypeParams) // Pass ctx and currentTypeParams
 		if len(field.Names) > 0 {
 			for _, name := range field.Names {
-				result = append(result, &FieldInfo{Name: name.Name, Type: fieldType})
+				result = append(result, &FieldInfo{Name: name.Name, Type: fieldType, Doc: commentText(field.Doc)})
 			}
 		} else {
-			result = append(result, &FieldInfo{Type: fieldType})
+			// Unnamed parameter/result, use type name if possible or leave empty
+			result = append(result, &FieldInfo{Type: fieldType, Doc: commentText(field.Doc)})
 		}
 	}
 	return result
 }
 
 // parseTypeExpr parses an expression representing a type.
-func (s *Scanner) parseTypeExpr(expr ast.Expr) *FieldType {
+// It now accepts ctx for logging.
+func (s *Scanner) parseTypeExpr(ctx context.Context, expr ast.Expr, currentTypeParams []*TypeParamInfo) *FieldType {
 	ft := &FieldType{resolver: s.resolver}
 	switch t := expr.(type) {
 	case *ast.Ident:
 		ft.Name = t.Name
-		// Check if it's a built-in type
-		// https://golang.org/ref/spec#Predeclared_identifiers
-		switch t.Name {
-		case "bool", "byte", "complex64", "complex128", "error", "float32", "float64",
-			"int", "int8", "int16", "int32", "int64", "rune", "string",
-			"uint", "uint8", "uint16", "uint32", "uint64", "uintptr":
-			ft.IsBuiltin = true
+		// Check if it's a built-in type or a type parameter
+		isTypeParam := false
+		if currentTypeParams != nil {
+			for _, tp := range currentTypeParams {
+				if tp.Name == t.Name {
+					isTypeParam = true
+					break
+				}
+			}
+		}
+		if isTypeParam {
+			ft.IsTypeParam = true
+		} else {
+			switch t.Name {
+			case "bool", "byte", "complex64", "complex128", "error", "float32", "float64",
+				"int", "int8", "int16", "int32", "int64", "rune", "string",
+				"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
+				"any", "comparable": // Add Go 1.18 predeclared identifiers for constraints
+				ft.IsBuiltin = true
+				if t.Name == "any" || t.Name == "comparable" {
+					ft.IsConstraint = true // Mark them as constraints
+				}
+			}
 		}
 	case *ast.StarExpr:
-		underlyingType := s.parseTypeExpr(t.X)
+		underlyingType := s.parseTypeExpr(ctx, t.X, currentTypeParams) // Pass ctx and currentTypeParams
 		underlyingType.IsPointer = true
 		return underlyingType
 	case *ast.SelectorExpr:
 		pkgIdent, ok := t.X.(*ast.Ident)
 		if !ok {
-			ft.Name = "unsupported_selector"
+			// Could be a more complex expression on the left of selector, e.g. another SelectorExpr
+			// For now, assume simple Pkg.Type form.
+			// If t.X is another SelectorExpr, like "a.b.C", then parseTypeExpr(t.X) should handle it.
+			// This part might need refinement for complex selectors.
+			// Let's represent the full selector as Name for now if not a simple Ident.
+			// This case needs to be robust.
+			// A common pattern is `pkg.Type` where `pkg` is `ast.Ident`.
+			// If `t.X` is not `ast.Ident`, it could be `anotherPkg.subPkg` which itself is a `SelectorExpr`.
+			// This recursive nature should be handled by `parseTypeExpr` returning a `FieldType`
+			// that represents `anotherPkg.subPkg` which we then use as `PkgName`.
+			// For now, let's make a simple assumption.
+			slog.Warn("Unhandled SelectorExpr with non-Ident X part", slog.Any("selector_x_type", fmt.Sprintf("%T", t.X)))
+			ft.Name = fmt.Sprintf("unsupported_selector_expr.%s", t.Sel.Name) // Fallback name
 			return ft
 		}
 		pkgImportPath, _ := s.importLookup[pkgIdent.Name]
 		qualifiedName := fmt.Sprintf("%s.%s", pkgImportPath, t.Sel.Name)
+
 		if overrideType, ok := s.ExternalTypeOverrides[qualifiedName]; ok {
 			ft.Name = overrideType
 			ft.IsResolvedByConfig = true
+			// If the override itself is a pointer, etc., this simple assignment isn't enough.
+			// Assume overrides are simple type names for now.
 			return ft
 		}
-		ft.Name = fmt.Sprintf("%s.%s", pkgIdent.Name, t.Sel.Name)
+		ft.Name = fmt.Sprintf("%s.%s", pkgIdent.Name, t.Sel.Name) // This might be too simple; Name should be t.Sel.Name
 		ft.PkgName = pkgIdent.Name
 		ft.typeName = t.Sel.Name
 		ft.fullImportPath = pkgImportPath
+	case *ast.IndexExpr: // For single type argument, e.g., MyType[string]
+		// t.X is the generic type (e.g., MyType)
+		// t.Index is the type argument (e.g., string)
+		genericType := s.parseTypeExpr(ctx, t.X, currentTypeParams)
+		if genericType.IsTypeParam {
+			// This case is likely an error in user code, e.g. T[int] where T is a type parameter.
+			// Or it could be a more complex scenario not yet fully handled for type parameters used as generic types.
+			slog.WarnContext(ctx, "IndexExpr on a type parameter, this might not be fully supported or implies an error", slog.String("type_param_name", genericType.Name))
+			// For now, return the type parameter itself, and attach the index as a "type arg" - this might need refinement.
+		}
+		typeArg := s.parseTypeExpr(ctx, t.Index, currentTypeParams)
+		genericType.TypeArgs = append(genericType.TypeArgs, typeArg)
+		// The Name of the FieldType should ideally represent the instantiated type,
+		// e.g., "MyType[string]". For now, genericType.Name still holds "MyType".
+		// The String() method for FieldType will need to account for TypeArgs.
+		return genericType // Return the base type with TypeArgs populated
+	case *ast.IndexListExpr: // For multiple type arguments (Go 1.18+), e.g., MyMap[string, int]
+		// t.X is the generic type (e.g., MyMap)
+		// t.Indices contains the type arguments (e.g., string, int)
+		genericType := s.parseTypeExpr(ctx, t.X, currentTypeParams)
+		if genericType.IsTypeParam {
+			slog.WarnContext(ctx, "IndexListExpr on a type parameter, this might not be fully supported or implies an error", slog.String("type_param_name", genericType.Name))
+		}
+		for _, indexExpr := range t.Indices {
+			typeArg := s.parseTypeExpr(ctx, indexExpr, currentTypeParams)
+			genericType.TypeArgs = append(genericType.TypeArgs, typeArg)
+		}
+		// Similar to IndexExpr, Name holds the base generic type name.
+		return genericType // Return the base type with TypeArgs populated
 	case *ast.ArrayType:
 		ft.IsSlice = true
-		ft.Name = "slice" // Or construct "[]ElemName"
-		ft.Elem = s.parseTypeExpr(t.Elt)
+		// For unnamed slices, Name could be "slice" or derived.
+		// Let's keep Name for the element type if possible, or make it specific like "[]<ElemType>".
+		// The current FieldType.String() reconstructs this.
+		// So ft.Name can be just "slice" or empty if Elem is filled.
+		ft.Name = "slice"                                        // Placeholder name
+		ft.Elem = s.parseTypeExpr(ctx, t.Elt, currentTypeParams) // Pass ctx and currentTypeParams
 	case *ast.MapType:
 		ft.IsMap = true
-		ft.Name = "map" // Or construct "map[KeyName]ValueName"
-		ft.MapKey = s.parseTypeExpr(t.Key)
-		ft.Elem = s.parseTypeExpr(t.Value)
+		ft.Name = "map"                                            // Placeholder name
+		ft.MapKey = s.parseTypeExpr(ctx, t.Key, currentTypeParams) // Pass ctx and currentTypeParams
+		ft.Elem = s.parseTypeExpr(ctx, t.Value, currentTypeParams) // Pass ctx and currentTypeParams
+	case *ast.InterfaceType: // Handle interface types used as constraints or inlined
+		// This represents an anonymous interface type, e.g. `interface{String() string}`
+		// It could be a constraint for a type parameter.
+		// For now, we'll give it a generic name. A fuller implementation might
+		// parse its methods if needed, but that's part of parseInterfaceType.
+		// Here, it's being used as a type expression.
+		ft.Name = "interface{}" // Simplified representation
+		// A more detailed parsing could involve creating a temporary TypeInfo for this interface.
+		// If this interface is a constraint, mark it.
+		// ft.IsConstraint = true; // This should be set if the context implies it's a constraint.
+		// The caller (parseTypeParamList) will set IsConstraint on the resulting FieldType.
 	default:
+		// Ensure logging uses context if available, or fallback for general utility functions.
+		slog.Warn("Unhandled type expression", slog.String("type", fmt.Sprintf("%T", t)))
 		ft.Name = fmt.Sprintf("unhandled_type_%T", t)
 	}
 	return ft

--- a/testdata/generics/generics.go
+++ b/testdata/generics/generics.go
@@ -1,0 +1,127 @@
+package generics
+
+import "fmt"
+
+// Constraint interface
+type Stringer interface {
+	String() string
+}
+
+// Generic function with a single type parameter
+func Print[T any](val T) {
+	fmt.Println(val)
+}
+
+// Generic function with a type constraint (interface)
+func PrintStringer[T Stringer](val T) {
+	fmt.Println(val.String())
+}
+
+// Generic function with comparable constraint
+func AreEqual[T comparable](a, b T) bool {
+	return a == b
+}
+
+// Generic struct
+type List[T any] struct {
+	items []T
+	Value T // Field using type parameter
+}
+
+// Method on generic struct
+func (l *List[T]) Add(item T) {
+	l.items = append(l.items, item)
+}
+
+// Method on generic struct using its type parameter in arg and receiver
+func (l *List[T]) Get(index int) T {
+	return l.items[index]
+}
+
+// Generic struct with multiple type parameters and constraints
+type KeyValue[K comparable, V any] struct {
+	Key   K
+	Value V
+}
+
+// Function that returns a generic type instance
+func NewList[T any](cap int) List[T] {
+	return List[T]{items: make([]T, 0, cap)}
+}
+
+// Function that uses an instantiated generic type
+func ProcessStringList(list List[string]) {
+	for i := 0; i < len(list.items); i++ {
+		fmt.Println(list.Get(i))
+	}
+}
+
+// Function with type parameter as argument and result
+func Identity[T any](val T) T {
+	return val
+}
+
+// Type alias for a generic type instantiation
+type StringList = List[string]
+
+// Type alias for a generic type itself.
+// type GenList[T any] = List[T] // This form of alias for generic type is a new type definition in effect.
+// A true alias for a generic type specifier might look like:
+// type MyList = List
+// But Go doesn't directly support aliasing a generic type specifier without its type parameters yet.
+// The above `GenList` example will be treated by `go/ast` as a new type `GenList[T]` whose underlying type is `List[T]`.
+
+// Let's use a more direct new type definition that uses an embedded generic type for clarity in testing.
+type GenList[T any] struct {
+	InnerList List[T]
+}
+
+// Generic type used as a field in a non-generic struct
+type Container struct {
+	IntList List[int]
+	KV      KeyValue[string, float64]
+}
+
+// Generic function used as a type for a field (not directly possible, but func type can be generic)
+// This is more about function types:
+type GenericFuncType[T any] func(T) T
+
+var MyGenericFuncInstance GenericFuncType[int] = Identity[int]
+
+// Interface with method using type parameters
+type Processor[T any, U Stringer] interface {
+	Process(data T) List[T]
+	ProcessKeyValue(kv KeyValue[string, T]) U
+}
+
+// Struct implementing a generic interface concept
+type IntStringProcessor struct{}
+
+func (ip *IntStringProcessor) Process(data int) List[int] {
+	l := NewList[int](1)
+	l.Add(data * 2)
+	return l
+}
+
+type myString string
+
+func (ms myString) String() string { return string(ms) }
+
+func (ip *IntStringProcessor) ProcessKeyValue(kv KeyValue[string, int]) myString {
+	fmt.Printf("Processing KV: %s -> %d\n", kv.Key, kv.Value)
+	return myString(fmt.Sprintf("%s:%d", kv.Key, kv.Value))
+}
+
+// Recursive generic type (e.g., for a tree node)
+type Node[T any] struct {
+	Value    T
+	Children []Node[T] // Recursive use of Node[T]
+}
+
+func NewNode[T any](value T) *Node[T] {
+	return &Node[T]{Value: value}
+}
+
+func (n *Node[T]) AddChild(child Node[T]) {
+	n.Children = append(n.Children, child)
+}


### PR DESCRIPTION
This change enables go-scan to parse and represent generic constructs introduced in Go 1.18.

Key changes:
- Updated data models in `scanner/models.go` to store information about type parameters (name, constraint) and type arguments. `TypeInfo`, `FunctionInfo`, and `FieldType` were modified.
- Enhanced parsing logic in `scanner/scanner.go`:
  - `parseTypeSpec` and `parseFuncDecl` now parse type parameter lists.
  - `parseTypeExpr` now handles `ast.IndexExpr` and `ast.IndexListExpr` for type arguments.
  - Context of current type parameters is passed down during parsing to correctly identify type parameter references (e.g., `IsTypeParam` flag).
  - Special handling for method receiver types to use the struct's type parameters as context.
- Added new test file `testdata/generics/generics.go` with various generic code examples.
- Added `TestScanner_ScanPackage_Generics` to `goscan_test.go` to verify the parsing of these generic constructs, including assertions for type parameter names, constraints, type arguments, and `IsTypeParam` flags.
- Updated `FieldType.String()` to correctly format instantiated generic types.