### PR TITLE
Support importing and using structs from external packages

### DIFF
--- a/examples/minigo/environment.go
+++ b/examples/minigo/environment.go
@@ -38,6 +38,15 @@ func (e *Environment) Assign(name string, val Object) (Object, bool) {
 		e.store[name] = val
 		return val, true
 	}
+
+// AllKeys returns a slice of all keys defined in this specific environment scope.
+func (e *Environment) AllKeys() []string {
+	keys := make([]string, 0, len(e.store))
+	for k := range e.store {
+		keys = append(keys, k)
+	}
+	return keys
+}
 	if e.outer != nil {
 		return e.outer.Assign(name, val)
 	}

--- a/examples/minigo/testdata/testpkg2/testpkg2.go
+++ b/examples/minigo/testdata/testpkg2/testpkg2.go
@@ -1,0 +1,40 @@
+package testpkg2
+
+type Foo struct {
+	Name string
+	ID   int
+}
+
+func NewFoo(name string, id int) *Foo {
+	return &Foo{Name: name, ID: id}
+}
+
+func GetFooName(f *Foo) string {
+	if f == nil {
+		return "nil foo"
+	}
+	return f.Name
+}
+
+func GetFooID(f *Foo) int {
+	if f == nil {
+		return -1
+	}
+	return f.ID
+}
+
+type Bar struct {
+	Value string
+}
+
+type Baz struct {
+	F *Foo
+	B Bar
+}
+
+func NewBaz(fooName string, fooID int, barValue string) *Baz {
+	return &Baz{
+		F: NewFoo(fooName, fooID),
+		B: Bar{Value: barValue},
+	}
+}

--- a/examples/minigo/todo.md
+++ b/examples/minigo/todo.md
@@ -29,7 +29,12 @@
 - [ ] Types
   - [ ] More specific integer types (int8, int32, int64, uint etc.)
   - [ ] Floating point numbers
-  - [ ] Structs
+  - [x] Structs
+    - [x] Basic definition and instantiation (within the same file)
+    - [x] Field access (e.g., `s.Field`)
+    - [x] Embedding (promoted fields, initialization, ambiguity, shadowing - within the same file)
+    - [x] Instantiation (via constructor functions) and field access for structs from imported packages
+    - [ ] Direct literal instantiation of structs from imported packages (e.g. `pkg.MyStruct{...}`)
   - [ ] Type declarations (`type MyInt int`)
   - [ ] Enhance type checking using information from go-scan
     - [ ] Basic static type checking for variable assignments based on go-scan TypeInfo.
@@ -41,11 +46,12 @@
 - [ ] Imports & Package Handling
   - [x] Basic import statement parsing (`import "path"` and `import alias "path"`) (Unsupported forms like . and _ are rejected)
   - [x] Loading imported package constants (`pkg.MyConst`) via `go-scan`. (As described in README)
-  - [/] Loading imported package functions (`pkg.MyFunc`) (README mentions only constants, but basic registration exists)
+  - [x] Loading imported package functions (`pkg.MyFunc`) via `go-scan`.
     - [x] Registration of imported functions as `UserDefinedFunction` objects in `evalSelectorExpr`.
-    - [ ] Ensure correct mapping of parameters and body from go-scan's `FunctionInfo` for imported functions.
-    - [ ] Verify calling convention and environment setup for imported functions.
-    - [ ] Add comprehensive tests for calling functions from imported packages.
+    - [x] Ensure correct mapping of parameters and body from go-scan's `FunctionInfo` for imported functions.
+    - [x] Verify calling convention and environment setup for imported functions.
+    - [x] Add comprehensive tests for calling functions from imported packages.
+  - [x] Loading exported struct definitions from imported packages via `go-scan`.
   - [ ] Support for imported global variables (e.g., `pkg.MyVar`) (Mentioned as future in README)
     - [ ] Extract imported global variable information using `go-scan`.
     - [ ] Make imported global variables accessible in the interpreter.


### PR DESCRIPTION
Implemented the following:
- Added `Interpreter.loadTypeSpec` to load struct definitions from external packages using `go-scan` results.
- Modified `evalSelectorExpr` to call `loadTypeSpec` when an external package is first accessed.
- Added a test case (`import struct from external package and access fields`) to verify calling functions that return structs from external packages and accessing their fields.
- Updated `todo.md` to reflect these changes.