### PR TITLE
feat: Improve external package struct/function handling in minigo

### DIFF
--- a/examples/minigo/environment.go
+++ b/examples/minigo/environment.go
@@ -57,3 +57,23 @@ func (e *Environment) ExistsInCurrentScope(name string) bool {
 // - Built-in variables/functions.
 // - Scope resolution for function calls (closures).
 // - Type information storage if the language becomes statically typed or for type checking.
+
+// GetAllEntries returns all entries from the current environment and its outer scopes.
+// Entries in inner scopes shadow those in outer scopes.
+func (e *Environment) GetAllEntries() map[string]Object {
+	allEntries := make(map[string]Object)
+
+	// Collect entries from outer scopes first
+	if e.outer != nil {
+		outerEntries := e.outer.GetAllEntries()
+		for name, obj := range outerEntries {
+			allEntries[name] = obj
+		}
+	}
+
+	// Add/overwrite with entries from the current scope
+	for name, obj := range e.store {
+		allEntries[name] = obj
+	}
+	return allEntries
+}

--- a/examples/minigo/object.go
+++ b/examples/minigo/object.go
@@ -145,8 +145,9 @@ type UserDefinedFunction struct {
 	Name       string // Simple name of the function
 	Parameters []*ast.Ident
 	Body       *ast.BlockStmt
-	Env        *Environment   // Closure: the environment where the function was defined
-	FileSet    *token.FileSet // FileSet for error reporting context
+	Env            *Environment   // Closure: the environment where the function was defined
+	FileSet        *token.FileSet // FileSet for error reporting context
+	ParamTypeExprs []ast.Expr     // AST expressions for parameter types
 
 	// Fields for external functions
 	IsExternal   bool   // True if this definition came from an imported package

--- a/examples/minigo/testdata/testpkg/testpkg.go
+++ b/examples/minigo/testdata/testpkg/testpkg.go
@@ -3,3 +3,44 @@ package testpkg
 const ExportedConst = "Hello from testpkg"
 const AnotherExportedConst = 12345
 const nonExportedConst = "Internal constant" // 小文字で始まる非エクスポート定数
+
+// Added for testing external struct and function
+type Point struct {
+	X int
+	Y int
+}
+
+func NewPoint(x int, y int) *Point {
+	return &Point{X: x, Y: y}
+}
+
+func NewPointValue(x int, y int) Point {
+	return Point{X: x, Y: y}
+}
+
+type Figure struct {
+    Name string
+    P    Point  // Struct field using a type from the same package
+}
+
+func NewFigure(name string, x int, y int) Figure {
+    return Figure{Name: name, P: Point{X: x, Y: y}}
+}
+
+func GetPointX(p Point) int {
+	return p.X
+}
+
+func GetFigureName(f Figure) string {
+    return f.Name
+}
+
+// Function returning a struct with an unexported field (for testing accessibility)
+type SecretPoint struct {
+    X int
+    secretY int // unexported
+}
+
+func NewSecretPoint(x, y int) SecretPoint {
+    return SecretPoint{X: x, secretY: y}
+}


### PR DESCRIPTION
Work towards enabling minigo to interpret functions that return structs defined in external Go packages, by evaluating the AST of those external elements.

Key changes and steps taken:

1.  **Plan Definition & Refinement:**
    *   Initial plan focused on identifying how external structs and functions were handled.
    *   Clarified with the user that the goal is AST-level interpretation of external Go code, not binary execution.
    *   Revised plan to load and evaluate ASTs of external structs and functions.

2.  **External Struct Definition Loading:**
    *   Modified `object.go`: Added `IsExternal`, `PackagePath`, and `FileSet` fields to `StructDefinition`.
    *   Modified `interpreter.go` (`evalSelectorExpr`): When an external package is imported (lazily), iterate through `PackageInfo.Types`. For exported struct types, create a minigo `StructDefinition` and register it in the environment with a qualified name (e.g., `pkgalias.StructName`).
    *   Modified `interpreter.go` (`evalCompositeLit`): Enabled handling of `ast.SelectorExpr` (e.g., `pkg.MyStruct`) as the type in a composite literal, allowing instantiation of external structs.

3.  **External Function Definition Loading & Call:**
    *   Modified `object.go`: Added `IsExternal`, `PackagePath`, and `PackageAlias` to `UserDefinedFunction`.
    *   Modified `interpreter.go` (`evalSelectorExpr`): When registering external functions, store their `PackageAlias` and mark them as external. The core mechanism of storing the AST body (`AstDecl.Body`) and evaluating it via `applyUserDefinedFunction` -> `evalBlockStatement` was largely suitable.

4.  **FileSet Handling for Accurate Error Reporting:**
    *   Introduced `activeFileSet *token.FileSet` field in the `Interpreter` struct.
    *   `LoadAndRun`: Initializes `activeFileSet` with the main script's `FileSet`.
    *   `applyUserDefinedFunction`:
        *   Changed signature to include `callerFileSet *token.FileSet`.
        *   Sets `i.activeFileSet` to the `FileSet` of the function being called (`fn.FileSet`). This is crucial for errors originating from external code to point to the correct source file.
        *   Restores the original `activeFileSet` on defer.
    *   Numerous `eval<NodeType>` methods: Changed calls to `formatErrorWithContext` to use `i.activeFileSet` instead of the global `i.FileSet`, ensuring errors are reported against the currently evaluating code's source.
    *   `evalCallExpr`: Passes `i.activeFileSet` as `callerFileSet` to `applyUserDefinedFunction`.
    *   Corrected `FileSet` sources for locally defined functions and structs in `evalFuncDecl`, `evalFuncLit`, `evalDeclStmt` to use `i.activeFileSet` (which would be the main script's `FileSet` in these contexts).

5.  **Test Case Creation:**
    *   Updated `testdata/testpkg/testpkg.go` with struct definitions (`Point`, `Figure`, `SecretPoint`) and functions returning these structs or taking them as arguments.
    *   Added `TestEvalExternalStructsAndFunctions` to `interpreter_test.go`, including various scenarios for instantiating and using external structs and functions.

6.  **Parsing of Main Script:**
    *   Corrected `LoadAndRun` to parse the main minigo script (e.g., `.mgo` file) using `go/parser.ParseFile` directly, instead of attempting to use `go-scan`. `go-scan` is now only used for imported Go packages. This resolved a class of test failures where `.mgo` files were being incorrectly treated as `.go` files by `go-scan`.

**Current Status & Remaining Issues:**

Despite the changes, tests are still failing. The primary remaining issues seem to be:

*   **Type Resolution for Composite Literals:**
    *   When a minigo script uses a qualified struct literal (e.g., `pkgalias.MyStruct{}`), the type `pkgalias.MyStruct` is not always found by `evalCompositeLit`. This is likely because the act of encountering the literal itself doesn't trigger the package loading mechanism in `evalSelectorExpr`.
    *   When an *external Go function's AST* contains a struct literal for a type defined in its *own package* (e.g., `Point{}` inside `testpkg.NewPoint`), `evalCompositeLit` (running in the context of that external function) fails to find the unqualified type `Point`. The environment for the external function needs to correctly resolve its own package's types without prefixes.

*   **Scope/Environment for External Functions:** The environment setup for evaluating external functions (`fn.Env` in `UserDefinedFunction`) needs to ensure that type lookups for symbols defined within that external function's own package are successful using their local (unqualified) names. The `activeFileSet` changes help with error *locations*, but not necessarily with name *resolution* within the correct scope.

**Next Steps (If I were to continue):**

1.  **Resolve Unqualified Names in External Functions:**
    *   In `applyUserDefinedFunction`, if `fn.IsExternal`, augment `funcEnv` so that types/functions/constants from `fn.PackagePath` (using `fn.PackageAlias`) are resolvable by their simple names. This might involve iterating `fn.Env` (the global env) for all symbols prefixed with `fn.PackageAlias + "."` and adding them to `funcEnv` without the prefix.
    *   Alternatively, modify `evalIdentifier` and `evalCompositeLit` (for `ast.Ident` types) to check `i.currentFnPackageAlias` (a new `Interpreter` field set during external function calls) and attempt to find `i.currentFnPackageAlias + "." + name` if `name` is not found directly.

2.  **Trigger Package Loading for Literals:**
    *   In `evalCompositeLit`, if the type is an `ast.SelectorExpr` (e.g., `pkg.Type`), and `pkg.Type` is not found in the environment, explicitly trigger the package loading logic for `pkg` (similar to what `evalSelectorExpr` does). This might involve refactoring the package loading part of `evalSelectorExpr` into a helper method.

These address the most prominent error patterns observed in the tests.