### PR TITLE
Fix: Resolve MiniGo interpreter test failures

### DIFF
--- a/examples/minigo/object.go
+++ b/examples/minigo/object.go
@@ -145,8 +145,9 @@ type UserDefinedFunction struct {
 	Name       string // Simple name of the function
 	Parameters []*ast.Ident
 	Body       *ast.BlockStmt
-	Env        *Environment   // Closure: the environment where the function was defined
-	FileSet    *token.FileSet // FileSet for error reporting context
+	Env            *Environment   // Closure: the environment where the function was defined
+	FileSet        *token.FileSet // FileSet for error reporting context
+	ParamTypeExprs []ast.Expr     // AST expressions for parameter types
 
 	// Fields for external functions
 	IsExternal   bool   // True if this definition came from an imported package


### PR DESCRIPTION
This commit addresses several issues in the MiniGo interpreter that were causing test failures, primarily related to external function calls, type resolution, and operator handling.

Key changes:
- Implemented argument type checking in `applyUserDefinedFunction` to correctly validate types of arguments passed to functions, especially for external functions. This resolves issues where incorrect types were not being caught, leading to subsequent errors like "undefined variable".
- Refined `resolveTypeAstToObjectType` to correctly resolve unqualified type names (e.g., `Point`) within the context of an external function's parameters by qualifying them with the function's package alias (e.g., `testpkg.Point`). Also improved lookup for qualified types (`pkg.Type`) to use the global environment.
- Enhanced the unary `&` (address-of) operator in `evalUnaryExpr` to support its use with composite literals (e.g., `&Point{}`), in addition to identifiers.
- Fixed various scope-related "no new variables on left side of :=" errors in `evalSelectorExpr` by declaring variables in the appropriate scope and using `=` for assignment where necessary.
- Corrected an `undefined: env` compilation error in `resolveTypeAstToObjectType`.

These changes collectively allow the test suite for `examples/minigo` to pass.