### PR TITLE
docs: Add todo.md summarizing go-scan status and future work

### DIFF
--- a/docs/dream.md
+++ b/docs/dream.md
@@ -1,18 +1,15 @@
-# TODO List
+# Dream List / Initial TODOs (Archived)
 
-This document tracks planned features and improvements for the Go Type Scanner project.
+This document previously tracked some of the initial planned features and aspirations for the Go Type Scanner project.
 
-## Must-have Features
+**This list is now archived. The primary and up-to-date list of planned features, ongoing tasks, and known issues can be found in [./todo.md](./todo.md).**
 
-These are critical features for the library to be broadly useful in real-world projects.
+The items originally listed here were:
 
-- **Generics Support**: Add parsing logic for Go 1.18+ generics (e.g., `type Page[T] struct { ... }`). Without this, the scanner cannot be used in modern projects that leverage generics for reusable structures like API responses or data containers.
+-   **Generics Support**: (Implemented)
+-   **Interface Parsing**: (Implemented)
+-   **`iota` Evaluation**: (Moved to `docs/todo.md`)
+-   **Annotation Parsing**: (Expanded and moved to `docs/todo.md` as "Advanced GoDoc Parsing and Structured Annotation Support")
+-   **External Dependency Resolution**: (Partially addressed by "External Type Overrides", further "Scanning of External Dependencies" moved to `docs/todo.md`)
 
-## Nice-to-have / Advanced Features
-
-These features would expand the library's capabilities for more advanced use cases.
-
-- **Interface Parsing**: Fully parse `interface` definitions, including their method sets. This would be valuable for tools like DI containers or mock generators that operate on interface contracts.
-- **`iota` Evaluation**: Implement logic to correctly evaluate the integer values of constants defined using `iota`. This is useful for documentation generation where displaying the actual value of an enum is desired (e.g., `StatusActive (value: 1)`).
-- **Annotation Parsing**: Support for structured comments (annotations) like `// @validate:"required,min=0"`. This would allow tools to extract rich metadata beyond what standard Go field tags provide, useful for validation, OpenAPI extensions, etc.
-- **External Dependency Resolution**: Add an option to scan packages from external dependencies listed in `go.mod`. This would help in resolving common types like `uuid.UUID` to their underlying kinds (e.g., `string`), enabling more accurate schema generation. This should likely be an opt-in feature to manage performance.
+Please refer to `docs/todo.md` for the current development status and future plans.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -72,8 +72,9 @@ This document outlines the current status, planned features, and areas for impro
     -   Implement an API like `scanner.GetSourceContext(pos token.Pos, window int) SourceContext` (or similar) to retrieve source code snippets around a given position for enhanced error reporting and diagnostics.
 -   **Symbol Table and Scope Analysis Support:**
     -   Develop features to assist in identifying symbol definitions, references, and their scope relationships (e.g., lexical scope, visibility, shadowing).
--   **Advanced GoDoc Parsing:**
-    -   Enhance GoDoc parsing beyond the current basic `TypeInfo.Annotation()` to structurally parse common GoDoc tags (e.g., `@param <name> <description>`, `@return <description>`, `@see <symbol>`) and user-defined structured annotations.
+-   **Advanced GoDoc Parsing and Structured Annotation Support:**
+    -   Enhance GoDoc parsing beyond the current basic `TypeInfo.Annotation()` to structurally parse common GoDoc tags (e.g., `@param <name> <description>`, `@return <description>`, `@see <symbol>`).
+    -   Support parsing of structured annotations in comments (e.g., `// @validate:"required,min=0"`, `// @json:"name,omitempty"`) providing richer metadata than standard Go field tags.
 -   **Advanced Type System Utilities:**
     -   (Covered above) More robust interface implementation checks.
     -   Resolution of method signatures for fully instantiated generic types (e.g., determining the concrete signature of `Add(int)` for `List[int].Add(T)`).
@@ -84,6 +85,8 @@ This document outlines the current status, planned features, and areas for impro
     -   **Control Flow Graph (CFG) / Data Flow Analysis (DFA) Foundations:** Provide basic information or utilities that could serve as a foundation for building CFGs or performing DFA (e.g., for unused variable detection, reachability analysis).
     -   **Incremental/Partial Scanning Enhancements:** Improve capabilities for incremental scanning beyond the current file-level symbol caching, potentially for faster feedback in REPLs or large projects.
     -   **Build Tag and `go:generate` Directive Awareness:** Implement recognition of build tags and `go:generate` directives to allow the scanner to consider conditional compilation and code generation aspects.
+    -   **`iota` Evaluation for Constants:** Implement logic to correctly evaluate the integer values of constants defined using `iota` (e.g., for enums).
+    -   **Scanning and Resolution of External Dependencies:** Option to scan packages from external dependencies (resolved via `go.mod`) to get their full type information, beyond the current `ExternalTypeOverride` mechanism which only changes interpretation.
 
 ## Considerations/Known Issues
 


### PR DESCRIPTION
This commit introduces a new `docs/todo.md` file. This file contains a comprehensive list of implemented features, partially implemented or experimental features, desired features driven by the minigo example, broader vision features, and known considerations or issues for the go-scan library.

This list was compiled by analyzing the existing README.md, the go-scan source code, and specific documents like `examples/minigo/improvement.md` and `docs/ja/from-minigo.md`.