### PR TITLE
feat: Add example for type conversion generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,3 +209,10 @@ The scanner can cache the file paths where symbols (types, functions, constants)
 - The `scanner.FindSymbolDefinitionLocation("package/import/path.SymbolName")` method leverages this cache. If caching is enabled and a symbol is not found in the cache (or if the cached file path is no longer valid), it will attempt to scan the relevant package and update the cache. If caching is disabled, it will always perform a fresh scan.
 
 This library is currently under development. See `docs/todo.md` for planned features.
+
+## More Examples
+
+*   **`examples/derivingjson`**: Demonstrates generating JSON marshaling/unmarshaling methods, including support for `oneOf` (sum types).
+*   **`examples/derivingbind`**: Shows how to generate methods for binding data from HTTP requests (query, path, header, body) to struct fields.
+*   **`examples/minigo`**: A mini Go interpreter that uses `go-scan` for parsing and understanding Go code structure.
+*   **`examples/convert`**: A prototype for generating type conversion functions between different Go structs. See `examples/convert/README.md` for details.

--- a/docs/ja/from-convert.md
+++ b/docs/ja/from-convert.md
@@ -1,0 +1,170 @@
+# `examples/convert` における型変換と `go-scan` の活用
+
+`examples/convert` は、Goの構造体間で型を変換するコード（コンバータ）を自動生成するジェネレータの試作例です。このジェネレータは `go-scan` を利用してソースコードから型情報を取得し、それに基づいて変換ロジックを構築します。
+
+## 1. `go-scan` に求められる機能と現状の評価
+
+`examples/convert` のような型変換ジェネレータを開発する上で、`go-scan` には以下の機能が求められます。
+
+### 1.1. 型情報の詳細取得
+
+ジェネレータは、変換元（Source）と変換先（Destination）の型について詳細な情報を必要とします。
+
+*   **構造体のフィールド情報**:
+    *   フィールド名、型、タグ、ドキュメントコメント。
+    *   **現状**: `go-scan` はこれらの情報を `scanner.FieldInfo` や `scanner.TypeInfo` を通じて提供しており、充足しています。
+*   **型の種類**:
+    *   型が構造体、エイリアス、プリミティブ、関数型など、どのような種類であるかの識別。
+    *   **現状**: `scanner.TypeInfo.Kind` （`StructKind`, `AliasKind`, `FuncKind` など）で提供されており、充足しています。
+*   **複合型（ポインタ、スライス、マップ）の詳細**:
+    *   ポインタ型であるか、スライスやマップの要素型は何か、といった情報。
+    *   **現状**: `scanner.FieldType` の `IsPointer`, `IsSlice`, `IsMap`, `Elem`, `MapKey` といったフィールドで提供されており、充足しています。
+*   **Embeddedフィールドの識別**:
+    *   フィールドがEmbeddedであるかどうかの識別。
+    *   **現状**: `scanner.FieldInfo.Embedded` で提供されており、充足しています。
+*   **フィールド名の正規化サポート**:
+    *   変換元と変換先のフィールド名を対応付ける際、大文字・小文字の違いや `_` (アンダースコア) の有無などを吸収するための正規化処理が必要になります。
+    *   **現状の不足/検討点**: `go-scan` 自体が正規化関数を提供するか、あるいはジェネレータ側で実装すべき汎用ロジックか。`go-scan` がAST情報を提供するため、ジェネレータ側での実装は可能ですが、一般的な正規化ルール（例: `snake_case` から `CamelCase`）のユーティリティがあれば便利かもしれません。
+
+### 1.2. 型変換ルールの外部定義サポート
+
+型が完全一致しないフィールド間の変換（例: `time.Time` から `string` へ）には、カスタム変換関数を適用する必要があります。
+
+*   **カスタム変換関数のマッピング**:
+    *   特定の型ペア（例: `Src:time.Time`, `Dst:string`）に対して、どの変換関数を使用するかを外部からジェネレータに指示できる仕組み。
+    *   **現状の不足/検討点**: `go-scan` は型情報を提供しますが、このマッピングルール自体を解釈する機能は持ちません。ジェネレータがこのマッピングをどのように受け取り、解釈するかが課題です。
+*   **minigo風DSLによるルール記述**:
+    *   ユーザーが変換ルールをminigoのようなドメイン固有言語（DSL）で記述し、ジェネレータがそれをパースしてGoの変換関数呼び出しを生成するアイデアがあります。
+    *   **現状の不足/検討点**: `go-scan` はDSLのパーサーやインタープリタを提供するわけではありません。しかし、DSL内で参照される型名やフィールド名を `go-scan` が提供する情報と照合し、検証する際に役立つ可能性があります。
+
+### 1.3. ASTノードへのアクセス
+
+ジェネレータが複雑な変換ロジックやヘルパー関数を生成する際に、元の型定義や関数定義のASTノード情報が必要になることがあります。
+
+*   **現状**: `scanner.TypeInfo.Node` や `scanner.FunctionInfo.AstDecl` などでASTノードへのアクセスが提供されており、充足しています。
+
+## 2. `examples/convert` の実装計画
+
+`examples/convert` ジェネレータは、以下のステップで実装を進めることを計画しています。
+
+### 2.1. 基本方針
+
+`go-scan` を用いて、変換元（Source）と変換先（Destination）のパッケージから型情報を読み取ります。読み取った情報に基づき、一方の型の値をもう一方の型の値に変換するGoの関数群（例: `func ConvertUser(src models.SrcUser) models.DstUser`) を自動生成します。
+
+### 2.2. フィールドマッピング戦略
+
+変換元のフィールドと変換先のフィールドを対応付けるためのルールは以下の通りです。
+
+1.  **フィールド名の正規化**:
+    *   まず、変換元と変換先のフィールド名を正規化します。正規化処理として、全て小文字にし、アンダースコア (`_`) を除去する処理を想定します。
+    *   例: `FirstName` -> `firstname`, `USER_ID` -> `userid`
+    *   正規化後の名前が一致すれば、それらを対応するフィールドとみなします。
+2.  **タグによる明示的な指定**:
+    *   変換元構造体のフィールドタグに、変換先フィールドの（正規化後の）名前を明示的に指定できるオプションを提供します。
+    *   例: `type Src struct { MyField string \`convert:"target_field_name"\` }`
+    *   このタグが存在する場合、フィールド名の正規化ルールよりも優先されます。
+
+### 2.3. 型変換戦略
+
+フィールド間で型が異なる場合の変換戦略は以下の通りです。
+
+1.  **型一致**: フィールドの型が完全に一致する場合、単純な代入文を生成します。
+2.  **カスタム型変換関数**:
+    *   型が異なる場合（例: `time.Time` を `string` に、`*int` を `int` に）、あらかじめ定義された型ペア変換関数を呼び出すコードを生成します。
+    *   これらの変換関数は、以下のいずれかの方法で提供されることを想定します。
+        *   **ユーザーによるGo関数提供**: ジェネレータの利用者が、特定の型ペア間の変換を行うGo関数を別途記述し、ジェネレータにその情報を（例えば設定ファイルやアノテーション経由で）伝えます。
+        *   **minigo風DSLからの生成**: ユーザーが変換ルールをminigoのようなDSLで記述し、ジェネレータがそのDSLを解釈して対応するGoの変換関数（または関数呼び出し部分）を生成します。このDSLは、単純な型キャストから、より複雑なロジック記述までサポートすることを目指します。
+            ```minigo
+            // Conceptual minigo DSL for type conversion rules
+            package converter
+
+            import (
+                "example.com/convert/models"
+                "time"
+                "fmt"
+            )
+
+            // Convert time.Time to string using RFC3339 format
+            define_converter TimeToString(src time.Time) string {
+                return src.Format(time.RFC3339)
+            }
+
+            // Convert *time.Time to string, handling nil
+            define_converter PtrTimeToString(src *time.Time) string {
+                if src == nil {
+                    return ""
+                }
+                return src.Format(time.RFC3339)
+            }
+
+            // Convert int64 to string for UserID
+            define_converter UserIDToString(src int64) string {
+                return fmt.Sprintf("user-%d", src)
+            }
+            ```
+            ジェネレータは、このDSLを読み込み、`TimeToString` や `PtrTimeToString` といった名前のGo関数を生成するか、あるいは直接変換処理のGoコードスニペットをインラインで生成します。
+
+### 2.4. Embeddedフィールドの扱い
+
+変換元または変換先の構造体にEmbeddedフィールドが存在する場合、それらは展開され、フラットなフィールドとして扱われます。`go-scan` から提供される `scanner.FieldInfo.Embedded` フラグを利用して、Embeddedフィールドを正しく識別し処理します。
+
+### 2.5. 生成されるコードの構造
+
+ジェネレータは、以下のような構造のGoの変換関数を生成します。
+
+```go
+package converter // Or a user-specified package
+
+import (
+	"example.com/convert/models" // Source/Destination models
+	"time"                       // If time conversions are needed
+	"fmt"                        // If formatting is needed
+	// Other necessary imports based on conversion functions
+)
+
+// ConvertSrcUserToDstUser converts models.SrcUser to models.DstUser
+func ConvertSrcUserToDstUser(ctx context.Context, src models.SrcUser) models.DstUser {
+	dst := models.DstUser{}
+
+	// Example: Direct assignment if types match and names (after normalization) match
+	// dst.FullName = src.FirstName + " " + src.LastName // (Manual or rule-based combination)
+
+	// Example: Using a custom converter for ID (int64 to string)
+	// dst.UserID = UserIDToString(src.ID) // Assuming UserIDToString is generated/defined
+
+	// Example: Handling embedded struct
+	// dst.Address = ConvertSrcAddressToDstAddress(ctx, src.Address) // Recursive call
+
+	// Example: Handling slice of structs
+	// if src.Details != nil {
+	//    dst.Details = make([]models.DstInternalDetail, len(src.Details))
+	//    for i, sDetail := range src.Details {
+	//        dst.Details[i] = ConvertSrcInternalDetailToDstInternalDetail(ctx, sDetail)
+	//    }
+	// }
+
+	// ... other field conversions ...
+
+	return dst
+}
+
+// Other converters like ConvertSrcAddressToDstAddress, etc.
+```
+
+*   **コンテキストの受け渡し**: 各変換関数は `context.Context` を第一引数として受け取ることを推奨します。これにより、タイムアウト制御やリクエストスコープの値の受け渡しなど、高度なユースケースに対応できます。
+*   **ネストされた構造体の変換**: ネストされた構造体（例: `SrcUser` 内の `SrcAddress`）は、対応する別の変換関数（例: `ConvertSrcAddressToDstAddress`）を再帰的に呼び出す形で処理されます。
+*   **スライスやマップの変換**: スライスやマップの要素も、要素の型に対応する変換処理（プリミティブな代入、または別の変換関数の呼び出し）をループ内で実行することで変換します。
+
+## 3. 懸念事項と今後の課題
+
+*   **フィールド名正規化ルールの複雑性**: 多様な命名規則（camelCase, PascalCase, snake_case, SCREAMING_SNAKE_CASEなど）に対応するための正規化ロジックは複雑になる可能性があります。どこまでを共通ルールとし、どこからをユーザー設定可能にするかのバランスが重要です。
+*   **型変換DSLの設計と実装コスト**: minigo風DSLは柔軟性が高い反面、その構文設計、パーサー、ジェネレータへの組み込みには相応の開発コストがかかります。初期段階では、よりシンプルな変換関数指定方法（例: 関数名文字列のマッピング）から始めることも検討できます。
+*   **エラーハンドリング**:
+    *   変換不可能な型ペアが指定された場合。
+    *   マッピングルールに曖昧さや不備があった場合。
+    *   実行時の変換エラー（例: 文字列から数値へのパース失敗）。
+    これらのエラーをどのように検出し、ユーザーに報告し、生成コード内で処理するかが課題となります。
+*   **生成コードのパフォーマンス**: 大量のデータを変換する場合、リフレクションを多用するような наивな実装ではパフォーマンスが問題になる可能性があります。可能な限り静的な型情報に基づいて最適化されたコードを生成することが望ましいです。
+*   **循環参照**: 相互に参照し合うような型構造（例: `User` が `Order` を持ち、`Order` が `User` を持つ）の変換では、無限ループに陥らないような工夫が必要です（例: 変換済みのオブジェクトを追跡する）。
+
+これらの計画と懸念事項を踏まえ、`examples/convert` の実装を進めていきます。初期は手動でのコンバータ作成から始め、段階的にジェネレータの機能を拡充していくアプローチを取ります。

--- a/examples/convert/README.md
+++ b/examples/convert/README.md
@@ -1,0 +1,85 @@
+# Go Type Converter Example (`examples/convert`)
+
+This example demonstrates a prototype for generating Go type conversion functions using the `go-scan` library. It explores how `go-scan` can be leveraged to read Go source code, understand type structures, and then automatically generate boilerplate code for converting one struct type to another.
+
+## Overview
+
+In many applications, you often need to convert data between different Go struct types. For example:
+*   Converting from a database model to an API response model.
+*   Transforming data from an external service's format to an internal application format.
+*   Mapping between different versions of a data structure.
+
+Manually writing these conversion functions can be tedious, error-prone, and repetitive, especially when dealing with complex nested structures or many fields. This example aims to automate this process.
+
+## Project Structure
+
+*   `models/models.go`: Defines the source (`Src*`) and destination (`Dst*`) struct types that we want to convert between.
+*   `converter/converter.go`: Contains **manually written** conversion functions. This serves as a reference for what the generator should ideally produce.
+*   `converter/converter_test.go`: Unit tests for the manually written conversion functions in `converter.go`.
+*   `converter/generated_converters.go`: This file will be **generated** by the prototype generator logic in `main.go`.
+*   `mapping/mapping.minigo`: A conceptual DSL (Domain Specific Language) file outlining how users might specify custom conversion rules in a more advanced version of the generator. This is currently for discussion and not fully implemented.
+*   `main.go`:
+    1.  Runs examples using the manually written converters (`runConversionExamples()`).
+    2.  Contains the prototype generator logic (`generateConverterPrototype()`) which uses `go-scan` to parse `models/models.go` and generate conversion functions into `converter/generated_converters.go`.
+
+## How it Works (Conceptual & Prototype)
+
+1.  **Model Definition**: You define your source and destination Go structs in `models/models.go`.
+2.  **Scanning with `go-scan`**: The `generateConverterPrototype()` function in `main.go` uses `go-scan` to:
+    *   Parse the `models` package.
+    *   Extract detailed information about `struct` types, including fields, field types, tags, and embedded structs.
+3.  **Generator Logic (Prototype in `main.go`)**:
+    *   It identifies pairs of source and destination types (e.g., `SrcUser` and `DstUser`).
+    *   It attempts to map fields between the source and destination structs based on:
+        *   (Future) Name normalization (e.g., converting `UserID` to `user_id` for matching).
+        *   (Future) Struct tags (e.g., `convert:"targetFieldName"`).
+        *   (Current) Some hardcoded rules based on the manual `converter.go` for demonstration.
+    *   It generates Go functions that perform the assignments, including:
+        *   Direct assignment for type-compatible fields.
+        *   Calls to other generated or helper functions for nested structs or complex type conversions (e.g., `time.Time` to `string`).
+        *   Handling of slices by iterating and converting each element.
+4.  **Code Output**: The generated Go conversion functions are written to `converter/generated_converters.go`.
+
+## Running the Example
+
+You can run this example from the root directory of the `go-scan` project.
+
+1.  **Run the main program**:
+    This will first execute the examples using the manual converters and then run the generator prototype, which will create/overwrite `examples/convert/converter/generated_converters.go`.
+
+    ```bash
+    go run ./examples/convert/main.go
+    ```
+
+2.  **Inspect Generated Code**:
+    After running, inspect `examples/convert/converter/generated_converters.go` to see the output of the prototype.
+
+3.  **Run Tests**:
+    To test the manually written converters (and potentially the generated ones if you integrate them into the test path):
+    ```bash
+    go test ./examples/convert/converter/...
+    ```
+    (You might need to be in the `examples/convert` directory or adjust paths if your Go workspace setup differs).
+
+## Role of `go-scan`
+
+`go-scan` is crucial for this example because:
+
+*   It allows the generator to understand the structure of Go types **without relying on `go/types` or compiling the code**. This makes the generator faster and more lightweight.
+*   It provides detailed information about fields (name, type, tags, embedded status), which is essential for mapping logic.
+*   Its `PackageResolver` and type resolution capabilities (e.g., `FieldType.Resolve()`) are key to handling types from different packages (though this example primarily focuses on types within the same `models` package for simplicity in its current prototype stage).
+*   It can access documentation comments, which could be used in the future for annotation-driven conversion rules.
+
+## Future Development (for this example)
+
+The current generator in `main.go` is a very basic prototype. A more complete generator would:
+
+*   Implement robust field name normalization and matching.
+*   Fully support struct tags for explicit field mapping.
+*   Allow users to specify custom transformation functions for incompatible types (potentially via a DSL like in `mapping.minigo` or Go code registration).
+*   Handle pointer-to-value, value-to-pointer, and other complex conversions more generically.
+*   Manage imports in the generated file dynamically (e.g., using `go-scan`'s `ImportManager`).
+*   Provide better error handling and reporting during generation.
+*   Be structured as a proper command-line tool.
+
+This example serves as a starting point and a testbed for exploring these more advanced code generation capabilities using `go-scan`.

--- a/examples/convert/converter/converter.go
+++ b/examples/convert/converter/converter.go
@@ -1,0 +1,142 @@
+package converter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"example.com/convert/models" // Assuming your module path is example.com/convert
+)
+
+// translateDescription is a helper function simulating internal processing.
+// In a real scenario, this could be a more complex logic, e.g., calling a translation service.
+func translateDescription(ctx context.Context, text string, targetLang string) string {
+	// Simulate a call to a translation service or internal logic
+	// For demonstration, we'll just prepend a string.
+	// The context could be used here for deadlines, cancellation, or passing request-scoped values.
+	if targetLang == "jp" {
+		return "翻訳済み (JP): " + text
+	}
+	return text
+}
+
+// --- User Conversion Functions ---
+
+// ConvertUser converts a models.SrcUser to a models.DstUser.
+// This function is EXPORTED because DstUser is specified as a "top-level type".
+func ConvertUser(ctx context.Context, src models.SrcUser) models.DstUser {
+	if ctx == nil {
+		ctx = context.Background() // Ensure context is never nil
+	}
+
+	dst := models.DstUser{}
+
+	// ID: int64 to string with formatting
+	dst.UserID = fmt.Sprintf("user-%d", src.ID)
+
+	// FullName: Combine FirstName and LastName
+	dst.FullName = src.FirstName + " " + src.LastName
+
+	// Address: Embedded struct conversion (calls unexported converter)
+	dst.Address = srcAddressToDstAddress(ctx, src.SrcAddress)
+
+	// Contact: Nested struct conversion (calls unexported converter)
+	dst.Contact = srcContactToDstContact(ctx, src.ContactInfo)
+
+	// Details: Slice of structs conversion (calls unexported converter for elements)
+	if src.Details != nil {
+		dst.Details = make([]models.DstInternalDetail, len(src.Details))
+		for i, sDetail := range src.Details {
+			dst.Details[i] = srcInternalDetailToDstInternalDetail(ctx, sDetail)
+		}
+	}
+
+	// CreatedAt: time.Time to string
+	dst.CreatedAt = src.CreatedAt.Format(time.RFC3339)
+
+	// UpdatedAt: *time.Time to string (handle nil)
+	if src.UpdatedAt != nil {
+		dst.UpdatedAt = src.UpdatedAt.Format(time.RFC3339)
+	} else {
+		dst.UpdatedAt = "" // Or handle as per specific requirements for nil
+	}
+
+	return dst
+}
+
+// srcAddressToDstAddress converts models.SrcAddress to models.DstAddress.
+// This function is UNEXPORTED as models.DstAddress is not a "top-level type" by itself,
+// but rather a component of DstUser.
+func srcAddressToDstAddress(ctx context.Context, src models.SrcAddress) models.DstAddress {
+	return models.DstAddress{
+		FullStreet: src.Street, // Renamed
+		CityName:   src.City,   // Renamed
+	}
+}
+
+// srcContactToDstContact converts models.SrcContact to models.DstContact.
+// This function is UNEXPORTED.
+func srcContactToDstContact(ctx context.Context, src models.SrcContact) models.DstContact {
+	dst := models.DstContact{
+		EmailAddress: src.Email, // Renamed
+	}
+	if src.Phone != nil {
+		dst.PhoneNumber = *src.Phone // Pointer to value
+	} else {
+		dst.PhoneNumber = "N/A" // Default value for nil phone
+	}
+	return dst
+}
+
+// srcInternalDetailToDstInternalDetail converts models.SrcInternalDetail to models.DstInternalDetail.
+// This function is UNEXPORTED and includes internal processing.
+func srcInternalDetailToDstInternalDetail(ctx context.Context, src models.SrcInternalDetail) models.DstInternalDetail {
+	// Simulate internal processing (e.g., translation)
+	localizedDescription := translateDescription(ctx, src.Description, "jp")
+
+	return models.DstInternalDetail{
+		ItemCode:        src.Code,               // Renamed
+		LocalizedDesc: localizedDescription, // Processed and renamed
+	}
+}
+
+// --- Order Conversion Functions ---
+
+// ConvertOrder converts a models.SrcOrder to a models.DstOrder.
+// This function is EXPORTED because DstOrder is specified as a "top-level type".
+func ConvertOrder(ctx context.Context, src models.SrcOrder) models.DstOrder {
+	if ctx == nil {
+		ctx = context.Background() // Ensure context is never nil
+	}
+
+	dst := models.DstOrder{
+		ID:          src.OrderID,
+		TotalAmount: src.Amount,
+	}
+
+	if src.Items != nil {
+		dst.LineItems = make([]models.DstItem, len(src.Items)) // Renamed field: Items -> LineItems
+		for i, sItem := range src.Items {
+			dst.LineItems[i] = srcItemToDstItem(ctx, sItem) // Calls unexported converter
+		}
+	}
+	return dst
+}
+
+// srcItemToDstItem converts models.SrcItem to models.DstItem.
+// This function is UNEXPORTED.
+func srcItemToDstItem(ctx context.Context, src models.SrcItem) models.DstItem {
+	return models.DstItem{
+		ProductCode: src.SKU,    // Renamed
+		Count:       src.Quantity, // Renamed
+	}
+}
+
+// Example of a function that might be generated or defined if SrcUser itself
+// needed to be converted from another type, perhaps with different rules.
+// For now, this is just to show how one might organize multiple converters.
+// func ConvertLegacyUserToSrcUser(ctx context.Context, legacy LegacyUser) models.SrcUser {
+//    // ... conversion logic ...
+//    return models.SrcUser{}
+//}

--- a/examples/convert/converter/converter.go
+++ b/examples/convert/converter/converter.go
@@ -39,9 +39,11 @@ func ConvertUser(ctx context.Context, src models.SrcUser) models.DstUser {
 	dst.FullName = src.FirstName + " " + src.LastName
 
 	// Address: Embedded struct conversion (calls unexported converter)
+	// SrcUser embeds SrcAddress, DstUser has Address DstAddress
 	dst.Address = srcAddressToDstAddress(ctx, src.SrcAddress)
 
 	// Contact: Nested struct conversion (calls unexported converter)
+	// SrcUser has ContactInfo SrcContact, DstUser has Contact DstContact
 	dst.Contact = srcContactToDstContact(ctx, src.ContactInfo)
 
 	// Details: Slice of structs conversion (calls unexported converter for elements)
@@ -70,8 +72,8 @@ func ConvertUser(ctx context.Context, src models.SrcUser) models.DstUser {
 // but rather a component of DstUser.
 func srcAddressToDstAddress(ctx context.Context, src models.SrcAddress) models.DstAddress {
 	return models.DstAddress{
-		FullStreet: src.Street, // Renamed
-		CityName:   src.City,   // Renamed
+		FullStreet: src.Street, // Renamed: Street -> FullStreet
+		CityName:   src.City,   // Renamed: City -> CityName
 	}
 }
 
@@ -79,7 +81,7 @@ func srcAddressToDstAddress(ctx context.Context, src models.SrcAddress) models.D
 // This function is UNEXPORTED.
 func srcContactToDstContact(ctx context.Context, src models.SrcContact) models.DstContact {
 	dst := models.DstContact{
-		EmailAddress: src.Email, // Renamed
+		EmailAddress: src.Email, // Renamed: Email -> EmailAddress
 	}
 	if src.Phone != nil {
 		dst.PhoneNumber = *src.Phone // Pointer to value
@@ -96,8 +98,8 @@ func srcInternalDetailToDstInternalDetail(ctx context.Context, src models.SrcInt
 	localizedDescription := translateDescription(ctx, src.Description, "jp")
 
 	return models.DstInternalDetail{
-		ItemCode:        src.Code,               // Renamed
-		LocalizedDesc: localizedDescription, // Processed and renamed
+		ItemCode:        src.Code,               // Renamed: Code -> ItemCode
+		LocalizedDesc: localizedDescription, // Processed and Renamed: Description -> LocalizedDesc
 	}
 }
 
@@ -111,8 +113,8 @@ func ConvertOrder(ctx context.Context, src models.SrcOrder) models.DstOrder {
 	}
 
 	dst := models.DstOrder{
-		ID:          src.OrderID,
-		TotalAmount: src.Amount,
+		ID:          src.OrderID, // Renamed: OrderID -> ID
+		TotalAmount: src.Amount,  // Renamed: Amount -> TotalAmount
 	}
 
 	if src.Items != nil {
@@ -128,15 +130,7 @@ func ConvertOrder(ctx context.Context, src models.SrcOrder) models.DstOrder {
 // This function is UNEXPORTED.
 func srcItemToDstItem(ctx context.Context, src models.SrcItem) models.DstItem {
 	return models.DstItem{
-		ProductCode: src.SKU,    // Renamed
-		Count:       src.Quantity, // Renamed
+		ProductCode: src.SKU,      // Renamed: SKU -> ProductCode
+		Count:       src.Quantity, // Renamed: Quantity -> Count
 	}
 }
-
-// Example of a function that might be generated or defined if SrcUser itself
-// needed to be converted from another type, perhaps with different rules.
-// For now, this is just to show how one might organize multiple converters.
-// func ConvertLegacyUserToSrcUser(ctx context.Context, legacy LegacyUser) models.SrcUser {
-//    // ... conversion logic ...
-//    return models.SrcUser{}
-//}

--- a/examples/convert/converter/converter_test.go
+++ b/examples/convert/converter/converter_test.go
@@ -1,0 +1,195 @@
+package converter
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"example.com/convert/models"
+)
+
+func TestConvertUser(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	phone := "123-456-7890"
+	updatedAt := now.Add(time.Hour)
+
+	srcUser := models.SrcUser{
+		ID:        101,
+		FirstName: "John",
+		LastName:  "Doe",
+		SrcAddress: models.SrcAddress{
+			Street: "123 Main St",
+			City:   "Anytown",
+		},
+		ContactInfo: models.SrcContact{
+			Email: "john.doe@example.com",
+			Phone: &phone,
+		},
+		Details: []models.SrcInternalDetail{
+			{Code: 1, Description: "Needs setup"},
+			{Code: 2, Description: "Pending review"},
+		},
+		CreatedAt: now,
+		UpdatedAt: &updatedAt,
+	}
+
+	expectedDstUser := models.DstUser{
+		UserID:   "user-101",
+		FullName: "John Doe",
+		Address: models.DstAddress{
+			FullStreet: "123 Main St",
+			CityName:   "Anytown",
+		},
+		Contact: models.DstContact{
+			EmailAddress: "john.doe@example.com",
+			PhoneNumber:  "123-456-7890",
+		},
+		Details: []models.DstInternalDetail{
+			{ItemCode: 1, LocalizedDesc: "翻訳済み (JP): Needs setup"},
+			{ItemCode: 2, LocalizedDesc: "翻訳済み (JP): Pending review"},
+		},
+		CreatedAt: now.Format(time.RFC3339),
+		UpdatedAt: updatedAt.Format(time.RFC3339),
+	}
+
+	dstUser := ConvertUser(ctx, srcUser)
+
+	if !reflect.DeepEqual(dstUser, expectedDstUser) {
+		t.Errorf("ConvertUser() got = %v, want %v", dstUser, expectedDstUser)
+	}
+}
+
+func TestConvertUser_NilFields(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+
+	srcUser := models.SrcUser{
+		ID:        102,
+		FirstName: "Jane",
+		LastName:  "Doe",
+		SrcAddress: models.SrcAddress{
+			Street: "456 Oak St",
+			City:   "Otherville",
+		},
+		ContactInfo: models.SrcContact{
+			Email: "jane.doe@example.com",
+			Phone: nil, // Nil phone
+		},
+		Details: []models.SrcInternalDetail{
+			{Code: 3, Description: "Urgent"},
+		},
+		CreatedAt: now,
+		UpdatedAt: nil, // Nil UpdatedAt
+	}
+
+	expectedDstUser := models.DstUser{
+		UserID:   "user-102",
+		FullName: "Jane Doe",
+		Address: models.DstAddress{
+			FullStreet: "456 Oak St",
+			CityName:   "Otherville",
+		},
+		Contact: models.DstContact{
+			EmailAddress: "jane.doe@example.com",
+			PhoneNumber:  "N/A", // Default for nil phone
+		},
+		Details: []models.DstInternalDetail{
+			{ItemCode: 3, LocalizedDesc: "翻訳済み (JP): Urgent"},
+		},
+		CreatedAt: now.Format(time.RFC3339),
+		UpdatedAt: "", // Empty string for nil UpdatedAt
+	}
+
+	dstUser := ConvertUser(ctx, srcUser)
+
+	if !reflect.DeepEqual(dstUser, expectedDstUser) {
+		t.Errorf("ConvertUser() with nil fields got = %v, want %v", dstUser, expectedDstUser)
+	}
+}
+
+func TestConvertOrder(t *testing.T) {
+	ctx := context.Background()
+	srcOrder := models.SrcOrder{
+		OrderID: "ORD-001",
+		Amount:  199.99,
+		Items: []models.SrcItem{
+			{SKU: "ITEM001", Quantity: 2},
+			{SKU: "ITEM002", Quantity: 1},
+		},
+	}
+
+	expectedDstOrder := models.DstOrder{
+		ID:          "ORD-001",
+		TotalAmount: 199.99,
+		LineItems: []models.DstItem{
+			{ProductCode: "ITEM001", Count: 2},
+			{ProductCode: "ITEM002", Count: 1},
+		},
+	}
+
+	dstOrder := ConvertOrder(ctx, srcOrder)
+
+	if !reflect.DeepEqual(dstOrder, expectedDstOrder) {
+		t.Errorf("ConvertOrder() got = %v, want %v", dstOrder, expectedDstOrder)
+	}
+}
+
+func TestSrcAddressToDstAddress(t *testing.T) {
+	ctx := context.Background()
+	src := models.SrcAddress{Street: "123 Main St", City: "Anytown"}
+	expected := models.DstAddress{FullStreet: "123 Main St", CityName: "Anytown"}
+	got := srcAddressToDstAddress(ctx, src)
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("srcAddressToDstAddress() = %v, want %v", got, expected)
+	}
+}
+
+func TestSrcContactToDstContact(t *testing.T) {
+	ctx := context.Background()
+	phone := "555-0100"
+	tests := []struct {
+		name     string
+		src      models.SrcContact
+		expected models.DstContact
+	}{
+		{
+			name: "with phone",
+			src:      models.SrcContact{Email: "test@example.com", Phone: &phone},
+			expected: models.DstContact{EmailAddress: "test@example.com", PhoneNumber: "555-0100"},
+		},
+		{
+			name: "nil phone",
+			src:      models.SrcContact{Email: "test2@example.com", Phone: nil},
+			expected: models.DstContact{EmailAddress: "test2@example.com", PhoneNumber: "N/A"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := srcContactToDstContact(ctx, tt.src); !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("srcContactToDstContact() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSrcInternalDetailToDstInternalDetail(t *testing.T) {
+	ctx := context.Background()
+	src := models.SrcInternalDetail{Code: 10, Description: "Test Desc"}
+	expected := models.DstInternalDetail{ItemCode: 10, LocalizedDesc: "翻訳済み (JP): Test Desc"}
+	got := srcInternalDetailToDstInternalDetail(ctx, src)
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("srcInternalDetailToDstInternalDetail() = %v, want %v", got, expected)
+	}
+}
+
+func TestSrcItemToDstItem(t *testing.T) {
+	ctx := context.Background()
+	src := models.SrcItem{SKU: "SKU007", Quantity: 3}
+	expected := models.DstItem{ProductCode: "SKU007", Count: 3}
+	got := srcItemToDstItem(ctx, src)
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("srcItemToDstItem() = %v, want %v", got, expected)
+	}
+}

--- a/examples/convert/go.mod
+++ b/examples/convert/go.mod
@@ -1,0 +1,3 @@
+module example.com/convert
+
+go 1.24.3

--- a/examples/convert/main.go
+++ b/examples/convert/main.go
@@ -6,14 +6,30 @@ import (
 	"fmt"
 	"time"
 
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"example.com/convert/converter" // Adjust module path if different
 	"example.com/convert/models"    // Adjust module path if different
+
+	"github.com/podhmo/go-scan/scanner"
+	typescanner "github.com/podhmo/go-scan"
 )
 
 func main() {
-	ctx := context.Background() // Parent context
+	// Part 1: Run existing examples
+	runConversionExamples()
 
-	// --- Example 1: User Conversion ---
+	// Part 2: Generator Prototype
+	fmt.Println("\n--- Generator Prototype ---")
+	generateConverterPrototype()
+}
+
+func runConversionExamples() {
+	ctx := context.Background() // Parent context
+		// --- Example 1: User Conversion ---
 	fmt.Println("--- User Conversion Example ---")
 	phone := "123-456-7890"
 	srcUser := models.SrcUser{
@@ -94,7 +110,6 @@ func main() {
 	fmt.Println("\nDestination User (with nils handled):")
 	printJSON(dstUserNil)
 	fmt.Println("------------------------------\n")
-
 }
 
 // printJSON is a helper to pretty-print structs as JSON.
@@ -105,4 +120,348 @@ func printJSON(data interface{}) {
 		return
 	}
 	fmt.Println(string(jsonData))
+}
+
+
+func generateConverterPrototype() {
+	// Assuming models are in a 'models' subdirectory relative to this file's package.
+	// Adjust this path as necessary.
+	modelsPath := "./models" // Or an absolute path if needed
+
+	// Get the current working directory to resolve the modelsPath relative to the project root.
+	wd, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("Failed to get current working directory: %v", err)
+	}
+
+	// Construct the full path to the models directory
+	// This assumes the 'examples/convert' directory is the current context for path resolution.
+	// If running from project root, this path needs to be 'examples/convert/models'.
+	// For simplicity, let's assume we are in 'examples/convert' or can resolve it.
+	// A more robust solution would use build tags or configuration.
+
+	// Let's try to locate the 'go-scan' module root to make path resolution more stable.
+	// This is a simplified lookup. A real generator might need more sophisticated path finding.
+	currentDir := wd
+	var projectRoot string
+	for {
+		if _, err := os.Stat(filepath.Join(currentDir, "go.mod")); err == nil {
+			// Check if this go.mod is the main project's go.mod
+			// For this example, we'll assume if it contains "github.com/podhmo/go-scan" it's the one.
+			// This is a heuristic.
+			b, _ := os.ReadFile(filepath.Join(currentDir, "go.mod"))
+			if strings.Contains(string(b), "github.com/podhmo/go-scan") {
+				projectRoot = currentDir
+				break
+			}
+		}
+		parent := filepath.Dir(currentDir)
+		if parent == currentDir {
+			log.Println("Could not reliably find project root containing 'github.com/podhmo/go-scan' in go.mod. Trying relative path.")
+			// Fallback or error if not found, for now, assume relative path works from 'examples/convert'
+			// If running `go run examples/convert/main.go` from project root, wd is projectRoot
+			// and modelsPath should be "examples/convert/models"
+			if strings.HasSuffix(wd, "examples/convert") {
+				modelsPath = filepath.Join(wd, "models")
+			} else {
+				// Try to construct path assuming wd is project root
+				modelsPath = filepath.Join(wd, "examples", "convert", "models")
+				if _, err := os.Stat(modelsPath); os.IsNotExist(err) {
+					log.Fatalf("Models directory not found at %s. Please ensure paths are correct.", modelsPath)
+				}
+			}
+			break // Exit loop if heuristic fails or relative path assumed
+		}
+		currentDir = parent
+	}
+	if projectRoot != "" {
+		modelsPath = filepath.Join(projectRoot, "examples", "convert", "models")
+	}
+
+
+	log.Printf("Scanning models in: %s\n", modelsPath)
+
+	// Create a go-scan Scanner instance.
+	// The first argument to New is a starting path to find the module root (go.mod).
+	// For this example, we'll use the modelsPath itself, assuming it's within a module.
+	s, err := typescanner.New(modelsPath)
+	if err != nil {
+		log.Fatalf("Failed to create scanner: %v", err)
+	}
+
+	// Scan the package containing the models.
+	pkgInfo, err := s.ScanPackage(modelsPath)
+	if err != nil {
+		log.Fatalf("Failed to scan package %s: %v", modelsPath, err)
+	}
+
+	var srcUserType, dstUserType *scanner.TypeInfo
+	var srcOrderType, dstOrderType *scanner.TypeInfo
+	// We'll also need other types for sub-converters
+	var srcAddressType, dstAddressType *scanner.TypeInfo
+	var srcContactType, dstContactType *scanner.TypeInfo
+	var srcInternalDetailType, dstInternalDetailType *scanner.TypeInfo
+	var srcItemType, dstItemType *scanner.TypeInfo
+
+	for _, t := range pkgInfo.Types {
+		switch t.Name {
+		case "SrcUser":
+			srcUserType = t
+		case "DstUser":
+			dstUserType = t
+		case "SrcOrder":
+			srcOrderType = t
+		case "DstOrder":
+			dstOrderType = t
+		case "SrcAddress":
+			srcAddressType = t
+		case "DstAddress":
+			dstAddressType = t
+		case "SrcContact":
+			srcContactType = t
+		case "DstContact":
+			dstContactType = t
+		case "SrcInternalDetail":
+			srcInternalDetailType = t
+		case "DstInternalDetail":
+			dstInternalDetailType = t
+		case "SrcItem":
+			srcItemType = t
+		case "DstItem":
+			dstItemType = t
+		}
+	}
+
+	if srcUserType == nil || dstUserType == nil || srcOrderType == nil || dstOrderType == nil {
+		log.Fatal("One or more top-level source or destination types not found in models package.")
+	}
+
+	// Create a string builder to accumulate the generated code.
+	var sb strings.Builder
+
+	sb.WriteString("package converter\n\n")
+	sb.WriteString("import (\n")
+	sb.WriteString("\t\"context\"\n")
+	sb.WriteString("\t\"fmt\"\n")
+	sb.WriteString("\t\"time\"\n")
+	sb.WriteString("\t\"example.com/convert/models\"\n") // Assuming models are in this path
+	sb.WriteString(")\n\n")
+
+	// Generate User converter
+	if srcUserType != nil && dstUserType != nil {
+		generateStructConverter(&sb, srcUserType, dstUserType, pkgInfo)
+	}
+	// Generate Order converter
+	if srcOrderType != nil && dstOrderType != nil {
+		generateStructConverter(&sb, srcOrderType, dstOrderType, pkgInfo)
+	}
+
+	// Generate necessary sub-converters (helper functions)
+	// In a real generator, we'd only generate these if they are actually needed by top-level converters
+	// and manage their names to avoid conflicts.
+	if srcAddressType != nil && dstAddressType != nil {
+		generateStructConverter(&sb, srcAddressType, dstAddressType, pkgInfo)
+	}
+	if srcContactType != nil && dstContactType != nil {
+		generateStructConverter(&sb, srcContactType, dstContactType, pkgInfo)
+	}
+	if srcInternalDetailType != nil && dstInternalDetailType != nil {
+		generateStructConverter(&sb, srcInternalDetailType, dstInternalDetailType, pkgInfo)
+	}
+	if srcItemType != nil && dstItemType != nil {
+		generateStructConverter(&sb, srcItemType, dstItemType, pkgInfo)
+	}
+
+	// Add the translateDescription helper as it's used by the manual converter
+	sb.WriteString(`
+// translateDescription is a helper function simulating internal processing.
+// In a real scenario, this could be a more complex logic, e.g., calling a translation service.
+func translateDescription(ctx context.Context, text string, targetLang string) string {
+	if targetLang == "jp" {
+		return "翻訳済み (JP): " + text
+	}
+	return text
+}
+`)
+
+
+	// Write the generated code to a file.
+	generatedFilePath := filepath.Join(filepath.Dir(modelsPath), "converter", "generated_converters.go")
+	if err := os.MkdirAll(filepath.Dir(generatedFilePath), 0755); err != nil {
+		log.Fatalf("Failed to create directory for generated converters: %v", err)
+	}
+	err = os.WriteFile(generatedFilePath, []byte(sb.String()), 0644)
+	if err != nil {
+		log.Fatalf("Failed to write generated converters: %v", err)
+	}
+
+	log.Printf("Generated converters successfully at: %s\n", generatedFilePath)
+	fmt.Println("--- Generator Prototype Finished ---")
+}
+
+// generateStructConverter generates conversion function code for a single struct pair.
+func generateStructConverter(sb *strings.Builder, srcType *scanner.TypeInfo, dstType *scanner.TypeInfo, pkgInfo *scanner.PackageInfo) {
+	if srcType.Struct == nil || dstType.Struct == nil {
+		log.Printf("Warning: Skipping generation for %s -> %s as one or both are not structs.\n", srcType.Name, dstType.Name)
+		return
+	}
+
+	// Determine function name (e.g., ConvertSrcUserToDstUser or srcAddressToDstAddress)
+	// A simple heuristic: if Dst type starts with "Dst", assume it's a top-level exported converter.
+	funcName := ""
+	if strings.HasPrefix(dstType.Name, "Dst") && strings.ToUpper(dstType.Name[0:1]) == dstType.Name[0:1] { // Exported
+		funcName = fmt.Sprintf("Convert%sTo%s", stripPrefix(srcType.Name, "Src"), dstType.Name)
+	} else { // Unexported helper
+		funcName = fmt.Sprintf("%sTo%s", camelCase(srcType.Name), strings.Title(dstType.Name))
+	}
+	// Correct common unexported names based on manual converter
+	if srcType.Name == "SrcAddress" && dstType.Name == "DstAddress" { funcName = "srcAddressToDstAddress" }
+	if srcType.Name == "SrcContact" && dstType.Name == "DstContact" { funcName = "srcContactToDstContact" }
+	if srcType.Name == "SrcInternalDetail" && dstType.Name == "DstInternalDetail" { funcName = "srcInternalDetailToDstInternalDetail" }
+	if srcType.Name == "SrcItem" && dstType.Name == "DstItem" { funcName = "srcItemToDstItem" }
+
+
+	sb.WriteString(fmt.Sprintf("// %s converts models.%s to models.%s\n", funcName, srcType.Name, dstType.Name))
+	sb.WriteString(fmt.Sprintf("func %s(ctx context.Context, src models.%s) models.%s {\n", funcName, srcType.Name, dstType.Name))
+	sb.WriteString(fmt.Sprintf("\tif ctx == nil { ctx = context.Background() }\n")) // Ensure context is not nil
+	sb.WriteString(fmt.Sprintf("\tdst := models.%s{}\n", dstType.Name))
+
+	// Field mapping logic (simplified, uses some hardcoded rules from manual_converter.go)
+	for _, dstField := range dstType.Struct.Fields {
+		// Try to find a corresponding source field or logic
+		mapped := false
+		// Rule 1: Specific known mappings (from manual converter)
+		if srcType.Name == "SrcUser" && dstType.Name == "DstUser" {
+			if dstField.Name == "UserID" {
+				sb.WriteString(fmt.Sprintf("\tdst.UserID = fmt.Sprintf(\"user-%%d\", src.ID)\n"))
+				mapped = true
+			} else if dstField.Name == "FullName" {
+				sb.WriteString(fmt.Sprintf("\tdst.FullName = src.FirstName + \" \" + src.LastName\n"))
+				mapped = true
+			} else if dstField.Name == "CreatedAt" {
+				sb.WriteString(fmt.Sprintf("\tdst.CreatedAt = src.CreatedAt.Format(time.RFC3339)\n"))
+				mapped = true
+			} else if dstField.Name == "UpdatedAt" {
+				sb.WriteString(fmt.Sprintf("\tif src.UpdatedAt != nil {\n"))
+				sb.WriteString(fmt.Sprintf("\t\tdst.UpdatedAt = src.UpdatedAt.Format(time.RFC3339)\n"))
+				sb.WriteString(fmt.Sprintf("\t} else {\n"))
+				sb.WriteString(fmt.Sprintf("\t\tdst.UpdatedAt = \"\"\n"))
+				sb.WriteString(fmt.Sprintf("\t}\n"))
+				mapped = true
+			}
+		} else if srcType.Name == "SrcAddress" && dstType.Name == "DstAddress" {
+			if dstField.Name == "FullStreet" { sb.WriteString(fmt.Sprintf("\tdst.FullStreet = src.Street\n")); mapped = true }
+			if dstField.Name == "CityName" { sb.WriteString(fmt.Sprintf("\tdst.CityName = src.City\n")); mapped = true }
+		} else if srcType.Name == "SrcContact" && dstType.Name == "DstContact" {
+			if dstField.Name == "EmailAddress" { sb.WriteString(fmt.Sprintf("\tdst.EmailAddress = src.Email\n")); mapped = true}
+			if dstField.Name == "PhoneNumber" {
+				sb.WriteString(fmt.Sprintf("\tif src.Phone != nil {\n"))
+				sb.WriteString(fmt.Sprintf("\t\tdst.PhoneNumber = *src.Phone\n"))
+				sb.WriteString(fmt.Sprintf("\t} else {\n"))
+				sb.WriteString(fmt.Sprintf("\t\tdst.PhoneNumber = \"N/A\"\n"))
+				sb.WriteString(fmt.Sprintf("\t}\n"))
+				mapped = true
+			}
+		} else if srcType.Name == "SrcInternalDetail" && dstType.Name == "DstInternalDetail" {
+			if dstField.Name == "ItemCode" { sb.WriteString(fmt.Sprintf("\tdst.ItemCode = src.Code\n")); mapped = true}
+			if dstField.Name == "LocalizedDesc" {
+				sb.WriteString(fmt.Sprintf("\tdst.LocalizedDesc = translateDescription(ctx, src.Description, \"jp\") // TODO: Make lang configurable\n"))
+				mapped = true
+			}
+		} else if srcType.Name == "SrcOrder" && dstType.Name == "DstOrder" {
+			if dstField.Name == "ID" { sb.WriteString(fmt.Sprintf("\tdst.ID = src.OrderID\n")); mapped = true}
+			if dstField.Name == "TotalAmount" { sb.WriteString(fmt.Sprintf("\tdst.TotalAmount = src.Amount\n")); mapped = true}
+		} else if srcType.Name == "SrcItem" && dstType.Name == "DstItem" {
+			if dstField.Name == "ProductCode" { sb.WriteString(fmt.Sprintf("\tdst.ProductCode = src.SKU\n")); mapped = true}
+			if dstField.Name == "Count" { sb.WriteString(fmt.Sprintf("\tdst.Count = src.Quantity\n")); mapped = true}
+		}
+
+
+		// Rule 2: Embedded struct conversion
+		if !mapped && dstField.Type.Name == "DstAddress" && srcType.Name == "SrcUser" { // Specific to User embedding Address
+			var srcAddrField *scanner.FieldInfo
+			for _, sf := range srcType.Struct.Fields { if sf.Embedded && sf.Type.Name == "SrcAddress" { srcAddrField = sf; break } }
+			if srcAddrField != nil {
+				sb.WriteString(fmt.Sprintf("\tdst.%s = srcAddressToDstAddress(ctx, src.%s)\n", dstField.Name, srcAddrField.Type.Name /* Usually src.SrcAddress */))
+				mapped = true
+			}
+		}
+
+		// Rule 3: Nested struct conversion
+		if !mapped && dstField.Type.Name == "DstContact" && srcType.Name == "SrcUser" { // Specific to User having ContactInfo
+			var srcContactField *scanner.FieldInfo
+			for _, sf := range srcType.Struct.Fields { if sf.Name == "ContactInfo" && sf.Type.Name == "SrcContact" { srcContactField = sf; break } }
+			if srcContactField != nil {
+				sb.WriteString(fmt.Sprintf("\tdst.%s = srcContactToDstContact(ctx, src.%s)\n", dstField.Name, srcContactField.Name))
+				mapped = true
+			}
+		}
+
+		// Rule 4: Slice of structs conversion
+		if !mapped && dstField.Type.IsSlice {
+			srcFieldName := dstField.Name // Try direct name match first for slice
+			if srcType.Name == "SrcOrder" && dstField.Name == "LineItems" { srcFieldName = "Items" } // Specific rename for Order:Items -> LineItems
+
+			var srcSliceField *scanner.FieldInfo
+			for _, sf := range srcType.Struct.Fields {
+				if sf.Name == srcFieldName && sf.Type.IsSlice {
+					srcSliceField = sf
+					break
+				}
+			}
+			if srcSliceField != nil && srcSliceField.Type.Elem != nil && dstField.Type.Elem != nil {
+				elemConvertFunc := fmt.Sprintf("%sTo%s", camelCase(srcSliceField.Type.Elem.Name), strings.Title(dstField.Type.Elem.Name))
+				// Correct common unexported names based on manual converter
+				if srcSliceField.Type.Elem.Name == "SrcInternalDetail" && dstField.Type.Elem.Name == "DstInternalDetail" { elemConvertFunc = "srcInternalDetailToDstInternalDetail"}
+				if srcSliceField.Type.Elem.Name == "SrcItem" && dstField.Type.Elem.Name == "DstItem" { elemConvertFunc = "srcItemToDstItem"}
+
+				sb.WriteString(fmt.Sprintf("\tif src.%s != nil {\n", srcSliceField.Name))
+				sb.WriteString(fmt.Sprintf("\t\tdst.%s = make([]models.%s, len(src.%s))\n", dstField.Name, dstField.Type.Elem.Name, srcSliceField.Name))
+				sb.WriteString(fmt.Sprintf("\t\tfor i, sElem := range src.%s {\n", srcSliceField.Name))
+				sb.WriteString(fmt.Sprintf("\t\t\tdst.%s[i] = %s(ctx, sElem)\n", dstField.Name, elemConvertFunc))
+				sb.WriteString(fmt.Sprintf("\t\t}\n"))
+				sb.WriteString(fmt.Sprintf("\t}\n"))
+				mapped = true
+			}
+		}
+
+		// Rule 5: Direct name and type match (fallback)
+		if !mapped {
+			for _, srcField := range srcType.Struct.Fields {
+				if normalizeFieldName(dstField.Name) == normalizeFieldName(srcField.Name) {
+					if srcField.Type.Name == dstField.Type.Name && !srcField.Type.IsMap && !srcField.Type.IsSlice && !dstField.Type.IsPointer && !srcField.Type.IsPointer { // Simple types
+						sb.WriteString(fmt.Sprintf("\tdst.%s = src.%s\n", dstField.Name, srcField.Name))
+						mapped = true
+						break
+					}
+				}
+			}
+		}
+
+
+		if !mapped {
+			sb.WriteString(fmt.Sprintf("\t// TODO: No mapping found for dst.%s (Type: %s)\n", dstField.Name, dstField.Type.Name))
+		}
+	}
+
+	sb.WriteString("\treturn dst\n")
+	sb.WriteString("}\n\n")
+}
+
+func stripPrefix(name, prefix string) string {
+	if strings.HasPrefix(name, prefix) {
+		return name[len(prefix):]
+	}
+	return name
+}
+
+func camelCase(s string) string {
+	if s == "" {
+		return ""
+	}
+	return strings.ToLower(s[0:1]) + s[1:]
+}
+
+func normalizeFieldName(name string) string {
+	return strings.ToLower(strings.ReplaceAll(name, "_", ""))
 }

--- a/examples/convert/main.go
+++ b/examples/convert/main.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"example.com/convert/converter" // Adjust module path if different
+	"example.com/convert/models"    // Adjust module path if different
+)
+
+func main() {
+	ctx := context.Background() // Parent context
+
+	// --- Example 1: User Conversion ---
+	fmt.Println("--- User Conversion Example ---")
+	phone := "123-456-7890"
+	srcUser := models.SrcUser{
+		ID:        101,
+		FirstName: "John",
+		LastName:  "Doe",
+		SrcAddress: models.SrcAddress{
+			Street: "123 Main St",
+			City:   "Anytown",
+		},
+		ContactInfo: models.SrcContact{
+			Email: "john.doe@example.com",
+			Phone: &phone,
+		},
+		Details: []models.SrcInternalDetail{
+			{Code: 1, Description: "Needs setup"},
+			{Code: 2, Description: "Pending review"},
+		},
+		CreatedAt: time.Now().Add(-24 * time.Hour), // Yesterday
+		UpdatedAt: func() *time.Time { t := time.Now(); return &t }(),
+	}
+
+	// Perform the conversion
+	dstUser := converter.ConvertUser(ctx, srcUser)
+
+	// Print the results (using JSON for readability)
+	fmt.Println("Source User:")
+	printJSON(srcUser)
+	fmt.Println("\nDestination User:")
+	printJSON(dstUser)
+	fmt.Println("------------------------------\n")
+
+	// --- Example 2: Order Conversion ---
+	fmt.Println("--- Order Conversion Example ---")
+	srcOrder := models.SrcOrder{
+		OrderID: "ORD-001",
+		Amount:  199.99,
+		Items: []models.SrcItem{
+			{SKU: "ITEM001", Quantity: 2},
+			{SKU: "ITEM002", Quantity: 1},
+		},
+	}
+
+	// Perform the conversion
+	dstOrder := converter.ConvertOrder(ctx, srcOrder)
+
+	// Print the results
+	fmt.Println("Source Order:")
+	printJSON(srcOrder)
+	fmt.Println("\nDestination Order:")
+	printJSON(dstOrder)
+	fmt.Println("------------------------------\n")
+
+	// --- Example 3: User with nil fields ---
+	fmt.Println("--- User Conversion with Nil Phone and UpdatedAt ---")
+	srcUserNil := models.SrcUser{
+		ID:        102,
+		FirstName: "Jane",
+		LastName:  "Doe",
+		SrcAddress: models.SrcAddress{
+			Street: "456 Oak St",
+			City:   "Otherville",
+		},
+		ContactInfo: models.SrcContact{
+			Email: "jane.doe@example.com",
+			Phone: nil, // Nil phone
+		},
+		Details: []models.SrcInternalDetail{
+			{Code: 3, Description: "Urgent"},
+		},
+		CreatedAt: time.Now().Add(-48 * time.Hour),
+		UpdatedAt: nil, // Nil UpdatedAt
+	}
+
+	dstUserNil := converter.ConvertUser(ctx, srcUserNil)
+	fmt.Println("Source User (with nils):")
+	printJSON(srcUserNil)
+	fmt.Println("\nDestination User (with nils handled):")
+	printJSON(dstUserNil)
+	fmt.Println("------------------------------\n")
+
+}
+
+// printJSON is a helper to pretty-print structs as JSON.
+func printJSON(data interface{}) {
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		fmt.Printf("Error marshalling to JSON: %v\n", err)
+		return
+	}
+	fmt.Println(string(jsonData))
+}

--- a/examples/convert/mapping/mapping.minigo
+++ b/examples/convert/mapping/mapping.minigo
@@ -1,131 +1,123 @@
 // This is a conceptual file demonstrating a minigo-like syntax for go-scan.
-// The actual syntax and capabilities would depend on the go-scan library.
+// The actual syntax and capabilities would depend on the go-scan library
+// and the generator that consumes this DSL.
 
-package converter
+package converter // Target package for generated converters (if any)
 
-import (
-	"example.com/convert/models"
-	"context"
-	"fmt"
-	"strings"
-	"time"
-)
-
-// Configuration for the converter generator
-// topLevel defines which types get exported converters.
-// Other types will have unexported converters by default.
-option "topLevel" = [
-	models.DstUser{},
-	models.DstOrder{},
+// Option to declare which destination types should have top-level (exported)
+// converter functions generated. Other conversions might result in unexported helper functions.
+option "topLevelTypes" = [
+	"example.com/convert/models.DstUser",
+	"example.com/convert/models.DstOrder",
 ]
 
-// --- User Conversion ---
+// Option to define global import aliases for this mapping file.
+// These can be overridden or augmented by specific converter definitions.
+option "imports" = {
+	"models": "example.com/convert/models",
+	"stdtime": "time", // Alias for standard time package
+	"customfmt": "example.com/convert/util/formatter", // Example custom package
+}
 
-// Convert SrcUser to DstUser
-// The 'convert' keyword indicates a mapping.
-// The function signature shows that context is passed.
-convert ConvertUser(ctx context.Context, src models.SrcUser) models.DstUser {
-	dst models.DstUser
+// --- Conversion Rule Definitions ---
 
-	// Direct mapping with potential type conversion
-	dst.UserID = fmt.Sprintf("user-%d", src.ID) // int64 to string with formatting
+// Rule for converting SrcUser to DstUser
+// 'convert' keyword indicates a mapping between two types.
+// The generator would use go-scan to get details for models.SrcUser and models.DstUser.
+convert models.SrcUser to models.DstUser {
+	// Field mappings:
+	// LHS: DstUser field, RHS: Expression using 'src' (instance of SrcUser)
 
-	// Combining fields
-	dst.FullName = src.FirstName + " " + src.LastName
-
-	// Embedded struct mapping (explicitly call sub-converter)
-	// The generator would understand to call srcAddressToDstAddress
-	dst.Address = convertSrcAddressToDstAddress(ctx, src.SrcAddress)
-
-	// Nested struct mapping (explicitly call sub-converter)
-	// The generator would understand to call srcContactToDstContact
-	dst.Contact = convertSrcContactToDstContact(ctx, src.ContactInfo)
-
-	// Slice mapping with element conversion
-	// The generator would understand to call srcInternalDetailToDstInternalDetail for each element
-	dst.Details = make([]models.DstInternalDetail, len(src.Details))
-	for i, sDetail := range src.Details {
-		dst.Details[i] = convertSrcInternalDetailToDstInternalDetail(ctx, sDetail)
+	UserID: fmt.Sprintf("user-%d", src.ID)                               // Type change (int64 to string) and formatting
+	FullName: src.FirstName + " " + src.LastName                         // Combining fields
+	Address: convertTo(models.DstAddress, src.SrcAddress)                 // Delegate to another converter for embedded/nested struct
+	Contact: convertTo(models.DstContact, src.ContactInfo)                // Delegate for nested struct
+	Details: mapSlice(src.Details, models.DstInternalDetail)              // Delegate for slice elements
+	CreatedAt: src.CreatedAt.Format(stdtime.RFC3339)                      // Type change (time.Time to string)
+	UpdatedAt: {                                                          // Block for more complex logic (e.g. pointer handling)
+		if src.UpdatedAt != nil {
+			return src.UpdatedAt.Format(stdtime.RFC3339)
+		}
+		return ""
 	}
 
-	// Time to string conversion (custom logic or built-in)
-	dst.CreatedAt = src.CreatedAt.Format(time.RFC3339)
-	if src.UpdatedAt != nil {
-		dst.UpdatedAt = src.UpdatedAt.Format(time.RFC3339)
-	} else {
-		dst.UpdatedAt = "" // Handle nil pointer
+	// Implicit mappings:
+	// If a field in DstUser has the same name (after normalization) and compatible type
+	// as a field in SrcUser, the generator could map it automatically.
+	// This DSL could have an option to enable/disable or configure auto-mapping.
+	// option "autoMap" = true (default)
+}
+
+// Rule for converting SrcAddress to DstAddress (likely unexported helper)
+convert models.SrcAddress to models.DstAddress {
+	FullStreet: src.Street          // Renaming: Street -> FullStreet
+	CityName: src.City              // Renaming: City -> CityName
+}
+
+// Rule for converting SrcContact to DstContact (likely unexported helper)
+convert models.SrcContact to models.DstContact {
+	EmailAddress: src.Email         // Renaming
+	PhoneNumber: {
+		if src.Phone != nil {
+			return *src.Phone
+		}
+		return "N/A"
 	}
-	return dst
 }
 
-// Convert SrcAddress to DstAddress (unexported by default as it's not topLevel)
-convert srcAddressToDstAddress(ctx context.Context, src models.SrcAddress) models.DstAddress {
-	dst models.DstAddress
-	dst.FullStreet = src.Street // Example of renaming
-	dst.CityName = src.City     // Example of renaming
-	return dst
+// Rule for converting SrcInternalDetail to DstInternalDetail
+// This demonstrates calling an "external" Go function for part of the logic.
+convert models.SrcInternalDetail to models.DstInternalDetail {
+	ItemCode: src.Code              // Renaming
+	LocalizedDesc: call("github.com/podhmo/go-scan/examples/convert/converter.translateDescription", ctx, src.Description, "jp")
+	// The 'call' keyword would instruct the generator to produce a Go function call.
+	// The generator would need to ensure 'translateDescription' is accessible and manage imports.
+	// 'ctx' is assumed to be available in the generated converter's scope.
 }
 
-// Convert SrcContact to DstContact (unexported)
-convert srcContactToDstContact(ctx context.Context, src models.SrcContact) models.DstContact {
-	dst models.DstContact
-	dst.EmailAddress = src.Email
-	if src.Phone != nil {
-		dst.PhoneNumber = *src.Phone // Pointer to value
-	} else {
-		dst.PhoneNumber = "N/A" // Handle nil pointer
-	}
-	return dst
+// Rule for SrcOrder to DstOrder
+convert models.SrcOrder to models.DstOrder {
+	ID: src.OrderID
+	TotalAmount: src.Amount
+	LineItems: mapSlice(src.Items, models.DstItem) // mapSlice implies converting each element
 }
 
-// Convert SrcInternalDetail to DstInternalDetail (unexported)
-// This demonstrates a placeholder for more complex internal processing.
-convert srcInternalDetailToDstInternalDetail(ctx context.Context, src models.SrcInternalDetail) models.DstInternalDetail {
-	dst models.DstInternalDetail
-	dst.ItemCode = src.Code
-
-	// Placeholder for internal processing, e.g., translation
-	// In a real scenario, this might call a service or another function.
-	// For this example, we'll simulate it.
-	// Assume translateDescription is a helper function available in the generation scope.
-	dst.LocalizedDesc = translateDescription(ctx, src.Description, "jp")
-
-	return dst
-}
-
-// --- Order Conversion ---
-
-// Convert SrcOrder to DstOrder
-convert ConvertOrder(ctx context.Context, src models.SrcOrder) models.DstOrder {
-	dst models.DstOrder
-	dst.ID = src.OrderID
-	dst.TotalAmount = src.Amount
-
-	dst.LineItems = make([]models.DstItem, len(src.Items))
-	for i, sItem := range src.Items {
-		dst.LineItems[i] = convertSrcItemToDstItem(ctx, sItem)
-	}
-	return dst
-}
-
-// Convert SrcItem to DstItem (unexported)
-convert srcSrcItemToDstItem(ctx context.Context, src models.SrcItem) models.DstItem {
-	dst models.DstItem
-	dst.ProductCode = src.SKU
-	dst.Count = src.Quantity
-	return dst
+// Rule for SrcItem to DstItem
+convert models.SrcItem to models.DstItem {
+	ProductCode: src.SKU
+	Count: src.Quantity
 }
 
 
-// --- Helper functions (conceptual) ---
-// These would be functions that the generated code could call.
-// Their actual implementation would be provided by the user or another library.
+// --- Potentially, define reusable conversion functions within the DSL itself ---
+// These could be translated into actual Go helper functions by the generator.
 
-func translateDescription(ctx context.Context, text string, targetLang string) string {
-	// In a real application, this would call a translation service.
-	// This is a mock implementation.
-	if targetLang == "jp" {
-		return "翻訳済み: " + text
-	}
-	return text
+func StringToInt(s string) (int, error) {
+	// This is minigo-like Go code that the generator would parse
+	// and either embed or create as a Go function.
+	// import "strconv" // Generator would need to track imports for this block
+	// return strconv.Atoi(s)
+	// For now, this is highly conceptual for this DSL.
+	// The 'call' mechanism for existing Go functions is more practical initially.
 }
+
+// --- Advanced Concepts (Future Ideas for DSL) ---
+
+// Conditional mapping:
+// convert A to B {
+//   FieldX: if src.Type == "TypeA" { return src.ValueA } else { return src.ValueB }
+// }
+
+// Ignoring fields:
+// convert A to B {
+//   ignore FieldZ // DstUser.FieldZ will not be mapped
+//   ignore src.OldField // SrcUser.OldField will not be used for auto-mapping
+// }
+
+// Custom mapping functions defined inline (very complex for a simple DSL):
+// convert A to B {
+//   ComplexField: func(s A) string {
+//     // minigo code for transformation
+//     return "complex_value_from_" + s.SomeProperty
+//   }(src)
+// }

--- a/examples/convert/mapping/mapping.minigo
+++ b/examples/convert/mapping/mapping.minigo
@@ -1,0 +1,131 @@
+// This is a conceptual file demonstrating a minigo-like syntax for go-scan.
+// The actual syntax and capabilities would depend on the go-scan library.
+
+package converter
+
+import (
+	"example.com/convert/models"
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Configuration for the converter generator
+// topLevel defines which types get exported converters.
+// Other types will have unexported converters by default.
+option "topLevel" = [
+	models.DstUser{},
+	models.DstOrder{},
+]
+
+// --- User Conversion ---
+
+// Convert SrcUser to DstUser
+// The 'convert' keyword indicates a mapping.
+// The function signature shows that context is passed.
+convert ConvertUser(ctx context.Context, src models.SrcUser) models.DstUser {
+	dst models.DstUser
+
+	// Direct mapping with potential type conversion
+	dst.UserID = fmt.Sprintf("user-%d", src.ID) // int64 to string with formatting
+
+	// Combining fields
+	dst.FullName = src.FirstName + " " + src.LastName
+
+	// Embedded struct mapping (explicitly call sub-converter)
+	// The generator would understand to call srcAddressToDstAddress
+	dst.Address = convertSrcAddressToDstAddress(ctx, src.SrcAddress)
+
+	// Nested struct mapping (explicitly call sub-converter)
+	// The generator would understand to call srcContactToDstContact
+	dst.Contact = convertSrcContactToDstContact(ctx, src.ContactInfo)
+
+	// Slice mapping with element conversion
+	// The generator would understand to call srcInternalDetailToDstInternalDetail for each element
+	dst.Details = make([]models.DstInternalDetail, len(src.Details))
+	for i, sDetail := range src.Details {
+		dst.Details[i] = convertSrcInternalDetailToDstInternalDetail(ctx, sDetail)
+	}
+
+	// Time to string conversion (custom logic or built-in)
+	dst.CreatedAt = src.CreatedAt.Format(time.RFC3339)
+	if src.UpdatedAt != nil {
+		dst.UpdatedAt = src.UpdatedAt.Format(time.RFC3339)
+	} else {
+		dst.UpdatedAt = "" // Handle nil pointer
+	}
+	return dst
+}
+
+// Convert SrcAddress to DstAddress (unexported by default as it's not topLevel)
+convert srcAddressToDstAddress(ctx context.Context, src models.SrcAddress) models.DstAddress {
+	dst models.DstAddress
+	dst.FullStreet = src.Street // Example of renaming
+	dst.CityName = src.City     // Example of renaming
+	return dst
+}
+
+// Convert SrcContact to DstContact (unexported)
+convert srcContactToDstContact(ctx context.Context, src models.SrcContact) models.DstContact {
+	dst models.DstContact
+	dst.EmailAddress = src.Email
+	if src.Phone != nil {
+		dst.PhoneNumber = *src.Phone // Pointer to value
+	} else {
+		dst.PhoneNumber = "N/A" // Handle nil pointer
+	}
+	return dst
+}
+
+// Convert SrcInternalDetail to DstInternalDetail (unexported)
+// This demonstrates a placeholder for more complex internal processing.
+convert srcInternalDetailToDstInternalDetail(ctx context.Context, src models.SrcInternalDetail) models.DstInternalDetail {
+	dst models.DstInternalDetail
+	dst.ItemCode = src.Code
+
+	// Placeholder for internal processing, e.g., translation
+	// In a real scenario, this might call a service or another function.
+	// For this example, we'll simulate it.
+	// Assume translateDescription is a helper function available in the generation scope.
+	dst.LocalizedDesc = translateDescription(ctx, src.Description, "jp")
+
+	return dst
+}
+
+// --- Order Conversion ---
+
+// Convert SrcOrder to DstOrder
+convert ConvertOrder(ctx context.Context, src models.SrcOrder) models.DstOrder {
+	dst models.DstOrder
+	dst.ID = src.OrderID
+	dst.TotalAmount = src.Amount
+
+	dst.LineItems = make([]models.DstItem, len(src.Items))
+	for i, sItem := range src.Items {
+		dst.LineItems[i] = convertSrcItemToDstItem(ctx, sItem)
+	}
+	return dst
+}
+
+// Convert SrcItem to DstItem (unexported)
+convert srcSrcItemToDstItem(ctx context.Context, src models.SrcItem) models.DstItem {
+	dst models.DstItem
+	dst.ProductCode = src.SKU
+	dst.Count = src.Quantity
+	return dst
+}
+
+
+// --- Helper functions (conceptual) ---
+// These would be functions that the generated code could call.
+// Their actual implementation would be provided by the user or another library.
+
+func translateDescription(ctx context.Context, text string, targetLang string) string {
+	// In a real application, this would call a translation service.
+	// This is a mock implementation.
+	if targetLang == "jp" {
+		return "翻訳済み: " + text
+	}
+	return text
+}

--- a/examples/convert/models/models.go
+++ b/examples/convert/models/models.go
@@ -1,0 +1,84 @@
+package models
+
+import "time"
+
+// --- Source Structs ---
+
+type SrcAddress struct {
+	Street string
+	City   string
+}
+
+type SrcContact struct {
+	Email string
+	Phone *string // Pointer to allow for nil
+}
+
+type SrcInternalDetail struct {
+	Code        int
+	Description string // This might need "translation"
+}
+
+type SrcUser struct {
+	ID        int64
+	FirstName string
+	LastName  string
+	SrcAddress
+	ContactInfo SrcContact
+	Details     []SrcInternalDetail
+	CreatedAt   time.Time
+	UpdatedAt *time.Time
+}
+
+// --- Destination Structs ---
+
+type DstAddress struct {
+	FullStreet string // Different name
+	CityName   string // Different name
+}
+
+type DstContact struct {
+	EmailAddress string // Different name
+	PhoneNumber  string // Pointer to value
+}
+
+// DstInternalDetail is an example of a type that might have an unexported converter
+// if it's only used within the DstUser conversion.
+type DstInternalDetail struct {
+	ItemCode        int    // Different name
+	LocalizedDesc string // Different name, implies processing
+}
+
+// DstUser is a "top-level type" for which an exported converter will be generated.
+type DstUser struct {
+	UserID    string // Different type (int64 to string)
+	FullName  string // Combination of FirstName and LastName
+	Address   DstAddress
+	Contact   DstContact
+	Details   []DstInternalDetail
+	CreatedAt string // Different type (time.Time to string)
+	UpdatedAt string // Pointer to value, different type
+}
+
+// Another top-level type for demonstrating multiple exported converters
+type SrcOrder struct {
+	OrderID string
+	Amount  float64
+	Items   []SrcItem
+}
+
+type SrcItem struct {
+	SKU      string
+	Quantity int
+}
+
+type DstOrder struct {
+	ID          string
+	TotalAmount float64
+	LineItems   []DstItem // Different name
+}
+
+type DstItem struct {
+	ProductCode string // Different name
+	Count       int    // Different name
+}

--- a/examples/convert/todo.md
+++ b/examples/convert/todo.md
@@ -1,0 +1,38 @@
+# TODO: Go Type Conversion Code Generation with go-scan
+
+## Main Objective
+
+Utilize the `go-scan` library to generate code for converting from one specific Go type to another.
+
+## Specific Requirements for Conversion Code
+
+*   **Source and Destination Types**: Must support `src` (source) and `dst` (destination) structs.
+*   **Field Handling**:
+    *   Must handle `embedded` fields.
+    *   Must support arbitrary field names (i.e., names can differ between `src` and `dst`).
+*   **Context Propagation**: Conversion functions should be able to accept a `context.Context` argument.
+*   **Internal Processing**: Allow for the integration of internal processing steps within the conversion logic (e.g., translating text from English to Japanese).
+*   **Conversion Function Visibility**:
+    *   Conversion functions for specified "top-level types" should be `exported`.
+    *   Conversion functions for other internal types should be `unexported`.
+    *   The criteria for what constitutes a "top-level type" are yet to be determined.
+
+## Current Challenges / Open Questions
+
+### 1. Location of Conversion Functions
+
+*   **Options**:
+    *   Define in a separate package.
+    *   Define as methods on either the source type or the destination type.
+*   **Primary Use Case**: Conversion to DTOs (Data Transfer Objects).
+*   **Reason for Conversion**: To handle subtle differences in structure (e.g., a field defined as a pointer in `src` becomes a value type in `dst`). The behavior for `nil` pointer-to-value conversions needs further detailing.
+
+### 2. Describing `src` to `dst` Relationships (Core Issue for this Example)
+
+*   **Goal**: Find a convenient way to describe these relationships for `go-scan`.
+*   **Alternatives Considered**:
+    *   A DSL similar to `minigo` (a subset of Go).
+    *   Using marker comments (e.g., specific keywords in comments).
+*   **Current Leaning**: A `minigo`-like approach is preferred over marker comments because:
+    *   Marker comments lack IDE autocompletion.
+    *   Typos in marker comments would likely lead to runtime errors, which are harder to detect than compile-time errors potentially offered by a DSL.


### PR DESCRIPTION
This commit introduces a new example in `examples/convert` that demonstrates how type conversion functions could be generated and used, addressing requirements such as:

- Handling source and destination structs with differing field names and types.
- Managing embedded fields.
- Passing `context.Context` through conversion functions.
- Incorporating internal processing steps (e.g., simulated translation).
- Differentiating between exported (top-level) and unexported (internal) conversion functions.

The example includes:
- `models.go`: Source and destination struct definitions.
- `mapping.minigo`: A conceptual DSL file illustrating how mappings might be defined for a tool like `go-scan`.
- `converter.go`: Manually implemented conversion functions that mimic generated code.
- `main.go`: A program to demonstrate the usage of the converters.
- `todo.md`: Outlines the objectives and challenges related to this type conversion task.
- `go.mod`: Go module file for the example.