### PR TITLE
Refactor examples/convert2 to use go-scan library

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -108,8 +108,63 @@ To address this, a utility struct `goscan.ImportManager` was introduced within t
 *   **Reduced Boilerplate**: Generators no longer need to implement their own complex import tracking and alias resolution logic.
 *   **Consistency**: Ensures a consistent approach to alias generation and conflict handling across different generators using `go-scan`.
 *   **Improved Robustness**: Centralized logic is easier to test thoroughly, leading to more reliable import management. The `ImportManager` includes specific handling for keywords, invalid identifiers, and common path-based naming issues.
-*   **Simpler Generator Code**: The client code in generators (like `examples/derivingjson/main.go`) becomes cleaner as they can delegate import path and type qualification Nasıls to the `ImportManager`.
+*   **Simpler Generator Code**: The client code in generators (like `examples/derivingjson/main.go`) becomes cleaner as they can delegate import path and type qualification to the `ImportManager`.
 
 **Application:**
 
 The `ImportManager` was successfully integrated into `examples/derivingjson/main.go` and `examples/derivingbind/main.go`, significantly simplifying their import management sections. The development process involved iterative refinement of the alias generation rules within `ImportManager.Add` based on test cases covering various scenarios (keyword clashes, dot/hyphen in package names, alias conflicts).
+
+---
+
+## Refactoring `examples/convert2` to Use `go-scan`
+
+**Context:**
+
+The `examples/convert2` tool, a code generator for struct conversions, initially used `go/parser` directly to parse Go source files and build its internal model of types and conversion rules. This refactoring effort aimed to replace the direct `go/parser` usage with the `go-scan` library (the parent module) to leverage its AST parsing capabilities and potentially simplify `convert2`'s parser logic.
+
+**Key Changes and Learnings:**
+
+1.  **Integration of `go-scan`:**
+    *   The `convert2/parser.ParseDirectory` function was modified to use `goscan.New()` to initialize a `go-scan` scanner and then `scanner.ScanPackage()` to get `scannermodel.PackageInfo`.
+    *   This provided `convert2` with structured information about types (`scannermodel.TypeInfo`), fields (`scannermodel.FieldInfo`), and access to AST nodes (`PackageInfo.AstFiles`, `TypeInfo.Node`) without needing to manage `go/parser` or `token.FileSet` directly within `convert2`.
+
+2.  **Type Information Mapping (`convertScannerTypeToModelType`):**
+    *   `go-scan` provides type information primarily through `scannermodel.FieldType` (for field types, underlying types of aliases, etc.) and `scannermodel.TypeInfo` (for type definitions).
+    *   A crucial part of the refactoring was creating a new helper function, `convertScannerTypeToModelType`, in `convert2/parser.go`. This function translates `scannermodel.FieldType` instances into `convert2`'s own `model.TypeInfo` structure.
+    *   **Responsibility for Resolution**: `go-scan` performs AST-level parsing but not full `go/types`-style type resolution. This means that while `go-scan` can identify that a field is `*foo.Bar`, the `convert2` layer is still responsible for:
+        *   Determining the simple name ("Bar"), package alias ("foo"), and full import path for "foo".
+        *   Constructing the `FullName` (e.g., "path/to/foo.Bar") for `model.TypeInfo`.
+        *   Handling built-in types, pointers, slices, and maps by recursively calling `convertScannerTypeToModelType` for element/key/value types.
+    *   The `scannermodel.FieldType` provides `Name` (which can be "pkg.Type" or "Type"), `PkgName` (alias), and `FullImportPath()`. Logic was added to correctly derive the simple name and fully qualified name for `model.TypeInfo`.
+    *   A specific challenge was handling pointer types: `go-scan`'s `FieldType` for `*T` has `IsPointer=true` and its `Name` relates to `T`. The `convertScannerTypeToModelType` function had to be careful to construct the `Elem` field of `model.TypeInfo` for `*T` by effectively describing `T` based on the information in the `FieldType` for `*T`.
+
+3.  **Comment Directive Parsing:**
+    *   `go-scan`'s `PackageInfo.AstFiles` provides access to the `*ast.File` nodes. This allowed `convert2` to continue using its existing logic for parsing `// convert:pair` and `// convert:rule` directives from comments (`fileAst.Doc`, `fileAst.Comments`).
+    *   The `resolveTypeFromString` function in `convert2/parser.go`, which resolves type names found in comment directives (e.g., `"mypkg.MyType"`), was rewritten. Instead of parsing the string to an `ast.Expr` and then using a complex AST-based resolver, it now:
+        *   Handles prefixes like `*`, `[]`, `map[]` through string manipulation and recursive calls.
+        *   For identifiers, it checks if the type is a known basic type.
+        *   For local types (e.g., "MyType" or "currentPackageName.MyType"), it looks up the type in the `parsedInfo.Structs` and `parsedInfo.NamedTypes` maps (which were populated from `go-scan`'s output).
+        *   For external types (e.g., "alias.ExtType"), it uses the file's import map (passed to it) to find the full import path for "alias" and constructs a `model.TypeInfo` representing the external type.
+
+4.  **Struct Field Tag Processing:**
+    *   `scannermodel.FieldInfo` (from `go-scan`) provides the full struct tag string via its `Tag` field.
+    *   A helper `extractConvertTag(fullTag string) string` was added to `convert2/parser.go` to specifically extract the content of the `convert:"..."` part from the full tag string.
+    *   The existing `parseFieldTag(convertContent string) model.ConvertTag` function then parses this extracted content. This removed the need for `convert2` to access the `*ast.Field` node directly for tag parsing.
+
+5.  **`go.mod` Configuration:**
+    *   Since `examples/convert2` now imports `github.com/podhmo/go-scan` (the parent module), its `go.mod` file required a `replace` directive: `replace github.com/podhmo/go-scan => ../../`.
+
+6.  **Testing and Debugging Insights:**
+    *   The refactoring significantly changed how type information is gathered. Iterative testing (`make test` within `examples/convert2`) was essential.
+    *   Initial test failures in the generated code were traced back to how `model.TypeInfo` (especially `FullName` and `Elem` for pointers) was being populated by `convertScannerTypeToModelType`.
+    *   Temporarily adding detailed debug prints (as comments) into the code generator (`generator.go`) to inspect the `model.TypeInfo` fields for problematic conversions was key to diagnosing mismatches in `elementsMatch` conditions.
+
+**Outcome:**
+
+The refactoring successfully integrated `go-scan` as the primary parsing engine for `examples/convert2`, simplifying its direct AST manipulation logic. While `convert2` still retains significant responsibility for interpreting `go-scan`'s output into its specific internal model, the foundational parsing is now delegated. The process highlighted the importance of clear contracts for the type information provided by `go-scan` and meticulous mapping in the consuming tool.
+
+**Troubleshooting Notes for `convert2` Refactoring:**
+
+*   **`undefined: variable` error**: During development, encountered perplexing compiler errors where a variable defined in an outer scope was reported as `undefined` on lines where it was being reassigned within an inner `if` block. This was resolved by ensuring the variable name was absolutely identical (no typos or invisible characters) across its definition and all uses/assignments. Using a temporary variable for intermediate results before assigning back to the main variable in the `if` block also helped clarify the scope and assignment.
+*   **`scannermodel.FieldType` interpretation**: Correctly interpreting the fields of `go-scan`'s `scannermodel.FieldType` (like `Name`, `PkgName`, and how `Elem` is used for pointers vs. slices/maps) was crucial for the `convertScannerTypeToModelType` translator function. For pointer types (`*T`), `FieldType.IsPointer` is true, and `FieldType.Name` refers to `T`'s name (possibly qualified); `FieldType.Elem` is *not* used for the pointed-to type in this case for `go-scan`'s model. `convert2`'s `model.TypeInfo` for `*T`, however, *does* use an `Elem` field to describe `T`. This mapping required careful implementation.
+*   **Remaining Warnings**: Some warnings like `WARN Unhandled type expression type=*ast.Ellipsis` and `WARN Package alias not found in file imports alias=simple typeStr=simple.MyTime` (for specific global rule patterns) may still appear during parsing. The ellipsis warning likely originates from `go-scan`'s parsing of standard library or other dependencies and doesn't affect `convert2`'s current test cases. The package alias warning for global rules might indicate that `resolveTypeFromString` could be further improved for types qualified with the current package's own name in rule definitions. These did not break tests but point to areas for future robustness improvements in the parser or `go-scan`.

--- a/examples/convert2/go.mod
+++ b/examples/convert2/go.mod
@@ -1,5 +1,11 @@
 module example.com/convert2
 
-go 1.21
+go 1.24
+
+toolchain go1.24.3
 
 // Replace with your actual Go version if different
+
+require github.com/podhmo/go-scan v0.0.0
+
+replace github.com/podhmo/go-scan => ../../

--- a/examples/convert2/testdata/simple/simple_gen.go
+++ b/examples/convert2/testdata/simple/simple_gen.go
@@ -70,7 +70,8 @@ func srcSimpleToDstSimple(ec *errorCollector, src SrcSimple) DstSimple {
 		return dst
 	}
 
-	// Mapping field SrcSimple.ID to DstSimple.ID
+	// Mapping field SrcSimple.ID (int) to DstSimple.ID (int)
+	// Src: Ptr=false, ElemFull=nil | Dst: Ptr=false, ElemFull=nil
 	ec.Enter("ID")
 	dst.ID = src.ID
 	ec.Leave()
@@ -78,7 +79,8 @@ func srcSimpleToDstSimple(ec *errorCollector, src SrcSimple) DstSimple {
 		return dst
 	}
 
-	// Mapping field SrcSimple.Name to DstSimple.Name
+	// Mapping field SrcSimple.Name (string) to DstSimple.Name (string)
+	// Src: Ptr=false, ElemFull=nil | Dst: Ptr=false, ElemFull=nil
 	ec.Enter("Name")
 	dst.Name = src.Name
 	ec.Leave()
@@ -87,7 +89,8 @@ func srcSimpleToDstSimple(ec *errorCollector, src SrcSimple) DstSimple {
 	}
 
 	// Source field SrcSimple.Description is skipped due to tag '-'.
-	// Mapping field SrcSimple.Value to DstSimple.Value
+	// Mapping field SrcSimple.Value (float64) to DstSimple.Value (float64)
+	// Src: Ptr=false, ElemFull=nil | Dst: Ptr=false, ElemFull=nil
 	ec.Enter("Value")
 	dst.Value = src.Value
 	ec.Leave()
@@ -95,7 +98,8 @@ func srcSimpleToDstSimple(ec *errorCollector, src SrcSimple) DstSimple {
 		return dst
 	}
 
-	// Mapping field SrcSimple.Timestamp to DstSimple.CreationTime
+	// Mapping field SrcSimple.Timestamp (time.Time) to DstSimple.CreationTime (time.Time)
+	// Src: Ptr=false, ElemFull=nil | Dst: Ptr=false, ElemFull=nil
 	ec.Enter("CreationTime")
 	dst.CreationTime = src.Timestamp
 	ec.Leave()
@@ -103,7 +107,8 @@ func srcSimpleToDstSimple(ec *errorCollector, src SrcSimple) DstSimple {
 		return dst
 	}
 
-	// Mapping field SrcSimple.PtrString to DstSimple.PtrString
+	// Mapping field SrcSimple.PtrString (*string) to DstSimple.PtrString (*string)
+	// Src: Ptr=true, ElemFull=string | Dst: Ptr=true, ElemFull=string
 	ec.Enter("PtrString")
 	dst.PtrString = src.PtrString
 	ec.Leave()
@@ -111,7 +116,8 @@ func srcSimpleToDstSimple(ec *errorCollector, src SrcSimple) DstSimple {
 		return dst
 	}
 
-	// Mapping field SrcSimple.StringPtr to DstSimple.StringPtr
+	// Mapping field SrcSimple.StringPtr (string) to DstSimple.StringPtr (*string)
+	// Src: Ptr=false, ElemFull=nil | Dst: Ptr=true, ElemFull=string
 	ec.Enter("StringPtr")
 	{
 		srcVal := src.StringPtr
@@ -122,7 +128,8 @@ func srcSimpleToDstSimple(ec *errorCollector, src SrcSimple) DstSimple {
 		return dst
 	}
 
-	// Mapping field SrcSimple.PtrToValue to DstSimple.PtrToValue
+	// Mapping field SrcSimple.PtrToValue (*float32) to DstSimple.PtrToValue (float32)
+	// Src: Ptr=true, ElemFull=float32 | Dst: Ptr=false, ElemFull=nil
 	ec.Enter("PtrToValue")
 	if src.PtrToValue != nil {
 		dst.PtrToValue = *src.PtrToValue
@@ -132,7 +139,8 @@ func srcSimpleToDstSimple(ec *errorCollector, src SrcSimple) DstSimple {
 		return dst
 	}
 
-	// Mapping field SrcSimple.RequiredPtrToValue to DstSimple.RequiredPtrToValue
+	// Mapping field SrcSimple.RequiredPtrToValue (*int) to DstSimple.RequiredPtrToValue (int)
+	// Src: Ptr=true, ElemFull=int | Dst: Ptr=false, ElemFull=nil
 	ec.Enter("RequiredPtrToValue")
 	if src.RequiredPtrToValue == nil {
 		ec.Addf("field 'RequiredPtrToValue' is required but source field RequiredPtrToValue is nil")
@@ -144,7 +152,8 @@ func srcSimpleToDstSimple(ec *errorCollector, src SrcSimple) DstSimple {
 		return dst
 	}
 
-	// Mapping field SrcSimple.CustomIntToString to DstSimple.CustomStr
+	// Mapping field SrcSimple.CustomIntToString (int) to DstSimple.CustomStr (string)
+	// Src: Ptr=false, ElemFull=nil | Dst: Ptr=false, ElemFull=nil
 	ec.Enter("CustomStr")
 	// Applying field tag: using IntToStr
 	dst.CustomStr = IntToStr(ec, src.CustomIntToString)
@@ -162,7 +171,8 @@ func srcWithAliasToDstWithAlias(ec *errorCollector, src SrcWithAlias) DstWithAli
 		return dst
 	}
 
-	// Mapping field SrcWithAlias.EventTime to DstWithAlias.EventTimestamp
+	// Mapping field SrcWithAlias.EventTime (example.com/convert2/testdata/simple.MyTime) to DstWithAlias.EventTimestamp (time.Time)
+	// Src: Ptr=false, ElemFull=nil | Dst: Ptr=false, ElemFull=nil
 	ec.Enter("EventTimestamp")
 	// TODO: Implement conversion for EventTime (example.com/convert2/testdata/simple.MyTime) to EventTimestamp (time.Time).
 	ec.Addf("type mismatch or complex conversion not yet implemented for field 'EventTimestamp' (example.com/convert2/testdata/simple.MyTime -> time.Time)")


### PR DESCRIPTION
This commit refactors the parser in `examples/convert2` to leverage the `go-scan` library for AST parsing and type information gathering, replacing direct usage of `go/parser`.

Key changes include:
- Updated `parser.ParseDirectory` to use `goscan.Scanner`.
- Introduced `convertScannerTypeToModelType` to map `go-scan`'s `scannermodel.FieldType` to `convert2`'s `model.TypeInfo`.
- Rewrote `resolveTypeFromString` for resolving type names in comment directives, now using information derived from `go-scan`.
- Added `extractConvertTag` helper for struct tag parsing.
- Removed obsolete AST processing logic, imports, and model fields no longer needed (e.g., `FieldInfo.AstField`, `StructInfo.Node`).
- Updated `generator.go` for compatibility, primarily by simplifying array type handling due to changes in available type information.
- Configured `examples/convert2/go.mod` to use the local `go-scan` module.
- Documented findings and troubleshooting steps in `docs/knowledge.md`.

The changes ensure that `examples/convert2` aligns with the intended usage of the `go-scan` library for parsing Go source files. All tests for `examples/convert2` pass after these modifications.