### PR TITLE
feat: Implement len() function for strings

### DIFF
--- a/examples/minigo/interpreter.go
+++ b/examples/minigo/interpreter.go
@@ -191,6 +191,25 @@ func NewInterpreter() *Interpreter {
 	for name, builtin := range builtinsStrings {
 		env.Define(name, builtin)
 	}
+
+	// Register len() function
+	env.Define("len", &BuiltinFunction{
+		Name: "len",
+		Fn: func(env *Environment, args ...Object) (Object, error) {
+			if len(args) != 1 {
+				// TODO: Later, use i.formatErrorWithContext if possible from builtins, or ensure evalCallExpr wraps it.
+				return nil, fmt.Errorf("len() takes exactly one argument (%d given)", len(args))
+			}
+			switch arg := args[0].(type) {
+			case *String:
+				return &Integer{Value: int64(len(arg.Value))}, nil
+			// TODO: Add support for arrays, slices, maps when they are implemented
+			default:
+				return nil, fmt.Errorf("len() not supported for type %s", args[0].Type())
+			}
+		},
+	})
+
 	return i
 }
 

--- a/examples/minigo/interpreter_test.go
+++ b/examples/minigo/interpreter_test.go
@@ -640,6 +640,74 @@ func main() {
 			expectError:   true,
 			errorContains: "type mismatch for argument",
 		},
+		// --- len() function tests ---
+		{
+			name: "len of empty string",
+			input: `
+package main
+func main() {
+	return len("")
+}`,
+			expected: int64(0),
+		},
+		{
+			name: "len of ascii string",
+			input: `
+package main
+func main() {
+	return len("abc")
+}`,
+			expected: int64(3),
+		},
+		{
+			name: "len of multibyte string",
+			input: `
+package main
+func main() {
+	return len("こんにちは")
+}`,
+			expected: int64(15), // UTF-8 byte length
+		},
+		{
+			name: "len with no arguments",
+			input: `
+package main
+func main() {
+	return len()
+}`,
+			expectError:   true,
+			errorContains: "len() takes exactly one argument (0 given)",
+		},
+		{
+			name: "len with too many arguments",
+			input: `
+package main
+func main() {
+	return len("a", "b")
+}`,
+			expectError:   true,
+			errorContains: "len() takes exactly one argument (2 given)",
+		},
+		{
+			name: "len with integer argument",
+			input: `
+package main
+func main() {
+	return len(123)
+}`,
+			expectError:   true,
+			errorContains: "len() not supported for type INTEGER",
+		},
+		{
+			name: "len with boolean argument",
+			input: `
+package main
+func main() {
+	return len(true)
+}`,
+			expectError:   true,
+			errorContains: "len() not supported for type BOOLEAN",
+		},
 	}
 
 	for _, tt := range tests {

--- a/examples/minigo/todo.md
+++ b/examples/minigo/todo.md
@@ -60,7 +60,7 @@
 - [ ] More `fmt` functions (e.g., `Println`)
 - [ ] More `strings` functions
 - [ ] Basic I/O (e.g., reading files, printing to console beyond Sprintf)
-- [ ] `len()` function for strings, arrays, slices, maps
+- [/] `len()` function for strings (arrays, slices, maps to be added later)
 - [ ] `panic` and `recover`
 
 ## Interpreter Internals & Tooling


### PR DESCRIPTION
- Add support for the `len()` built-in function for string types.
- Includes tests for various string inputs and error cases.
- Update todo.md to reflect the partial completion of the `len()` function.