### PR TITLE
feat: Implement array, slice, and map data structures

### DIFF
--- a/examples/minigo/todo.md
+++ b/examples/minigo/todo.md
@@ -19,10 +19,10 @@
   - [x] Return statements (`return x`)
   - [x] Closures (lexical scoping for functions)
   - [x] Recursive function calls
-- [ ] Data Structures
-  - [ ] Arrays (e.g., `var a [3]int`, `a[0] = 1`)
-  - [ ] Slices (dynamic arrays)
-  - [ ] Maps (hash maps)
+- [x] Data Structures
+  - [x] Arrays (e.g., `var a [3]int`, `a[0] = 1`)
+  - [x] Slices (dynamic arrays, includes `append()`)
+  - [x] Maps (hash maps)
 - [ ] Control Flow
   - [x] `for` loops (various forms: `for {}`, `for i < N {}`, `for i := 0; i < N; i++ {}`. Range-based loop not yet supported)
   - [x] `break` and `continue` statements (unlabeled)
@@ -57,10 +57,11 @@
 - [x] `fmt.Sprintf` (basic implementation)
 - [x] `strings.Join` (custom varargs implementation for now)
 - [x] `Null` object and implicit returns for `null`
+- [x] `len()` function for strings, arrays, slices, maps
+- [x] `append()` function for slices
 - [ ] More `fmt` functions (e.g., `Println`)
 - [ ] More `strings` functions
 - [ ] Basic I/O (e.g., reading files, printing to console beyond Sprintf)
-- [/] `len()` function for strings (arrays, slices, maps to be added later)
 - [ ] `panic` and `recover`
 
 ## Interpreter Internals & Tooling


### PR DESCRIPTION
This commit introduces support for array, slice, and map data types to the MiniGo interpreter.

Key changes include:
- Defined new object types (Array, Slice, Map, Hashable, HashKey) in object.go.
- Implemented AST node evaluation for:
    - Array, slice, and map literals.
    - Index expressions (a[i], m[k]) for reading.
    - Slice expressions (s[l:h]).
    - Assignment to indexed elements (a[i]=v, m[k]=v).
    - Zero-value initialization for array, slice, and map declarations.
- Extended the built-in `len()` function to support these new types.
- Added a new built-in `append()` function for slices.
- Added comprehensive tests for these features, ensuring they pass.
- Updated todo.md to reflect these completions.