### PR TITLE
feat: Implement struct field assignment

### DIFF
--- a/examples/minigo/todo.md
+++ b/examples/minigo/todo.md
@@ -34,7 +34,7 @@
     - [x] Struct literal instantiation (`Point{X: 10, Y: 20}`)
     - [x] Field access (`p.X`)
     - [x] Basic embedded structs (promoted fields, initialization of embedded struct by type name)
-    - [ ] Field assignment (`p.X = 100`) - *Requires LHS of assignment to be SelectorExpr*
+    - [x] Field assignment (`p.X = 100`) - *Requires LHS of assignment to be SelectorExpr*
     - [ ] Unkeyed struct literals (e.g. `Point{10,20}`)
     - [ ] Type checking for struct field assignments and initializers.
     - [ ] Zero value for struct types (uninitialized fields are NULL, explicit zero struct via `T{}`)
@@ -84,7 +84,7 @@
 - [ ] Test suite expansion (more comprehensive tests for all features)
   - [ ] Test type checking during struct instantiation (e.g., `Point{X: "not-an-int"}`). (from interpreter_struct_test.go TODO)
   - [ ] Test non-keyed struct literals (e.g., `Point{10, 20}`). (from interpreter_struct_test.go TODO)
-  - [ ] Test modifying struct fields (e.g., `p.X = 30`) once LHS of assignment can be SelectorExpr. (from interpreter_struct_test.go TODO)
+  - [x] Test modifying struct fields (e.g., `p.X = 30`) once LHS of assignment can be SelectorExpr. (from interpreter_struct_test.go TODO)
   - [ ] Test returning struct from main and checking its value directly from LoadAndRun's result. (from interpreter_struct_test.go TODO)
   - [ ] Test struct definition within a function (local type declarations). (from interpreter_struct_test.go TODO)
   - [ ] Test for duplicate field names in struct literal (e.g. `Point{X:1, X:2}`). (from interpreter_struct_test.go TODO)


### PR DESCRIPTION
This commit introduces support for struct field assignment (e.g., `p.X = 100`).

Key changes:
- Modified `evalAssignStmt` in `interpreter.go` to handle `ast.SelectorExpr` on the left-hand side.
- Added a helper function `setFieldInEmbedded` to manage assignments to promoted fields in embedded structs, including ambiguity detection and creation of intermediate embedded instances if necessary.
- Added a new test suite `TestStructFieldAssignment` in `interpreter_struct_test.go` with comprehensive tests for direct field assignment, promoted field assignment (shallow and deep), and various error conditions.
- Updated `todo.md` to reflect the completion of this feature.