### PR TITLE
Fix: Set ModuleRoot in minigo tests to find go.mod

### DIFF
--- a/examples/minigo/builtin_fmt.go
+++ b/examples/minigo/builtin_fmt.go
@@ -99,7 +99,7 @@ func evalFmtPrintln(args ...Object) (Object, error) {
 		outputParts[i] = arg.Inspect()
 	}
 	fmt.Println(strings.Join(outputParts, " ")) // strings.Join is from Go's standard library
-	return NULL, nil                             // Println returns no meaningful value
+	return NULL, nil                            // Println returns no meaningful value
 }
 
 // GetBuiltinFmtFunctions returns a map of fmt built-in functions.

--- a/examples/minigo/interpreter_strings_join_test.go
+++ b/examples/minigo/interpreter_strings_join_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,13 +29,15 @@ func runMiniGoScriptForTest(t *testing.T, scriptContent string, expectedValue in
 	}
 
 	interpreter := NewInterpreter()
-	// Set ModuleRoot if your tests rely on go.mod discovery for imports,
-	// though for these self-contained strings.Join tests, it might not be strictly necessary
-	// if no external packages are imported by the test scripts themselves.
-	// For consistency with other tests, and if NewInterpreter setup benefits, let's set it.
-	// If tests are simple and don't involve go-scan for imports, this can be simpler.
-	// Assuming these tests don't need complex module resolution beyond what NewInterpreter provides by default.
-	// interpreter.ModuleRoot = baseDir // Or a more appropriate root if shared packages were involved.
+
+	// Determine project root relative to this test file.
+	// This file is in examples/minigo, so ../../ should be the project root.
+	projectRoot, err := filepath.Abs("../../")
+	if err != nil {
+		t.Fatalf("Failed to determine project root: %v", err)
+	}
+	interpreter.ModuleRoot = projectRoot
+	// t.Logf("Set ModuleRoot for interpreter to: %s", interpreter.ModuleRoot) // For debugging
 
 	ctx := context.Background()
 	runErr := interpreter.LoadAndRun(ctx, mainMgoFile, "main")

--- a/examples/minigo/interpreter_test.go
+++ b/examples/minigo/interpreter_test.go
@@ -501,7 +501,7 @@ func NewSecretPoint(x, y int) SecretPoint { return SecretPoint{X: x, secretY: y}
 	createTempGoFile(t, testPkgDir, "testpkg.go", testPkgGoContent)
 
 	tests := []struct {
-		name          string
+		name           string
 		input          string
 		expected       interface{}
 		expectError    bool


### PR DESCRIPTION
The TestStringsJoinRefactored tests in examples/minigo were failing because the go-scan scanner could not find the go.mod file when running tests in a temporary directory.

This commit fixes the issue by explicitly setting the `interpreter.ModuleRoot` to the project's root directory within the `runMiniGoScriptForTest` helper function. This allows the scanner to correctly initialize and locate the go.mod file, enabling the tests to pass.