### PR TITLE
WIP: Implement basic type declarations (type MyInt int)

### DIFF
--- a/examples/minigo/environment.go
+++ b/examples/minigo/environment.go
@@ -77,3 +77,34 @@ func (e *Environment) GetAllEntries() map[string]Object {
 	}
 	return allEntries
 }
+
+// SetType defines a type in the current environment.
+// Type definitions (like StructDefinition or DefinedType) are also Objects.
+func (e *Environment) SetType(name string, typeDef Object) {
+	// For now, types are stored in the same map as variables/functions.
+	// Consider a separate map if type namespace needs to be distinct.
+	e.store[name] = typeDef
+}
+
+// ResolveType retrieves a type definition by name from the environment.
+// It checks the current and outer scopes.
+func (e *Environment) ResolveType(name string) (Object, bool) {
+	// For now, types are retrieved using the same mechanism as variables/functions.
+	// The caller is responsible for asserting the Object is a type definition (e.g., *StructDefinition, *DefinedType).
+	obj, ok := e.Get(name)
+	if !ok {
+		return nil, false
+	}
+
+	// Basic check: is the object something that represents a type?
+	switch obj.(type) {
+	case *StructDefinition, *DefinedType:
+		return obj, true
+	default:
+		// It's some other kind of object (e.g., an Integer variable with the same name as a potential type)
+		// This indicates a name collision or misuse if a type was expected.
+		// For now, we return it and let the caller decide.
+		// A stricter ResolveType might return (nil, false) here.
+		return obj, true // Found an object, but maybe not a type definition. Caller must verify.
+	}
+}

--- a/examples/minigo/testdata/type_declarations.mgo
+++ b/examples/minigo/testdata/type_declarations.mgo
@@ -1,0 +1,57 @@
+// Test basic type declarations and conversions
+
+// Basic type declaration
+type MyInt int
+var x MyInt = MyInt(10)
+var x_val int = int(x) // Should be 10
+
+// Type declaration based on another defined type
+type MyIntAlias MyInt
+var a MyIntAlias = MyIntAlias(MyInt(20))
+var a_myint_val MyInt = MyInt(a)    // Convert MyIntAlias to MyInt
+var a_int_val int = int(a_myint_val) // Convert MyInt to int (should be 20)
+
+// Test with string based type
+type MyString string
+var s1 MyString = MyString("hello")
+var s1_val string = string(s1) // Should be "hello"
+
+type MyStringAlias MyString
+var s2 MyStringAlias = MyStringAlias(MyString("world"))
+var s2_mystring_val MyString = MyString(s2)
+var s2_string_val string = string(s2_mystring_val) // Should be "world"
+
+
+// Simple function to return values for checking from Go test
+func get_x_val() int {
+	return x_val
+}
+
+func get_a_int_val() int {
+	return a_int_val
+}
+
+func get_s1_val() string {
+	return s1_val
+}
+
+func get_s2_string_val() string {
+	return s2_string_val
+}
+
+// Test assigning converted value back to original type
+var initial_int int = 100
+type AnotherInt int
+var another_val AnotherInt = AnotherInt(initial_int) // another_val is 100 (type AnotherInt)
+var converted_back_int int = int(another_val)      // converted_back_int is 100 (type int)
+
+var final_assign AnotherInt = AnotherInt(converted_back_int) // final_assign should be 100 (type AnotherInt)
+var final_assign_int int = int(final_assign)
+
+func get_final_assign_int() int {
+    return final_assign_int
+}
+
+func main() {
+	// Entry point, variables are global
+}

--- a/examples/minigo/testdata/type_declarations_errors.mgo
+++ b/examples/minigo/testdata/type_declarations_errors.mgo
@@ -1,0 +1,35 @@
+// Test type declaration errors
+
+// Case 1: Direct assignment between int and MyInt (should fail)
+type MyIntErr1 int
+var x1 MyIntErr1
+var y1 int = 10
+// x1 = y1 // Expected error: cannot use y1 (type int) as type MyIntErr1 in assignment
+
+// Case 2: Direct assignment between MyInt and int (should fail)
+type MyIntErr2 int
+var x2 MyIntErr2 = MyIntErr2(20)
+var y2 int
+// y2 = x2 // Expected error: cannot use x2 (type MyIntErr2) as type int in assignment
+
+// Case 3: Invalid conversion - MyInt(string)
+type MyIntErr3 int
+var s3 string = "hello"
+// var x3 MyIntErr3 = MyIntErr3(s3) // Expected error: cannot convert s3 (type string) to type MyIntErr3
+
+// Case 4: Invalid conversion - MyString(int)
+type MyStringErr4 string
+var i4 int = 40
+// var x4 MyStringErr4 = MyStringErr4(i4) // Expected error: cannot convert i4 (type int) to type MyStringErr4
+
+// Case 5: Assignment between two different defined types with same underlying type
+type MyIntA int
+type MyIntB int
+var valA MyIntA = MyIntA(50)
+var valB MyIntB
+// valB = valA // Expected error: cannot use valA (type MyIntA) as type MyIntB in assignment
+
+func main() {
+    // These lines will cause errors if uncommented.
+    // The test will uncomment them one by one.
+}


### PR DESCRIPTION
- Added DefinedType object and supporting infrastructure in object.go and environment.go.
- Modified interpreter to parse and store type MyInt int declarations.
- Began aliasing 'go/ast' to 'goast' to debug a persistent syntax error, but this change is incomplete across interpreter.go.
- Added initial test files and test function for type declarations.

The feature is not yet fully functional due to an ongoing syntax error in interpreter.go related to the 'ast' package name, which is being addressed by aliasing the import. Further work is needed to complete the aliasing and then implement type checking and conversions.