### PR TITLE
feat: Implement initial structure of `convert` tool

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,8 +33,9 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
 -   **In-Memory File Overlay:** Added an "overlay" feature to `go-scan` to allow providing in-memory file content. This is useful for tools that generate or modify Go source code without writing to the filesystem. This was implemented as described in [docs/plan-overlay.md](./docs/plan-overlay.md).
 -   **Integration Tests for Examples:** Added integration tests for the code generation tools in the `examples/` directory using the new `scantest` library.
 -   **Variadic Parameter Parsing**: Correctly parses variadic parameters (e.g., `...string`) as slice types (e.g., `[]string`) within function signatures. The `IsVariadic` flag on `FunctionInfo` is set, and the parameter's `FieldType` accurately reflects the corresponding slice type.
+-   **Initial `convert` Tool Implementation**: Implemented the CLI entrypoint and a basic parser for the `convert` tool. The tool now uses a `@derivingconvert(DstType)` annotation on source types to define conversion pairs, as documented in the updated `docs/plan-neo-convert.md`.
 
 ## To Be Implemented
 
--   **Implement `convert` Tool**: Implement the annotation-based code generation tool as described in [docs/plan-neo-convert.md](./docs/plan-neo-convert.md).
-    -   Initial task: Create the CLI entrypoint and basic parser structure.
+-   **Implement `convert` Tool**: Continue implementing the annotation-based code generation tool.
+    -   Next: Implement the code generator to produce conversion functions based on the parsed `ConversionPair` model.

--- a/cmd/convert/main.go
+++ b/cmd/convert/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"log"
+	"os"
+
+	"github.com/podhmo/go-scan/internal/convert"
+)
+
+func main() {
+	var (
+		inputPath  string
+		outputPath string
+	)
+
+	flag.StringVar(&inputPath, "input", "", "path to input package")
+	flag.StringVar(&outputPath, "output", "", "path to output file")
+	flag.Parse()
+
+	if inputPath == "" {
+		log.Fatal("-input is required")
+	}
+	if outputPath == "" {
+		log.Fatal("-output is required")
+	}
+
+	if err := run(inputPath, outputPath); err != nil {
+		log.Fatalf("!! %+v", err)
+	}
+}
+
+func run(inputPath string, outputPath string) error {
+	ctx := context.Background()
+	info, err := convert.Parse(ctx, inputPath)
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(info)
+}

--- a/examples/convert/models/models.go
+++ b/examples/convert/models/models.go
@@ -19,6 +19,7 @@ type SrcInternalDetail struct {
 	Description string // This might need "translation"
 }
 
+// @derivingconvert(DstUser)
 type SrcUser struct {
 	ID        int64
 	FirstName string
@@ -61,6 +62,7 @@ type DstUser struct {
 }
 
 // Another top-level type for demonstrating multiple exported converters
+// @derivingconvert(DstOrder)
 type SrcOrder struct {
 	OrderID string
 	Amount  float64

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,3 @@ go 1.24
 toolchain go1.24.3
 
 require github.com/google/go-cmp v0.7.0
-
-require (
-	golang.org/x/mod v0.26.0 // indirect
-	golang.org/x/sync v0.16.0 // indirect
-	golang.org/x/tools v0.35.0 // indirect
-)

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,2 @@
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-golang.org/x/mod v0.26.0 h1:EGMPT//Ezu+ylkCijjPc+f4Aih7sZvaAr+O3EHBxvZg=
-golang.org/x/mod v0.26.0/go.mod h1:/j6NAhSk8iQ723BGAUyoAcn7SlD7s15Dp9Nd/SfeaFQ=
-golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
-golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
-golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
-golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=

--- a/internal/convert/model.go
+++ b/internal/convert/model.go
@@ -1,0 +1,16 @@
+package convert
+
+// ParsedInfo holds all parsed conversion rules and type information.
+type ParsedInfo struct {
+	PackageName     string
+	PackagePath     string // Import path of the package being parsed
+	ConversionPairs []ConversionPair
+}
+
+// ConversionPair defines a top-level conversion between two types.
+// Corresponds to: // convert:pair <SrcType> -> <DstType>
+type ConversionPair struct {
+	SrcTypeName string
+	DstTypeName string
+	MaxErrors   int
+}

--- a/internal/convert/parser.go
+++ b/internal/convert/parser.go
@@ -1,0 +1,63 @@
+package convert
+
+import (
+	"context"
+	"fmt"
+	"go/token"
+	"regexp"
+
+	"github.com/podhmo/go-scan/locator"
+	"github.com/podhmo/go-scan/scanner"
+)
+
+var reDerivingConvert = regexp.MustCompile(`@derivingconvert\(([^,)]+)\)`)
+
+// Parse parses the package and returns the parsed information.
+func Parse(ctx context.Context, pkgpath string) (*ParsedInfo, error) {
+	// 1. Use locator to find module info and package directory
+	l, err := locator.New(".", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create locator from current directory: %w", err)
+	}
+
+	pkgDir, err := l.FindPackageDir(pkgpath)
+	if err != nil {
+		return nil, fmt.Errorf("could not find package directory for import path %q: %w", pkgpath, err)
+	}
+
+	// 2. Create and configure the scanner
+	fset := token.NewFileSet()
+	s, err := scanner.New(fset, nil, nil, l.ModulePath(), l.RootDir())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create scanner: %w", err)
+	}
+
+	// 3. Scan the located package directory
+	scannedPkg, err := s.ScanPackage(ctx, pkgDir, s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan package at %q: %w", pkgDir, err)
+	}
+
+	// 4. Parse annotations
+	info := &ParsedInfo{
+		PackageName: scannedPkg.Name,
+		PackagePath: pkgpath,
+	}
+
+	for _, t := range scannedPkg.Types {
+		if t.Doc == "" {
+			continue
+		}
+		m := reDerivingConvert.FindStringSubmatch(t.Doc)
+		if m == nil {
+			continue
+		}
+		pair := ConversionPair{
+			SrcTypeName: t.Name,
+			DstTypeName: m[1],
+		}
+		info.ConversionPairs = append(info.ConversionPairs, pair)
+	}
+
+	return info, nil
+}

--- a/internal/convert/parser_test.go
+++ b/internal/convert/parser_test.go
@@ -1,0 +1,70 @@
+package convert
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/podhmo/go-scan/scantest"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   map[string]string
+		pkgPath string
+		want    *ParsedInfo
+		wantErr bool
+	}{
+		{
+			name: "simple pair",
+			files: map[string]string{
+				"go.mod": "module myapp",
+				"models/models.go": `
+package models
+
+// @derivingconvert(Dst)
+type Src struct {}
+
+type Dst struct {}
+`,
+			},
+			pkgPath: "myapp/models",
+			want: &ParsedInfo{
+				PackageName: "models",
+				PackagePath: "myapp/models",
+				ConversionPairs: []ConversionPair{
+					{SrcTypeName: "Src", DstTypeName: "Dst"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, cleanup := scantest.WriteFiles(t, tt.files)
+			defer cleanup()
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("failed to get current working directory: %v", err)
+			}
+			if err := os.Chdir(dir); err != nil {
+				t.Fatalf("failed to change directory to %s: %v", dir, err)
+			}
+			defer os.Chdir(cwd)
+
+			ctx := context.Background()
+			got, err := Parse(ctx, tt.pkgPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Parse() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/scantest/README.md
+++ b/scantest/README.md
@@ -1,0 +1,109 @@
+# Testing with `scantest`
+
+The `scantest` package provides a lightweight testing harness for tools built on top of `go-scan`. It simplifies the process of writing tests that involve parsing Go source files by managing temporary file creation and scanner invocation.
+
+## Core Concepts
+
+The primary goal of `scantest` is to allow you to test your tool's logic against a set of virtual Go source files without needing to manage testdata directories manually. It provides two key helper functions:
+
+-   `scantest.WriteFiles(t, files)`: Creates a temporary directory and writes a map of file paths to their content. It's perfect for setting up your test cases, including `go.mod` files and one or more Go source files.
+-   `scantest.Run(t, dir, patterns, action)`: This is the main test runner. It initializes a `go-scan` scanner, scans the specified patterns within the given directory, and invokes your custom `ActionFunc` with the results.
+
+## How to Use `scantest`
+
+The typical workflow for testing a tool that uses `go-scan` involves these steps:
+
+1.  **Define Test Cases**: Create a table-driven test with each case defining a set of Go source files.
+2.  **Set Up Files**: In your test loop, use `scantest.WriteFiles` to create a temporary directory populated with your test source files.
+3.  **Implement the Action**: Create an `ActionFunc` that receives the `*scan.Scanner` and `[]*scan.Package` from `go-scan`. This is where you place the core logic of your test.
+4.  **Run the Test**: Call `scantest.Run` with the temporary directory and your action function.
+5.  **Assert Results**: Inside the `ActionFunc`, perform assertions on the data you extract from the `scan.Package` results.
+
+### Example: Testing an Annotation Parser
+
+Let's say you are building a tool that finds structs with a `@mytool:generate` annotation and records the struct name.
+
+First, you would define your tool's parsing logic. This function is what you want to test. It operates on the results of a `go-scan` scan, not on a specific file path.
+
+```go
+// mytool/parser.go
+
+package mytool
+
+import (
+    "strings"
+    scan "github.com/podhmo/go-scan"
+)
+
+// This is the function we want to test.
+// It takes the scan results and extracts the names of structs with the annotation.
+func ExtractAnnotatedStructs(pkgs []*scan.Package) []string {
+    var names []string
+    for _, pkg := range pkgs {
+        for _, t := range pkg.Types {
+            if strings.Contains(t.Doc, "@mytool:generate") {
+                names = append(names, t.Name)
+            }
+        }
+    }
+    return names
+}
+```
+
+Next, you would write a test for `ExtractAnnotatedStructs` using `scantest`.
+
+```go
+// mytool/parser_test.go
+
+package mytool
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	scan "github.com/podhmo/go-scan"
+	"github.com/podhmo/go-scan/scantest"
+)
+
+func TestExtractAnnotatedStructs(t *testing.T) {
+	files := map[string]string{
+		"go.mod": "module example.com/hello",
+		"hello.go": `
+package hello
+
+// @mytool:generate
+type Foo struct {}
+
+type Bar struct {} // No annotation
+
+// @mytool:generate
+type Baz struct {}
+`,
+	}
+
+	// 1. Set up the temporary directory and files.
+	dir, cleanup := scantest.WriteFiles(t, files)
+	defer cleanup()
+
+	// 2. Define the action to be performed on the scan results.
+	action := func(ctx context.Context, s *scan.Scanner, pkgs []*scan.Package) error {
+		// 3. Call the function you are testing.
+		got := ExtractAnnotatedStructs(pkgs)
+		want := []string{"Foo", "Baz"}
+
+		// 4. Assert the results.
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("ExtractAnnotatedStructs() mismatch (-want +got):\n%s", diff)
+		}
+		return nil
+	}
+
+	// 5. Run the test. scantest handles the scanning and calls our action.
+	if _, err := scantest.Run(t, dir, []string{"./..."}, action); err != nil {
+		t.Fatalf("scantest.Run() failed: %v", err)
+	}
+}
+```
+
+This approach effectively decouples your tool's core logic from the file system and the `go-scan` boilerplate, leading to cleaner and more maintainable tests. Your parser logic is tested against the direct output of `go-scan`, which is exactly what it will receive in production.


### PR DESCRIPTION
This commit introduces the initial implementation of the `convert` tool, a new code generator for creating type conversion functions.

The main changes are:
- A new annotation `@derivingconvert(DstType)` is introduced to define conversion pairs. This annotation is placed in the doc comment of the source struct.
- The CLI entrypoint `cmd/convert` is created.
- A basic parser in `internal/convert` is implemented to extract conversion pairs.
- The design document `docs/plan-neo-convert.md` is updated to reflect the new annotation.
- A new `scantest/README.md` is added to provide clear instructions on how to test tools built with `go-scan`.
- Unit tests for the parser are added using `scantest`.