### PR TITLE
Fix: 修正 `make test` で失敗するテスト

### DIFF
--- a/examples/convert/generator/generator.go
+++ b/examples/convert/generator/generator.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"go/format"
-	"strings"
 	"text/template"
 
 	"example.com/convert/parser"
@@ -120,12 +119,16 @@ func Generate(s *goscan.Scanner, packageName string, pairs []parser.ConversionPa
 					dstBase = dstBase.Elem
 				}
 
+				if srcBase == nil || dstBase == nil {
+					continue
+				}
+
 				helperKey := fmt.Sprintf("%s_to_%s", srcBase.Name, dstBase.Name)
 				if !worklist[helperKey] {
-					if srcBase.Definition != nil && dstBase.Definition != nil {
+					if field.SrcDef != nil && field.DstDef != nil {
 						allPairs = append(allPairs, parser.ConversionPair{
-							SrcType:          srcBase.Definition,
-							DstType:          dstBase.Definition,
+							SrcType:          field.SrcDef,
+							DstType:          field.DstDef,
 							DstPkgImportPath: dstBase.FullImportPath(),
 						})
 						worklist[helperKey] = true
@@ -166,7 +169,7 @@ func Generate(s *goscan.Scanner, packageName string, pairs []parser.ConversionPa
 		"getAssignment": getAssignment,
 	}
 
-	tmpl, err := template.New("converter").Funcs(funcMap).Parse(strings.TrimSpace(codeTemplate))
+	tmpl, err := template.New("converter").Funcs(funcMap).Parse(codeTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse template: %w", err)
 	}

--- a/examples/convert/generator/generator_test.go
+++ b/examples/convert/generator/generator_test.go
@@ -119,7 +119,6 @@ func ConvertSrcOrderToDstOrder(ctx context.Context, src source.SrcOrder) (destin
 func convertSrcOrderToDstOrder(ctx context.Context, src source.SrcOrder) destination.DstOrder {
 	dst := destination.DstOrder{}
 	dst.OrderID = src.OrderID
-
 	if src.Items != nil {
 		newSlice := make([]destination.DstItem, 0, len(src.Items))
 		for _, elem := range src.Items {
@@ -241,7 +240,6 @@ func ConvertSrcProfileToDstProfile(ctx context.Context, src source.SrcProfile) (
 func convertSrcProfileToDstProfile(ctx context.Context, src source.SrcProfile) destination.DstProfile {
 	dst := destination.DstProfile{}
 	dst.Name = src.Name
-
 	if src.Attributes != nil {
 		newMap := make(map[string]string, len(src.Attributes))
 		for key, value := range src.Attributes {
@@ -249,7 +247,6 @@ func convertSrcProfileToDstProfile(ctx context.Context, src source.SrcProfile) d
 		}
 		dst.Attributes = newMap
 	}
-
 	if src.Tags != nil {
 		newMap := make(map[string]destination.DstTag, len(src.Tags))
 		for key, value := range src.Tags {
@@ -257,7 +254,6 @@ func convertSrcProfileToDstProfile(ctx context.Context, src source.SrcProfile) d
 		}
 		dst.Tags = newMap
 	}
-
 	return dst
 }
 

--- a/examples/convert/testdata/complex.go.golden
+++ b/examples/convert/testdata/complex.go.golden
@@ -17,11 +17,10 @@ func ConvertSrcUserToDstUser(ctx context.Context, src source.SrcUser) (destinati
 // convertSrcUserToDstUser is the internal conversion function.
 func convertSrcUserToDstUser(ctx context.Context, src source.SrcUser) destination.DstUser {
 	dst := destination.DstUser{}
-
 	if src.Details != nil {
-		newSlice := make([]DstInternalDetail, 0, len(src.Details))
+		newSlice := make([]destination.DstInternalDetail, 0, len(src.Details))
 		for _, elem := range src.Details {
-			newSlice = append(newSlice, elem)
+			newSlice = append(newSlice, convertSrcInternalDetailToDstInternalDetail(ctx, elem))
 		}
 		dst.Details = newSlice
 	}
@@ -58,24 +57,47 @@ func convertComplexSourceToComplexTarget(ctx context.Context, src source.Complex
 		tmp := *src.Ptr
 		dst.Ptr = &tmp
 	}
-
 	if src.Slice != nil {
-		newSlice := make([]SubTarget, 0, len(src.Slice))
+		newSlice := make([]destination.SubTarget, 0, len(src.Slice))
 		for _, elem := range src.Slice {
-			newSlice = append(newSlice, elem)
+			newSlice = append(newSlice, convertSubSourceToSubTarget(ctx, elem))
 		}
 		dst.Slice = newSlice
 	}
-
 	if src.SliceOfPtrs != nil {
-		newSlice := make([]*SubTarget, 0, len(src.SliceOfPtrs))
+		newSlice := make([]*destination.SubTarget, 0, len(src.SliceOfPtrs))
 		for _, elem := range src.SliceOfPtrs {
 			if elem != nil {
-				tmp := *elem
+				tmp := convertSubSourceToSubTarget(ctx, *elem)
 				newSlice = append(newSlice, &tmp)
 			}
 		}
 		dst.SliceOfPtrs = newSlice
 	}
+	return dst
+}
+
+// ConvertSrcInternalDetailToDstInternalDetail converts SrcInternalDetail to DstInternalDetail.
+func ConvertSrcInternalDetailToDstInternalDetail(ctx context.Context, src source.SrcInternalDetail) (destination.DstInternalDetail, error) {
+	dst := convertSrcInternalDetailToDstInternalDetail(ctx, src)
+	return dst, nil
+}
+
+// convertSrcInternalDetailToDstInternalDetail is the internal conversion function.
+func convertSrcInternalDetailToDstInternalDetail(ctx context.Context, src source.SrcInternalDetail) destination.DstInternalDetail {
+	dst := destination.DstInternalDetail{}
+	return dst
+}
+
+// ConvertSubSourceToSubTarget converts SubSource to SubTarget.
+func ConvertSubSourceToSubTarget(ctx context.Context, src source.SubSource) (destination.SubTarget, error) {
+	dst := convertSubSourceToSubTarget(ctx, src)
+	return dst, nil
+}
+
+// convertSubSourceToSubTarget is the internal conversion function.
+func convertSubSourceToSubTarget(ctx context.Context, src source.SubSource) destination.SubTarget {
+	dst := destination.SubTarget{}
+	dst.Value = src.Value
 	return dst
 }

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -61,6 +61,14 @@ func (s *Scanner) ResolveType(ctx context.Context, fieldType *FieldType) (*TypeI
 // It delegates the call to the configured resolver, which is typically the top-level
 // goscan.Scanner instance.
 func (s *Scanner) ScanPackageByImport(ctx context.Context, importPath string) (*PackageInfo, error) {
+	if s.resolver == s {
+		if s.currentPkg != nil && s.currentPkg.ImportPath == importPath {
+			return s.currentPkg, nil
+		}
+		// This might indicate a logic error where the scanner is trying to resolve a package
+		// it's already in the process of scanning, but the import path doesn't match.
+		return nil, fmt.Errorf("internal resolver loop detected for import path %q, current package is %q", importPath, s.currentPkg.ImportPath)
+	}
 	if s.resolver == nil {
 		return nil, fmt.Errorf("scanner's internal resolver is not set, cannot scan by import path %q", importPath)
 	}

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -61,7 +61,7 @@ func TestScanPackageFeatures(t *testing.T) {
 		filepath.Join(testDir, "variadic.go"),
 	}
 
-	pkgInfo, err := s.ScanFiles(context.Background(), filesToScan, testDir, &MockResolver{})
+	pkgInfo, err := s.ScanFiles(context.Background(), filesToScan, testDir, "example.com/test/features", &MockResolver{})
 	if err != nil {
 		t.Fatalf("ScanFiles failed for %v: %v", filesToScan, err)
 	}
@@ -149,7 +149,7 @@ func TestScanFiles(t *testing.T) {
 
 	t.Run("scan_single_file", func(t *testing.T) {
 		filePath := filepath.Join(testdataDir, "features.go")
-		pkgInfo, err := s.ScanFiles(context.Background(), []string{filePath}, testdataDir, mockResolver)
+		pkgInfo, err := s.ScanFiles(context.Background(), []string{filePath}, testdataDir, "example.com/test/features", mockResolver)
 		if err != nil {
 			t.Fatalf("ScanFiles single file failed: %v", err)
 		}
@@ -169,7 +169,7 @@ func TestScanFiles(t *testing.T) {
 			filepath.Join(testdataDir, "features.go"),
 			filepath.Join(testdataDir, "another.go"),
 		}
-		pkgInfo, err := s.ScanFiles(context.Background(), filePaths, testdataDir, mockResolver)
+		pkgInfo, err := s.ScanFiles(context.Background(), filePaths, testdataDir, "example.com/test/features", mockResolver)
 		if err != nil {
 			t.Fatalf("ScanFiles multiple files failed: %v", err)
 		}
@@ -194,14 +194,14 @@ func TestScanFiles(t *testing.T) {
 			filepath.Join(testdataDir, "features.go"),     // package features
 			filepath.Join(testdataDir, "differentpkg.go"), // package otherfeatures
 		}
-		_, err := s.ScanFiles(context.Background(), filePaths, testdataDir, mockResolver)
+		_, err := s.ScanFiles(context.Background(), filePaths, testdataDir, "example.com/test/features", mockResolver)
 		if err == nil {
 			t.Error("Expected error when scanning files from different packages, got nil")
 		}
 	})
 
 	t.Run("scan_empty_file_list", func(t *testing.T) {
-		_, err := s.ScanFiles(context.Background(), []string{}, testdataDir, mockResolver)
+		_, err := s.ScanFiles(context.Background(), []string{}, testdataDir, "example.com/test/features", mockResolver)
 		if err == nil {
 			t.Error("Expected error when scanning an empty file list, got nil")
 		}
@@ -209,7 +209,7 @@ func TestScanFiles(t *testing.T) {
 
 	t.Run("scan_non_existent_file", func(t *testing.T) {
 		filePaths := []string{filepath.Join(testdataDir, "nonexistent.go")}
-		_, err := s.ScanFiles(context.Background(), filePaths, testdataDir, mockResolver)
+		_, err := s.ScanFiles(context.Background(), filePaths, testdataDir, "example.com/test/features", mockResolver)
 		if err == nil {
 			t.Error("Expected error when scanning non-existent file, got nil")
 		}
@@ -272,7 +272,7 @@ func TestResolve_DirectRecursion(t *testing.T) {
 		t.Fatalf("scanner.New failed: %v", err)
 	}
 
-	pkgInfo, err := s.ScanFiles(context.Background(), []string{filepath.Join(testDir, "direct.go")}, testDir, s) // s implements PackageResolver
+	pkgInfo, err := s.ScanFiles(context.Background(), []string{filepath.Join(testDir, "direct.go")}, testDir, "example.com/test/recursion/direct", s) // s implements PackageResolver
 	if err != nil {
 		t.Fatalf("ScanFiles failed: %v", err)
 	}
@@ -344,7 +344,7 @@ func TestResolve_MutualRecursion(t *testing.T) {
 			// Use the main scanner 's' to perform the scan.
 			// The resolver passed to ScanFiles should be the mockResolver itself
 			// to handle further package lookups.
-			pkg, err := s.ScanFiles(ctx, []string{filepath.Join(pkgDir, filepath.Base(pkgDir)+".go")}, pkgDir, mockResolver)
+			pkg, err := s.ScanFiles(ctx, []string{filepath.Join(pkgDir, filepath.Base(pkgDir)+".go")}, pkgDir, importPath, mockResolver)
 			if err == nil && pkg != nil {
 				pkgCache[importPath] = pkg // Store in cache
 			}
@@ -437,7 +437,7 @@ func TestScanWithOverlay(t *testing.T) {
 	scanFilePath := filepath.Join(absTestDir, "basic.go")
 
 	// The pkgDirPath should also be an absolute path to the package directory.
-	pkgInfo, err := s.ScanFiles(context.Background(), []string{scanFilePath}, absTestDir, &MockResolver{})
+	pkgInfo, err := s.ScanFiles(context.Background(), []string{scanFilePath}, absTestDir, modulePath, &MockResolver{})
 	if err != nil {
 		t.Fatalf("ScanFiles with overlay failed: %v", err)
 	}


### PR DESCRIPTION
`s.ScanFiles` の呼び出しに不足していた `pkgImportPath` 引数を追加しました。 `scanner.ScanPackageByImport` での無限再帰を修正しました。
`example/convert` のジェネレータとテストコードを修正し、すべてのテストが成功するようにしました。