### PR TITLE
feat: Implement errorCollector for robust error handling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -76,9 +76,9 @@ as described in [docs/plan-neo-convert.md](docs/plan-neo-convert.md)
     -   [x] Implement global type conversion rules (`"<SrcType>" -> "<DstType>", using=<funcName>`).
     -   [ ] Implement validator rules (`"<DstType>", validator=<funcName>`).
 -   [x] **Add Tests for `// convert:rule`**: Write tests for global conversion and validator rules.
--   [ ] **Error Handling with `errorCollector`**: Implement the `errorCollector` struct and generate code that uses it to report multiple conversion errors.
--   [ ] **Add Tests for Error Handling**: Write tests to verify that `errorCollector` correctly accumulates and reports errors.
--   [ ] **Improve Generated Code Error Handling**: Replace `// TODO: proper error handling` placeholders in the generator with more robust error handling, even if it's not the full `errorCollector` implementation.
+-   [x] **Error Handling with `errorCollector`**: Implement the `errorCollector` struct and generate code that uses it to report multiple conversion errors.
+-   [x] **Add Tests for Error Handling**: Write tests to verify that `errorCollector` correctly accumulates and reports errors.
+-   [x] **Improve Generated Code Error Handling**: Replace `// TODO: proper error handling` placeholders in the generator with more robust error handling, even if it's not the full `errorCollector` implementation.
 
 ### Known Issues
 

--- a/examples/convert/testdata/maps.go.golden
+++ b/examples/convert/testdata/maps.go.golden
@@ -4,39 +4,78 @@ package maps
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"example.com/convert/model"
 	context "context"
 	fmt "fmt"
 )
+
+func convertSrcToDst(ec *model.ErrorCollector, src *Src) *Dst {
+	if src == nil {
+		return nil
+	}
+	dst := &Dst{}
+	if ec.MaxErrorsReached() { return dst }
+	ec.Enter("Items")
+	{
+	convertedMap := make(map[string]DstItem, len(src.Items))
+	for key, value := range src.Items {
+		ec.Enter(fmt.Sprintf("[%v]", key))
+		convertedMap[key] = *convertSrcItemToDstItem(ec, &value)
+		ec.Leave()
+	}
+	dst.Items = convertedMap
+}
+	ec.Leave()
+	if ec.MaxErrorsReached() { return dst }
+	ec.Enter("ItemPtrs")
+	{
+	convertedMap := make(map[string]*interface{}, len(src.ItemPtrs))
+	for key, value := range src.ItemPtrs {
+		ec.Enter(fmt.Sprintf("[%v]", key))
+		convertedMap[key] = value // Cannot convert pointer types, element type is nil
+		ec.Leave()
+	}
+	dst.ItemPtrs = convertedMap
+}
+	ec.Leave()
+	return dst
+}
 
 // ConvertSrcToDst converts Src to Dst.
 func ConvertSrcToDst(ctx context.Context, src *Src) (*Dst, error) {
 	if src == nil {
 		return nil, nil
 	}
-	dst := &Dst{}
-	{
-	convertedMap := make(map[string]DstItem, len(src.Items))
-	for key, value := range src.Items {
-		{ conv, err := ConvertSrcItemToDstItem(ctx, &value); if err == nil { convertedMap[key] = *conv } }
+	ec := model.NewErrorCollector(0) // TODO: get maxErrors from annotation
+	dst := convertSrcToDst(ec, src)
+	if ec.HasErrors() {
+		return dst, errors.Join(ec.Errors()...)
 	}
-	dst.Items = convertedMap
+	return dst, nil
 }
-	{
-	convertedMap := make(map[string]*interface{}, len(src.ItemPtrs))
-	for key, value := range src.ItemPtrs {
-		convertedMap[key] = value // Cannot convert pointer types, element type is nil
+func convertSrcItemToDstItem(ec *model.ErrorCollector, src *SrcItem) *DstItem {
+	if src == nil {
+		return nil
 	}
-	dst.ItemPtrs = convertedMap
+	dst := &DstItem{}
+	if ec.MaxErrorsReached() { return dst }
+	ec.Enter("Value")
+	dst.Value = src.Value
+	ec.Leave()
+	return dst
 }
-	return dst, nil // TODO: error handling
-}
+
 // ConvertSrcItemToDstItem converts SrcItem to DstItem.
 func ConvertSrcItemToDstItem(ctx context.Context, src *SrcItem) (*DstItem, error) {
 	if src == nil {
 		return nil, nil
 	}
-	dst := &DstItem{}
-	dst.Value = src.Value
-	return dst, nil // TODO: error handling
+	ec := model.NewErrorCollector(0) // TODO: get maxErrors from annotation
+	dst := convertSrcItemToDstItem(ec, src)
+	if ec.HasErrors() {
+		return dst, errors.Join(ec.Errors()...)
+	}
+	return dst, nil
 }

--- a/examples/convert/testdata/pointers.go.golden
+++ b/examples/convert/testdata/pointers.go.golden
@@ -4,42 +4,82 @@ package pointers
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"example.com/convert/model"
 	context "context"
 	fmt "fmt"
 )
+
+func convertSrcToDst(ec *model.ErrorCollector, src *Src) *Dst {
+	if src == nil {
+		return nil
+	}
+	dst := &Dst{}
+	if ec.MaxErrorsReached() { return dst }
+	ec.Enter("Items")
+	{
+	convertedSlice := make([]*interface{}, len(src.Items))
+	for i, item := range src.Items {
+		ec.Enter(fmt.Sprintf("[%d]", i))
+		convertedSlice[i] = item // Cannot convert pointer types, element type is nil
+		ec.Leave()
+	}
+	dst.Items = convertedSlice
+}
+	ec.Leave()
+	if ec.MaxErrorsReached() { return dst }
+	ec.Enter("ItemsPtr")
+	if src.ItemsPtr != nil {
+	tmp := DstItem
+	tmp = *convertSrcItemToDstItem(ec, &(*src.ItemsPtr))
+	dst.ItemsPtr = &tmp
+}
+	ec.Leave()
+	if ec.MaxErrorsReached() { return dst }
+	ec.Enter("ItemsPtrPtr")
+	if src.ItemsPtrPtr != nil {
+	tmp := *interface{}
+	tmp = (*src.ItemsPtrPtr) // Cannot convert pointer types, element type is nil
+	dst.ItemsPtrPtr = &tmp
+}
+	ec.Leave()
+	return dst
+}
 
 // ConvertSrcToDst converts Src to Dst.
 func ConvertSrcToDst(ctx context.Context, src *Src) (*Dst, error) {
 	if src == nil {
 		return nil, nil
 	}
-	dst := &Dst{}
-	{
-	convertedSlice := make([]*interface{}, len(src.Items))
-	for i, item := range src.Items {
-		convertedSlice[i] = item // Cannot convert pointer types, element type is nil
+	ec := model.NewErrorCollector(0) // TODO: get maxErrors from annotation
+	dst := convertSrcToDst(ec, src)
+	if ec.HasErrors() {
+		return dst, errors.Join(ec.Errors()...)
 	}
-	dst.Items = convertedSlice
+	return dst, nil
 }
-	if src.ItemsPtr != nil {
-	tmp := DstItem
-	{ conv, err := ConvertSrcItemToDstItem(ctx, &(*src.ItemsPtr)); if err == nil { tmp = *conv } }
-	dst.ItemsPtr = &tmp
+func convertSrcItemToDstItem(ec *model.ErrorCollector, src *SrcItem) *DstItem {
+	if src == nil {
+		return nil
+	}
+	dst := &DstItem{}
+	if ec.MaxErrorsReached() { return dst }
+	ec.Enter("Value")
+	dst.Value = src.Value
+	ec.Leave()
+	return dst
 }
-	if src.ItemsPtrPtr != nil {
-	tmp := *interface{}
-	tmp = (*src.ItemsPtrPtr) // Cannot convert pointer types, element type is nil
-	dst.ItemsPtrPtr = &tmp
-}
-	return dst, nil // TODO: error handling
-}
+
 // ConvertSrcItemToDstItem converts SrcItem to DstItem.
 func ConvertSrcItemToDstItem(ctx context.Context, src *SrcItem) (*DstItem, error) {
 	if src == nil {
 		return nil, nil
 	}
-	dst := &DstItem{}
-	dst.Value = src.Value
-	return dst, nil // TODO: error handling
+	ec := model.NewErrorCollector(0) // TODO: get maxErrors from annotation
+	dst := convertSrcItemToDstItem(ec, src)
+	if ec.HasErrors() {
+		return dst, errors.Join(ec.Errors()...)
+	}
+	return dst, nil
 }

--- a/examples/convert/testdata/rules.go.golden
+++ b/examples/convert/testdata/rules.go.golden
@@ -4,18 +4,38 @@ package rules
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"example.com/convert/model"
 	context "context"
 	fmt "fmt"
 )
+
+func convertSrcToDst(ec *model.ErrorCollector, src *Src) *Dst {
+	if src == nil {
+		return nil
+	}
+	dst := &Dst{}
+	if ec.MaxErrorsReached() { return dst }
+	ec.Enter("CreatedAt")
+	dst.CreatedAt = src.CreatedAt
+	ec.Leave()
+	if ec.MaxErrorsReached() { return dst }
+	ec.Enter("UpdatedAt")
+	dst.UpdatedAt = overrideTime(ec, src.UpdatedAt)
+	ec.Leave()
+	return dst
+}
 
 // ConvertSrcToDst converts Src to Dst.
 func ConvertSrcToDst(ctx context.Context, src *Src) (*Dst, error) {
 	if src == nil {
 		return nil, nil
 	}
-	dst := &Dst{}
-	dst.CreatedAt = src.CreatedAt
-	dst.UpdatedAt = overrideTime(ctx, src.UpdatedAt)
-	return dst, nil // TODO: error handling
+	ec := model.NewErrorCollector(0) // TODO: get maxErrors from annotation
+	dst := convertSrcToDst(ec, src)
+	if ec.HasErrors() {
+		return dst, errors.Join(ec.Errors()...)
+	}
+	return dst, nil
 }

--- a/examples/convert/testdata/slices.go.golden
+++ b/examples/convert/testdata/slices.go.golden
@@ -4,32 +4,66 @@ package slices
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"example.com/convert/model"
 	context "context"
 	fmt "fmt"
 )
+
+func convertSrcToDst(ec *model.ErrorCollector, src *Src) *Dst {
+	if src == nil {
+		return nil
+	}
+	dst := &Dst{}
+	if ec.MaxErrorsReached() { return dst }
+	ec.Enter("Items")
+	{
+	convertedSlice := make([]DstItem, len(src.Items))
+	for i, item := range src.Items {
+		ec.Enter(fmt.Sprintf("[%d]", i))
+		convertedSlice[i] = *convertSrcItemToDstItem(ec, &item)
+		ec.Leave()
+	}
+	dst.Items = convertedSlice
+}
+	ec.Leave()
+	return dst
+}
 
 // ConvertSrcToDst converts Src to Dst.
 func ConvertSrcToDst(ctx context.Context, src *Src) (*Dst, error) {
 	if src == nil {
 		return nil, nil
 	}
-	dst := &Dst{}
-	{
-	convertedSlice := make([]DstItem, len(src.Items))
-	for i, item := range src.Items {
-		{ conv, err := ConvertSrcItemToDstItem(ctx, &item); if err == nil { convertedSlice[i] = *conv } }
+	ec := model.NewErrorCollector(0) // TODO: get maxErrors from annotation
+	dst := convertSrcToDst(ec, src)
+	if ec.HasErrors() {
+		return dst, errors.Join(ec.Errors()...)
 	}
-	dst.Items = convertedSlice
+	return dst, nil
 }
-	return dst, nil // TODO: error handling
+func convertSrcItemToDstItem(ec *model.ErrorCollector, src *SrcItem) *DstItem {
+	if src == nil {
+		return nil
+	}
+	dst := &DstItem{}
+	if ec.MaxErrorsReached() { return dst }
+	ec.Enter("Value")
+	dst.Value = src.Value
+	ec.Leave()
+	return dst
 }
+
 // ConvertSrcItemToDstItem converts SrcItem to DstItem.
 func ConvertSrcItemToDstItem(ctx context.Context, src *SrcItem) (*DstItem, error) {
 	if src == nil {
 		return nil, nil
 	}
-	dst := &DstItem{}
-	dst.Value = src.Value
-	return dst, nil // TODO: error handling
+	ec := model.NewErrorCollector(0) // TODO: get maxErrors from annotation
+	dst := convertSrcItemToDstItem(ec, src)
+	if ec.HasErrors() {
+		return dst, errors.Join(ec.Errors()...)
+	}
+	return dst, nil
 }

--- a/examples/convert/testdata/tags.go.golden
+++ b/examples/convert/testdata/tags.go.golden
@@ -4,23 +4,50 @@ package tags
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"example.com/convert/model"
 	context "context"
 	fmt "fmt"
 )
+
+func convertSrcWithTagsToDstWithTags(ec *model.ErrorCollector, src *SrcWithTags) *DstWithTags {
+	if src == nil {
+		return nil
+	}
+	dst := &DstWithTags{}
+	if ec.MaxErrorsReached() { return dst }
+	ec.Enter("ID")
+	dst.ID = src.ID
+	ec.Leave()
+	if ec.MaxErrorsReached() { return dst }
+	ec.Enter("UserAge")
+	dst.UserAge = src.Age
+	ec.Leave()
+	if ec.MaxErrorsReached() { return dst }
+	ec.Enter("Profile")
+	dst.Profile = convertProfile(ec, src.Profile)
+	ec.Leave()
+	if ec.MaxErrorsReached() { return dst }
+	ec.Enter("ManagerID")
+	if src.ManagerID == nil {
+	ec.Add(fmt.Errorf("ManagerID is required"))
+} else {
+	dst.ManagerID = src.ManagerID // Cannot convert pointer types, element type is nil
+}
+	ec.Leave()
+	return dst
+}
 
 // ConvertSrcWithTagsToDstWithTags converts SrcWithTags to DstWithTags.
 func ConvertSrcWithTagsToDstWithTags(ctx context.Context, src *SrcWithTags) (*DstWithTags, error) {
 	if src == nil {
 		return nil, nil
 	}
-	dst := &DstWithTags{}
-	dst.ID = src.ID
-	dst.UserAge = src.Age
-	dst.Profile = convertProfile(ctx, src.Profile)
-	if src.ManagerID == nil {
-	return nil, fmt.Errorf("ManagerID is required")
-}
-dst.ManagerID = src.ManagerID // Cannot convert pointer types, element type is nil
-	return dst, nil // TODO: error handling
+	ec := model.NewErrorCollector(0) // TODO: get maxErrors from annotation
+	dst := convertSrcWithTagsToDstWithTags(ec, src)
+	if ec.HasErrors() {
+		return dst, errors.Join(ec.Errors()...)
+	}
+	return dst, nil
 }


### PR DESCRIPTION
This commit introduces the `errorCollector` to the `convert` tool, enabling the aggregation of multiple errors during the code generation process.

Key changes:
- Added the `ErrorCollector` struct in the `model` package to manage and store errors with their corresponding field paths.
- Modified the code generator to produce functions that utilize the `errorCollector`. This includes creating an internal helper function that accepts the collector and a top-level function that initializes it and returns the collected errors.
- Updated the assignment logic (`getAssignment`, `generateConversion`, etc.) to handle errors through the collector, including support for the `required` tag.
- Added a new integration test (`TestIntegration_WithErrorHandling`) to verify that multiple errors (from `required` tags and custom functions) are correctly collected and reported.
- Updated all existing golden files to reflect the new code generation output.
- Updated `TODO.md` to mark the error handling tasks as complete.