### PR TITLE
docs: examples/convertのTODOを抽出し、計画ドキュメントを更新

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -79,6 +79,8 @@ as described in [docs/plan-neo-convert.md](docs/plan-neo-convert.md)
 -   [x] **Error Handling with `errorCollector`**: Implement the `errorCollector` struct and generate code that uses it to report multiple conversion errors.
 -   [x] **Add Tests for Error Handling**: Write tests to verify that `errorCollector` correctly accumulates and reports errors.
 -   [x] **Improve Generated Code Error Handling**: Replace `// TODO: proper error handling` placeholders in the generator with more robust error handling, even if it's not the full `errorCollector` implementation.
+-   [ ] **Parse `max_errors` from Annotation**: Implement parsing for the `max_errors` option in the `@derivingconvert` annotation and pass it to the `ErrorCollector`. (from `generator/generator.go`)
+-   [ ] **Handle Map Key Conversion**: Implement logic to convert map keys when the source and destination map key types are different. (from `generator/generator.go`)
 
 ### Known Issues
 


### PR DESCRIPTION
Output:
docs: I've extracted the TODOs from examples/convert and updated the plan.