### PR TITLE
I am working on elaborating on the rationale for all convert options …

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -81,6 +81,8 @@ as described in [docs/plan-neo-convert.md](docs/plan-neo-convert.md)
 -   [x] **Improve Generated Code Error Handling**: Replace `// TODO: proper error handling` placeholders in the generator with more robust error handling, even if it's not the full `errorCollector` implementation.
 -   [x] **Parse `max_errors` from Annotation**: Implement parsing for the `max_errors` option in the `@derivingconvert` annotation.
 -   [ ] **Handle Map Key Conversion**: Implement logic to convert map keys when the source and destination map key types are different.
+-   [ ] **Implement automatic field selection for untagged fields**: Normalize field names (lowercase, remove underscores) for matching.
+-   [ ] **Support assignment for assignable embedded fields**
 -   [x] **Add Tests for `max_errors` and Map Key Conversion**: Write integration tests for the `max_errors` and map key conversion features. (Blocked by `go mod tidy` issue in tests)
 -   [x] **Support `replace` directives in `go.mod`**: Enhanced `go-scan`'s dependency resolution to correctly handle `replace` directives in `go.mod` files. (Note: integration tests revealed issues with `go mod tidy` in temporary directories)
 

--- a/TODO.md
+++ b/TODO.md
@@ -81,7 +81,7 @@ as described in [docs/plan-neo-convert.md](docs/plan-neo-convert.md)
 -   [x] **Improve Generated Code Error Handling**: Replace `// TODO: proper error handling` placeholders in the generator with more robust error handling, even if it's not the full `errorCollector` implementation.
 -   [x] **Parse `max_errors` from Annotation**: Implement parsing for the `max_errors` option in the `@derivingconvert` annotation.
 -   [ ] **Handle Map Key Conversion**: Implement logic to convert map keys when the source and destination map key types are different.
--   [ ] **Implement automatic field selection for untagged fields**: Normalize field names (lowercase, remove underscores) for matching.
+-   [ ] **Implement automatic field selection for untagged fields**: Use `json` tag as a fallback for field name matching (priority: `convert` tag > `json` tag > normalized field name).
 -   [ ] **Support assignment for assignable embedded fields**
 -   [x] **Add Tests for `max_errors` and Map Key Conversion**: Write integration tests for the `max_errors` and map key conversion features. (Blocked by `go mod tidy` issue in tests)
 -   [x] **Support `replace` directives in `go.mod`**: Enhanced `go-scan`'s dependency resolution to correctly handle `replace` directives in `go.mod` files. (Note: integration tests revealed issues with `go mod tidy` in temporary directories)


### PR DESCRIPTION
…in the documentation. My plan is as follows:

- First, I'll add details about automatic field selection for untagged and embedded fields.
- Then, I'll add a new section explaining the purpose and impact of all `convert` tag and rule options (`using`, `required`, `validator`).
- Finally, I'll update the TODO.md file to reflect the new implementation tasks.