### PR TITLE
Fix scantest replace directive

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -84,8 +84,8 @@ as described in [docs/plan-neo-convert.md](docs/plan-neo-convert.md)
 -   [ ] **Handle Map Key Conversion**: Implement logic to convert map keys when the source and destination map key types are different.
 -   [-] **Implement automatic field selection for untagged fields**: Use `json` tag as a fallback for field name matching (priority: `convert` tag > `json` tag > normalized field name).
 -   [ ] **Support assignment for assignable embedded fields**
--   [x] **Add Tests for `max_errors` and Map Key Conversion**: Write integration tests for the `max_errors` and map key conversion features. (Blocked by `go mod tidy` issue in tests)
--   [x] **Support `replace` directives in `go.mod`**: Enhanced `go-scan`'s dependency resolution to correctly handle `replace` directives in `go.mod` files. (Note: integration tests revealed issues with `go mod tidy` in temporary directories)
+-   [x] **Add Tests for `max_errors` and Map Key Conversion**: Write integration tests for the `max_errors` and map key conversion features.
+-   [x] **Support `replace` directives in `go.mod`**: Enhanced `go-scan`'s dependency resolution to correctly handle `replace` directives in `go.mod` files.
 
 ### Known Issues
 -   **Duplicate Imports in Generated Code**: The `goscan.ImportManager` sometimes generates duplicate import statements, which can cause compilation errors. This should be fixed to ensure each package is imported only once.

--- a/TODO.md
+++ b/TODO.md
@@ -89,7 +89,6 @@ as described in [docs/plan-neo-convert.md](docs/plan-neo-convert.md)
 
 ### Known Issues
 -   **Duplicate Imports in Generated Code**: The `goscan.ImportManager` sometimes generates duplicate import statements, which can cause compilation errors. This should be fixed to ensure each package is imported only once.
--   **`replace` directive path resolution in `scantest`**: Integration tests using `scantest` fail when the temporary `go.mod` uses a `replace` directive with a relative path. `scantest` needs to be improved to handle this scenario, possibly by adjusting the temporary directory structure or the `go` command's working directory.
 
 ### Future Tasks (Post-Migration)
 *   **Improve Import Management**: Handle import alias collisions robustly. Consider using `golang.org/x/tools/imports` for final output formatting.

--- a/examples/convert/main_test.go
+++ b/examples/convert/main_test.go
@@ -182,7 +182,7 @@ type Dst struct {
 }
 
 func TestIntegration_WithErrorHandling(t *testing.T) {
-	t.Skip("skipping due to relative path issue in test")
+	// t.Skip("skipping due to relative path issue in test")
 	files := map[string]string{
 		"go.mod": `
 module example.com/m

--- a/examples/convert/main_test.go
+++ b/examples/convert/main_test.go
@@ -182,7 +182,6 @@ type Dst struct {
 }
 
 func TestIntegration_WithErrorHandling(t *testing.T) {
-	// t.Skip("skipping due to relative path issue in test")
 	files := map[string]string{
 		"go.mod": `
 module example.com/m


### PR DESCRIPTION

The `scantest.Run` function now automatically handles `go.mod` files
that use `replace` directives with relative local paths (e.g., `../`).

Previously, integration tests using `scantest` would fail in such
scenarios because the `go-scan` locator could not resolve the path
correctly. The test's temporary directory is not the current working
directory, causing `os.Stat` on the relative path to fail.

This commit introduces a mechanism in `scantest.Run` to:
1. Read the `go.mod` file of the test project.
2. Detect any `replace` directives with relative paths.
3. Convert these relative paths to absolute paths based on the
   temporary test directory's location.
4. Create an in-memory `go.mod` file with the absolute paths.
5. Pass this modified `go.mod` to `go-scan` using the `WithOverlay`
   option.

This ensures that the scanner can correctly locate the replaced
local modules during tests without modifying the `locator`'s core
logic.

A new integration test, `TestRun_WithReplaceDirective`, has been
added to verify this functionality.

The corresponding known issue has been removed from `TODO.md`.