### PR TITLE
I've just committed the changes to implement on-demand multi-package …

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -93,17 +93,17 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
 Based on the plan in [docs/plan-multi-package-handling.md](./docs/plan-multi-package-handling.md).
 
 **Part 1: Core Library Foundation**
-*   [ ] **Enhance Test Harness (`scantest`)**:
-    *   [ ] Modify `scantest` to automatically search parent directories for `go.mod` to use as a default module root.
-    *   [ ] Add an option to `scantest` to allow explicitly setting the module root path for a test run.
-*   [ ] **Implement Core Scanning Logic**:
-    *   [ ] The parent `goscan.Scanner` must pass a reference to itself to the internal `scanner.Scanner` upon creation.
-    *   [ ] The `scanner.FieldType` struct must be modified to store the reference to the parent `goscan.Scanner`.
-    *   [ ] Implement the `Resolve()` method on `scanner.FieldType` to trigger an on-demand scan.
-*   [ ] **Add Core Unit Tests**:
-    *   [ ] Add a unit test (`TestFieldType_Resolve_CrossPackage`) for finding type definitions in an uncached package.
-    *   [ ] Add a unit test to confirm `Resolve()` is idempotent.
-    *   [ ] Add a unit test for the nested, multi-package scanning scenario.
+*   [x] **Enhance Test Harness (`scantest`)**:
+    *   [x] Modify `scantest` to automatically search parent directories for `go.mod` to use as a default module root.
+    *   [x] Add an option to `scantest` to allow explicitly setting the module root path for a test run.
+*   [x] **Implement Core Scanning Logic**:
+    *   [x] The parent `goscan.Scanner` must pass a reference to itself to the internal `scanner.Scanner` upon creation.
+    *   [x] The `scanner.FieldType` struct must be modified to store the reference to the parent `goscan.Scanner`.
+    *   [x] Implement the `Resolve()` method on `scanner.FieldType` to trigger an on-demand scan.
+*   [x] **Add Core Unit Tests**:
+    *   [x] Add a unit test (`TestFieldType_Resolve_CrossPackage`) for finding type definitions in an uncached package.
+    *   [x] Add a unit test to confirm `Resolve()` is idempotent.
+    *   [x] Add a unit test for the nested, multi-package scanning scenario.
 
 **Part 2: Library Consumer Updates**
 *   [ ] **Refactor `examples/convert`**:

--- a/examples/convert/parser/parser_test.go
+++ b/examples/convert/parser/parser_test.go
@@ -12,6 +12,18 @@ import (
 	"github.com/podhmo/go-scan/scanner"
 )
 
+// MockResolver is a mock implementation of PackageResolver for tests.
+type MockResolver struct {
+	ScanPackageByImportFunc func(ctx context.Context, importPath string) (*scanner.PackageInfo, error)
+}
+
+func (m *MockResolver) ScanPackageByImport(ctx context.Context, importPath string) (*scanner.PackageInfo, error) {
+	if m.ScanPackageByImportFunc != nil {
+		return m.ScanPackageByImportFunc(ctx, importPath)
+	}
+	return nil, nil // Default mock behavior
+}
+
 func TestParse(t *testing.T) {
 	source := `
 package sample
@@ -51,12 +63,13 @@ type MyTime time.Time
 		"source.go": []byte(source),
 	}
 
-	s, err := scanner.New(fset, nil, overlay, "example.com/sample", ".")
+	resolver := &MockResolver{}
+	s, err := scanner.New(fset, nil, overlay, "example.com/sample", ".", resolver)
 	if err != nil {
 		t.Fatalf("scanner.New() failed: %v", err)
 	}
 
-	pkg, err := s.ScanFiles(context.Background(), []string{"source.go"}, ".", s)
+	pkg, err := s.ScanFiles(context.Background(), []string{"source.go"}, ".")
 	if err != nil {
 		t.Fatalf("ScanFiles() failed: %v", err)
 	}

--- a/goscan.go
+++ b/goscan.go
@@ -150,7 +150,7 @@ func New(options ...ScannerOption) (*Scanner, error) {
 	}
 	s.locator = loc
 
-	initialScanner, err := scanner.New(s.fset, s.ExternalTypeOverrides, s.overlay, loc.ModulePath(), loc.RootDir())
+	initialScanner, err := scanner.New(s.fset, s.ExternalTypeOverrides, s.overlay, loc.ModulePath(), loc.RootDir(), s)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create internal scanner: %w", err)
 	}
@@ -165,7 +165,7 @@ func (s *Scanner) SetExternalTypeOverrides(ctx context.Context, overrides scanne
 		overrides = make(scanner.ExternalTypeOverride)
 	}
 	s.ExternalTypeOverrides = overrides
-	newInternalScanner, err := scanner.New(s.fset, s.ExternalTypeOverrides, s.overlay, s.locator.ModulePath(), s.locator.RootDir())
+	newInternalScanner, err := scanner.New(s.fset, s.ExternalTypeOverrides, s.overlay, s.locator.ModulePath(), s.locator.RootDir(), s)
 	if err != nil {
 		slog.WarnContext(ctx, "Failed to re-initialize internal scanner with new overrides. Continuing with previous scanner settings.", slog.Any("error", err))
 		return
@@ -273,7 +273,7 @@ func (s *Scanner) ScanPackage(ctx context.Context, pkgPath string) (*scanner.Pac
 
 	var currentCallPkgInfo *scanner.PackageInfo
 	if len(filesToParseNow) > 0 {
-		currentCallPkgInfo, err = s.scanner.ScanFiles(ctx, filesToParseNow, absPkgPath, s)
+		currentCallPkgInfo, err = s.scanner.ScanFiles(ctx, filesToParseNow, absPkgPath)
 		if err != nil {
 			return nil, fmt.Errorf("ScanPackage: internal scan of files for package %s failed: %w", absPkgPath, err)
 		}
@@ -469,7 +469,7 @@ func (s *Scanner) ScanFiles(ctx context.Context, filePaths []string) (*scanner.P
 		}, nil
 	}
 
-	pkgInfo, err := s.scanner.ScanFiles(ctx, filesToParse, pkgDirAbs, s) // Scan only unvisited files
+	pkgInfo, err := s.scanner.ScanFiles(ctx, filesToParse, pkgDirAbs) // Scan only unvisited files
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan files in %s (import path %s): %w", pkgDirAbs, importPath, err)
 	}
@@ -657,7 +657,7 @@ func (s *Scanner) ScanPackageByImport(ctx context.Context, importPath string) (*
 
 	var currentCallPkgInfo *scanner.PackageInfo
 	if len(filesToParseThisCall) > 0 {
-		currentCallPkgInfo, err = s.scanner.ScanFiles(ctx, filesToParseThisCall, pkgDirAbs, s)
+		currentCallPkgInfo, err = s.scanner.ScanFiles(ctx, filesToParseThisCall, pkgDirAbs)
 		if err != nil {
 			return nil, fmt.Errorf("ScanPackageByImport: scanning files for %s failed: %w", importPath, err)
 		}

--- a/goscan_crosspkg_test.go
+++ b/goscan_crosspkg_test.go
@@ -1,0 +1,205 @@
+package goscan_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	scan "github.com/podhmo/go-scan"
+	"github.com/podhmo/go-scan/scantest"
+)
+
+func TestFieldType_Resolve_CrossPackage(t *testing.T) {
+	files := map[string]string{
+		"go.mod": "module example.com/test",
+		"models/user.go": `
+package models
+type User struct {
+	ID   string
+	Name string
+}`,
+		"api/handler.go": `
+package api
+import "example.com/test/models"
+type Handler struct {
+	User models.User
+}`,
+	}
+
+	dir, cleanup := scantest.WriteFiles(t, files)
+	defer cleanup()
+
+	// We scan the 'api' package. The 'models' package should be resolved on-demand.
+	_, err := scantest.Run(t, dir, []string{"api"}, func(ctx context.Context, s *scan.Scanner, pkgs []*scan.Package) error {
+		if len(pkgs) != 1 {
+			return fmt.Errorf("expected 1 package, got %d", len(pkgs))
+		}
+		apiPkg := pkgs[0]
+		handlerType := apiPkg.Lookup("Handler")
+		if handlerType == nil {
+			return fmt.Errorf("type Handler not found in package api")
+		}
+		if handlerType.Struct == nil {
+			return fmt.Errorf("Handler is not a struct")
+		}
+		if len(handlerType.Struct.Fields) != 1 {
+			return fmt.Errorf("expected 1 field in Handler, got %d", len(handlerType.Struct.Fields))
+		}
+
+		userField := handlerType.Struct.Fields[0]
+		if userField.Name != "User" {
+			return fmt.Errorf("expected field name 'User', got %s", userField.Name)
+		}
+
+		// --- Act ---
+		// Resolve the type of the 'User' field.
+		resolvedType, err := userField.Type.Resolve(ctx, make(map[string]struct{}))
+		if err != nil {
+			return fmt.Errorf("Resolve() failed: %w", err)
+		}
+
+		// --- Assert ---
+		if resolvedType == nil {
+			return fmt.Errorf("Resolve() returned nil, expected a TypeInfo for models.User")
+		}
+
+		if diff := cmp.Diff("User", resolvedType.Name); diff != "" {
+			return fmt.Errorf("resolved type name mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff("example.com/test/models", resolvedType.PkgPath); diff != "" {
+			return fmt.Errorf("resolved type pkgPath mismatch (-want +got):\n%s", diff)
+		}
+
+		// Test for idempotency: resolve again.
+		resolvedType2, err := userField.Type.Resolve(ctx, make(map[string]struct{}))
+		if err != nil {
+			return fmt.Errorf("second Resolve() failed: %w", err)
+		}
+		if resolvedType2 == nil {
+			return fmt.Errorf("second Resolve() returned nil")
+		}
+		// Check if it's the same instance (pointer equality)
+		if resolvedType != resolvedType2 {
+			return fmt.Errorf("Resolve() is not idempotent; returned different instances")
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("scantest.Run() failed: %v", err)
+	}
+}
+
+func TestFieldType_Resolve_NestedCrossPackage(t *testing.T) {
+	files := map[string]string{
+		"go.mod": "module example.com/test",
+		"models/profile.go": `
+package models
+type Profile struct {
+	Email string
+}`,
+		"models/user.go": `
+package models
+type User struct {
+	ID   string
+	Name string
+}`,
+		"dmodels/profile.go": `
+package dmodels
+// d is for destination
+type Profile struct {
+	Email string
+}`,
+		"api/payloads.go": `
+package api
+import "example.com/test/models"
+type UserCreateRequest struct {
+	Name string
+	Profile models.Profile
+}`,
+		"destination/types.go": `
+package destination
+import "example.com/test/dmodels"
+type User struct {
+	ID string
+	Name string
+	Profile dmodels.Profile
+}`,
+	}
+
+	dir, cleanup := scantest.WriteFiles(t, files)
+	defer cleanup()
+
+	// We scan 'api' and 'destination' packages initially.
+	// 'models' and 'dmodels' should be resolved on-demand.
+	_, err := scantest.Run(t, dir, []string{"api", "destination"}, func(ctx context.Context, s *scan.Scanner, pkgs []*scan.Package) error {
+		if len(pkgs) != 2 {
+			return fmt.Errorf("expected 2 packages, got %d", len(pkgs))
+		}
+
+		var apiPkg, destPkg *scan.Package
+		for _, p := range pkgs {
+			if p.Name == "api" {
+				apiPkg = p
+			}
+			if p.Name == "destination" {
+				destPkg = p
+			}
+		}
+		if apiPkg == nil || destPkg == nil {
+			return fmt.Errorf("could not find both api and destination packages in initial scan")
+		}
+
+		// Find the source struct: api.UserCreateRequest
+		srcType := apiPkg.Lookup("UserCreateRequest")
+		if srcType == nil {
+			return fmt.Errorf("type UserCreateRequest not found in package api")
+		}
+		srcProfileField := srcType.Struct.Fields[1] // Profile models.Profile
+
+		// Find the destination struct: destination.User
+		dstType := destPkg.Lookup("User")
+		if dstType == nil {
+			return fmt.Errorf("type User not found in package destination")
+		}
+		dstProfileField := dstType.Struct.Fields[2] // Profile dmodels.Profile
+
+		// --- Act & Assert ---
+		// 1. Resolve the source profile type
+		srcProfileResolved, err := srcProfileField.Type.Resolve(ctx, make(map[string]struct{}))
+		if err != nil {
+			return fmt.Errorf("resolving source Profile failed: %w", err)
+		}
+		if srcProfileResolved == nil {
+			return fmt.Errorf("resolving source Profile returned nil")
+		}
+		if diff := cmp.Diff("Profile", srcProfileResolved.Name); diff != "" {
+			return fmt.Errorf("source resolved name mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff("example.com/test/models", srcProfileResolved.PkgPath); diff != "" {
+			return fmt.Errorf("source resolved pkgPath mismatch (-want +got):\n%s", diff)
+		}
+
+		// 2. Resolve the destination profile type
+		dstProfileResolved, err := dstProfileField.Type.Resolve(ctx, make(map[string]struct{}))
+		if err != nil {
+			return fmt.Errorf("resolving destination Profile failed: %w", err)
+		}
+		if dstProfileResolved == nil {
+			return fmt.Errorf("resolving destination Profile returned nil")
+		}
+		if diff := cmp.Diff("Profile", dstProfileResolved.Name); diff != "" {
+			return fmt.Errorf("destination resolved name mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff("example.com/test/dmodels", dstProfileResolved.PkgPath); diff != "" {
+			return fmt.Errorf("destination resolved pkgPath mismatch (-want +got):\n%s", diff)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scantest.Run() failed: %v", err)
+	}
+}

--- a/scantest/scantest_test.go
+++ b/scantest/scantest_test.go
@@ -54,7 +54,7 @@ func TestRun_PureCheck(t *testing.T) {
 		return nil
 	}
 
-	result, err := Run(t, dir, []string{"."}, action)
+	result, err := Run(t, dir, []string{"."}, action, WithModuleRoot(dir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestRun_GenerateFile(t *testing.T) {
 		return pd.SaveGoFile(ctx, gf, "main_gen.go")
 	}
 
-	result, err := Run(t, dir, []string{"."}, generateAction)
+	result, err := Run(t, dir, []string{"."}, generateAction, WithModuleRoot(dir))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
…AST scanning. This introduces the core functionality to resolve types across package boundaries as needed.

Here are the key changes I made:

-   **`scantest` Enhancements**: I made the test harness (`scantest`) more robust for multi-package testing.
    -   It now automatically detects the module root by searching from the test's temporary directory and then from the current working directory. This allows it to work for both self-contained and project-dependent tests.
    -   For greater control, I also added an explicit `WithModuleRoot()` option.

-   **Core Logic Refactoring**: I refactored the internal `scanner.Scanner` to receive the `PackageResolver` (`*goscan.Scanner`) upon creation. This simplifies the scanning methods and solidifies the parent-child relationship between the scanners, which is crucial for lazy resolution.

-   **New Cross-Package Tests**: I added comprehensive tests (`TestFieldType_Resolve_CrossPackage`, `TestFieldType_Resolve_NestedCrossPackage`) that verify the new on-demand resolution logic for simple, nested, and idempotent scenarios.

These changes implement the first part of the plan for "On-Demand, Multi-Package AST Scanning" as outlined in `TODO.md` and `docs/plan-multi-package-handling.md`.