### PR TITLE
feat: add github action to extract md updates

### DIFF
--- a/.github/workflows/extract-md-updates.yml
+++ b/.github/workflows/extract-md-updates.yml
@@ -1,0 +1,60 @@
+name: Extract Markdown Updates
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: 'The pull request number to extract markdown files from'
+        required: true
+
+jobs:
+  extract-md-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create new branch
+        run: |
+          git checkout -b automation/md-updates-${{ github.event.inputs.pull_request_number }}
+
+      - name: Extract and commit .md files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          PR_NUMBER=${{ github.event.inputs.pull_request_number }}
+          git fetch origin pull/$PR_NUMBER/head:pr-$PR_NUMBER
+
+          # Get the list of changed files in the PR, filter for .md files
+          MD_FILES=$(gh pr diff $PR_NUMBER --name-only | grep '\.md$' || true)
+
+          if [ -z "$MD_FILES" ]; then
+            echo "No markdown files found in the pull request."
+            exit 0
+          fi
+
+          # Checkout the .md files from the PR branch
+          for file in $MD_FILES; do
+            git checkout pr-$PR_NUMBER -- $file
+          done
+
+          # Commit the changes
+          git add .
+          git commit -m "docs: extract markdown updates from #${PR_NUMBER}"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.CREATE_PULL_REQUEST }}
+          commit-message: "docs: extract markdown updates from #${{ github.event.inputs.pull_request_number }}"
+          title: "Docs: Extract markdown updates from #${{ github.event.inputs.pull_request_number }}"
+          body: "This PR extracts markdown file updates from #${{ github.event.inputs.pull_request_number }}."
+          branch: "automation/md-updates-${{ github.event.inputs.pull_request_number }}"
+          base: main
+          delete-branch: true
+          labels: "automated-pr, documentation"


### PR DESCRIPTION
This commit adds a new GitHub Action that can be manually triggered to extract markdown file changes from a pull request and create a new pull request with those changes.