### PR TITLE
refactor(scanner): Export Fields for Manual FieldType Creation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -104,9 +104,9 @@ Based on the plan in [docs/plan-multi-package-handling.md](./docs/plan-multi-pac
     *   [x] Add a unit test (`TestFieldType_Resolve_CrossPackage`) for finding type definitions in an uncached package.
     *   [x] Add a unit test to confirm `Resolve()` is idempotent.
     *   [x] Add a unit test for the nested, multi-package scanning scenario.
-*   [ ] **Expose Fields for Manual `FieldType` Creation**:
-    *   [ ] Export `Resolver`, `FullImportPath`, and `TypeName` on `scanner.FieldType` to allow consumers to construct resolvable types from non-AST sources (e.g., annotations).
-    *   [ ] Update internal library code to use the new exported fields.
+*   [x] **Expose Fields for Manual `FieldType` Creation**:
+    *   [x] Export `Resolver`, `FullImportPath`, and `TypeName` on `scanner.FieldType` to allow consumers to construct resolvable types from non-AST sources (e.g., annotations).
+    *   [x] Update internal library code to use the new exported fields.
 
 **Part 2: Library Consumer Updates**
 *   [ ] **Refactor `examples/convert`**:

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -593,7 +593,7 @@ func (s *Scanner) parseFieldList(ctx context.Context, fields []*ast.Field, curre
 // parseTypeExpr parses an expression representing a type.
 // It now accepts ctx for logging.
 func (s *Scanner) parseTypeExpr(ctx context.Context, expr ast.Expr, currentTypeParams []*TypeParamInfo) *FieldType {
-	ft := &FieldType{resolver: s.resolver}
+	ft := &FieldType{Resolver: s.resolver}
 	switch t := expr.(type) {
 	case *ast.Ident:
 		ft.Name = t.Name
@@ -624,8 +624,8 @@ func (s *Scanner) parseTypeExpr(ctx context.Context, expr ast.Expr, currentTypeP
 			}
 			if !isBuiltin && s.currentPkg != nil {
 				// Assume it's a type from the current package
-				ft.fullImportPath = s.currentPkg.ImportPath
-				ft.typeName = t.Name
+				ft.FullImportPath = s.currentPkg.ImportPath
+				ft.TypeName = t.Name
 			}
 		}
 	case *ast.StarExpr:
@@ -662,8 +662,8 @@ func (s *Scanner) parseTypeExpr(ctx context.Context, expr ast.Expr, currentTypeP
 		}
 		ft.Name = fmt.Sprintf("%s.%s", pkgIdent.Name, t.Sel.Name) // This might be too simple; Name should be t.Sel.Name
 		ft.PkgName = pkgIdent.Name
-		ft.typeName = t.Sel.Name
-		ft.fullImportPath = pkgImportPath
+		ft.TypeName = t.Sel.Name
+		ft.FullImportPath = pkgImportPath
 	case *ast.IndexExpr: // For single type argument, e.g., MyType[string]
 		// t.X is the generic type (e.g., MyType)
 		// t.Index is the type argument (e.g., string)

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -245,9 +245,9 @@ func TestFieldType_Resolve(t *testing.T) {
 	ft := &FieldType{
 		Name:           "models.User",
 		PkgName:        "models",
-		resolver:       resolver,
-		fullImportPath: "example.com/models",
-		typeName:       "User",
+		Resolver:       resolver,
+		FullImportPath: "example.com/models",
+		TypeName:       "User",
 	}
 
 	// First call to Resolve should trigger the resolver

--- a/type_relation.go
+++ b/type_relation.go
@@ -121,8 +121,8 @@ func compareSignatures(interfaceMethod *scanner.MethodInfo, structMethod *scanne
 // This is a simplified comparison. A robust solution needs full type resolution.
 func compareFieldTypes(type1 *scanner.FieldType, type2 *scanner.FieldType) bool {
 	fmt.Printf("DEBUG: compareFieldTypes: type1_name=%s, type1_pkg=%s, type1_full_import=%s, type1_is_pointer=%t, type1_is_slice=%t, type1_is_map=%t -- type2_name=%s, type2_pkg=%s, type2_full_import=%s, type2_is_pointer=%t, type2_is_slice=%t, type2_is_map=%t\n",
-		type1.Name, type1.PkgName, type1.FullImportPath(), type1.IsPointer, type1.IsSlice, type1.IsMap,
-		type2.Name, type2.PkgName, type2.FullImportPath(), type2.IsPointer, type2.IsSlice, type2.IsMap,
+		type1.Name, type1.PkgName, type1.FullImportPath, type1.IsPointer, type1.IsSlice, type1.IsMap,
+		type2.Name, type2.PkgName, type2.FullImportPath, type2.IsPointer, type2.IsSlice, type2.IsMap,
 	)
 	if type1 == nil && type2 == nil {
 		fmt.Println("DEBUG: compareFieldTypes: both nil, returning true")


### PR DESCRIPTION
I've made this change as part of my work on the "On-Demand, Multi-Package AST Scanning" feature.

Here are the changes I made:
- I exported the `resolver`, `fullImportPath`, and `typeName` fields on `scanner.FieldType` to `Resolver`, `FullImportPath`, and `TypeName` respectively. This allows you to manually construct a resolvable `FieldType`, which is necessary for features that parse type information from sources other than Go AST nodes (e.g., annotations).
- I removed the `FullImportPath()` method, which conflicted with the newly exported field.
- I updated all the relevant library code (`scanner.go`, `models.go`, `type_relation.go`) and tests (`scanner_test.go`) to use the new exported field names.