### PR TITLE
I've updated my logic for handling `TODO.md` files.

### DIFF
--- a/.github/workflows/extract-md-updates.yml
+++ b/.github/workflows/extract-md-updates.yml
@@ -46,7 +46,13 @@ jobs:
           fi
 
           for file in $MD_FILES; do
-            git checkout pr-$PR_NUMBER -- $file
+            if [ "$file" = "TODO.md" ]; then
+              # Special handling for TODO.md: turn [x] back to [ ]
+              git show "pr-$PR_NUMBER:$file" | sed 's/\[x\]/\[ \]/g' > "$file"
+            else
+              # Default behavior for other .md files
+              git checkout "pr-$PR_NUMBER" -- "$file"
+            fi
           done
 
       - name: Create Pull Request

--- a/.github/workflows/extract-md-updates.yml
+++ b/.github/workflows/extract-md-updates.yml
@@ -36,7 +36,10 @@ jobs:
         run: |
           set -e
           PR_NUMBER=${{ github.event.inputs.pull_request_number }}
+          BASE_BRANCH=${{ steps.pr_info.outputs.base_branch }}
           git fetch origin pull/$PR_NUMBER/head:pr-$PR_NUMBER
+          # Also fetch base branch to have it locally for git show
+          git fetch origin $BASE_BRANCH:$BASE_BRANCH
 
           MD_FILES=$(gh pr diff $PR_NUMBER --name-only | grep '\.md$' || true)
 
@@ -47,8 +50,31 @@ jobs:
 
           for file in $MD_FILES; do
             if [ "$file" = "TODO.md" ]; then
-              # Special handling for TODO.md: turn [x] back to [ ]
-              git show "pr-$PR_NUMBER:$file" | sed 's/\[x\]/\[ \]/g' > "$file"
+              # Get base and head versions of the file
+              git show "$BASE_BRANCH:$file" > TODO.md.base
+              git show "pr-$PR_NUMBER:$file" > TODO.md.head
+
+              # Use awk to revert only the tasks that were checked in this PR
+              awk '
+                NR==FNR { base_lines[$0]; next }
+                {
+                  line = $0
+                  # See if line contains a checked task
+                  if (sub(/- \[x\]/, "- [ ]", line)) {
+                    # If the unchecked version of the line existed in the base file...
+                    if (line in base_lines) {
+                      # ...then print the reverted (unchecked) line.
+                      print line
+                      next
+                    }
+                  }
+                  # Otherwise, print the original line from the PR branch.
+                  print $0
+                }
+              ' TODO.md.base TODO.md.head > "$file"
+
+              # Clean up temp files
+              rm TODO.md.base TODO.md.head
             else
               # Default behavior for other .md files
               git checkout "pr-$PR_NUMBER" -- "$file"


### PR DESCRIPTION
From now on, when I prepare a pull request, I will revert any task in a `TODO.md` file that you've marked as complete (`[x]`) back to incomplete (`[ ]`). This ensures that completed TODOs from a feature branch will show up as open tasks again in the target branch.

My logic for all other markdown files remains unchanged.