### PR TITLE
I found an issue with the code generator for the `convert` tool: it w…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -109,14 +109,14 @@ Based on the plan in [docs/plan-multi-package-handling.md](./docs/plan-multi-pac
     *   [x] Update internal library code to use the new exported fields.
 
 **Part 2: Library Consumer Updates**
-*   [ ] **Refactor `examples/convert`**:
-    *   [ ] Simplify the `main.go` entrypoint to only scan the initial source package.
-    *   [ ] Remove manual `ScanPackageByImport` calls from the `parser`.
-    *   [ ] Modify the `parser` to call `FieldType.Resolve()` to find type definitions referenced in annotations.
-*   [ ] **Update `examples/convert` Integration Tests**:
-    *   [ ] Update the integration tests to use the enhanced `scantest` harness.
-    *   [ ] Cover scenarios with nested structs from multiple different packages.
-    *   [ ] Verify that the generated code compiles, has correct imports, and works as expected.
+*   [x] **Refactor `examples/convert`**:
+    *   [x] Simplify the `main.go` entrypoint to only scan the initial source package.
+    *   [x] Remove manual `ScanPackageByImport` calls from the `parser`.
+    *   [x] Modify the `parser` to call `FieldType.Resolve()` to find type definitions referenced in annotations.
+*   [x] **Update `examples/convert` Integration Tests**:
+    *   [x] Update the integration tests to use the enhanced `scantest` harness.
+    *   [x] Cover scenarios with nested structs from multiple different packages.
+    *   [x] Verify that the generated code compiles, has correct imports, and works as expected.
 
 **Part 3: CI and Regression Prevention**
 *   [ ] **Add CI Check for `examples/convert`**:

--- a/examples/convert/generator/generator.go
+++ b/examples/convert/generator/generator.go
@@ -478,7 +478,18 @@ func generateConversion(im *goscan.ImportManager, info *model.ParsedInfo, src, d
 		if !srcT.IsPointer {
 			srcPtr = "&" + src
 		}
-		conversion := fmt.Sprintf("*convert%sTo%s(%s, %s, %s)", srcT.Name, dstT.Name, ctxVar, ecVar, srcPtr)
+
+		// Use TypeName for unqualified name to avoid duplicate package prefixes
+		srcTypeName := srcT.TypeName
+		if srcTypeName == "" {
+			srcTypeName = srcT.Name // fallback
+		}
+		dstTypeName := dstT.TypeName
+		if dstTypeName == "" {
+			dstTypeName = dstT.Name // fallback
+		}
+
+		conversion := fmt.Sprintf("*convert%sTo%s(%s, %s, %s)", srcTypeName, dstTypeName, ctxVar, ecVar, srcPtr)
 		if dst != "" {
 			return fmt.Sprintf("%s = %s", dst, conversion)
 		}


### PR DESCRIPTION
…as producing incorrect function calls for nested struct conversions when the types were located in different packages. It would sometimes generate a call with a duplicated package alias, like `alias.alias.Func()`, which caused a compilation error.

The problem was that the generator was using the `FieldType.Name` field, which can be a package-qualified name (e.g., `external.DstInfo`), to construct the name of the recursive helper function (e.g., `convertSrcToexternal.DstInfo`).

I fixed this by using the `FieldType.TypeName` field instead, which always contains the unqualified type name. This ensures that the generated function call `convertSrcToDstInfo()` uses the correct, unqualified name, matching the function definition and preventing the duplicated alias.

This change completes the refactoring for on-demand, multi-package scanning as described in the `TODO.md`. All tests now pass.