### PR TITLE
Of course! Here is the rewritten message from Jules's perspective:

### DIFF
--- a/locator/locator.go
+++ b/locator/locator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/podhmo/go-scan/scanner"
@@ -226,7 +227,7 @@ func (l *Locator) FindPackageDir(importPath string) (string, error) {
 	// 3. Try standard library packages in GOROOT
 	// This is a heuristic: standard library packages usually don't have dots.
 	if !strings.Contains(importPath, ".") {
-		goRoot := os.Getenv("GOROOT")
+		goRoot := runtime.GOROOT()
 		if goRoot != "" {
 			candidatePath := filepath.Join(goRoot, "src", importPath)
 			if stat, err := os.Stat(candidatePath); err == nil && stat.IsDir() {

--- a/locator/locator.go
+++ b/locator/locator.go
@@ -223,6 +223,18 @@ func (l *Locator) FindPackageDir(importPath string) (string, error) {
 		}
 	}
 
+	// 3. Try standard library packages in GOROOT
+	// This is a heuristic: standard library packages usually don't have dots.
+	if !strings.Contains(importPath, ".") {
+		goRoot := os.Getenv("GOROOT")
+		if goRoot != "" {
+			candidatePath := filepath.Join(goRoot, "src", importPath)
+			if stat, err := os.Stat(candidatePath); err == nil && stat.IsDir() {
+				return candidatePath, nil
+			}
+		}
+	}
+
 	// If no replace directive matched and led to a path, and the original logic failed, then error.
 	return "", fmt.Errorf("import path %q could not be resolved. Current module is %q (root: %s)", importPath, l.modulePath, l.rootDir)
 }


### PR DESCRIPTION
I've just implemented a new feature and fixed an issue with Go standard library resolution.

I introduced a new function, `ScanFilesWithKnownImportPath`, to the scanner. This change allows you to specify the canonical import path of a package manually, which is crucial for correctly handling Go's standard library packages where the import path (like "time") doesn't match the file system path (like "$GOROOT/src/time").

Here’s a summary of the changes I made:
1.  **Enhanced the `locator`**: I added a fallback to `FindPackageDir` to search for packages in `$GOROOT/src` if they aren't found in your current module. This is based on the heuristic that standard library packages do not contain a dot in their import path.
2.  **Refactored the `scanner`**: I extracted the core logic of `ScanFiles` into a private `scanGoFiles` method. Now, `ScanFiles` derives the import path and calls `scanGoFiles`, and the new `ScanFilesWithKnownImportPath` function calls `scanGoFiles` with a provided import path.
3.  **Integrated into `goscan`**: I updated the `ScanPackageByImport` function in `goscan.go` to detect standard library paths and use the new `ScanFilesWithKnownImportPath` function, ensuring the correct import path is assigned.
4.  **Added Tests**: To verify the new behavior, I added a unit test for `ScanFilesWithKnownImportPath`.

I also confirmed that all existing tests pass, so no regressions were introduced.