### PR TITLE
refactor(testing): Refactor goscan_test.go using scantest

### DIFF
--- a/goscan_scantest_test.go
+++ b/goscan_scantest_test.go
@@ -1,0 +1,93 @@
+package goscan_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	goscan "github.com/podhmo/go-scan"
+	"github.com/podhmo/go-scan/scanner"
+	"github.com/podhmo/go-scan/scantest"
+)
+
+// findType is a helper to find a type by name in PackageInfo.
+func findType(types []*scanner.TypeInfo, name string) *scanner.TypeInfo {
+	for _, ti := range types {
+		if ti.Name == name {
+			return ti
+		}
+	}
+	return nil
+}
+
+func TestImplements_DerivingJSON_Scenario_WithScantest(t *testing.T) {
+	files := map[string]string{
+		"go.mod": `
+module example.com/derivingjson_scenario
+go 1.22.4
+`,
+		"types.go": `
+package derivingjson_scenario
+
+type EventData interface {
+	EventData()
+}
+
+type UserCreated struct{}
+func (e *UserCreated) EventData() {}
+
+type MessagePosted struct{}
+func (e *MessagePosted) EventData() {}
+
+type NotAnImplementer struct{}
+`,
+	}
+
+	dir, cleanup := scantest.WriteFiles(t, files)
+	defer cleanup()
+
+	action := func(ctx context.Context, s *goscan.Scanner, pkgs []*goscan.Package) error {
+		if len(pkgs) != 1 {
+			return fmt.Errorf("expected 1 package, but got %d", len(pkgs))
+		}
+		pkgInfo := pkgs[0]
+
+		// Find the interface
+		eventDataInterface := findType(pkgInfo.Types, "EventData")
+		if eventDataInterface == nil {
+			t.Fatal("Interface 'EventData' not found")
+		}
+
+		// Find implementers
+		var implementers []*scanner.TypeInfo
+		for _, ti := range pkgInfo.Types {
+			if ti.Kind == scanner.StructKind {
+				if goscan.Implements(ti, eventDataInterface, pkgInfo) {
+					implementers = append(implementers, ti)
+				}
+			}
+		}
+
+		if len(implementers) != 2 {
+			t.Fatalf("Expected to find 2 implementers, got %d", len(implementers))
+		}
+
+		implementerNames := make([]string, len(implementers))
+		for i, impl := range implementers {
+			implementerNames[i] = impl.Name
+		}
+		sort.Strings(implementerNames)
+
+		expectedImplementers := []string{"MessagePosted", "UserCreated"}
+		if diff := cmp.Diff(expectedImplementers, implementerNames); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+		return nil
+	}
+
+	if _, err := scantest.Run(t, dir, []string{"."}, action); err != nil {
+		t.Fatalf("scantest.Run() failed: %v", err)
+	}
+}

--- a/goscan_test.go
+++ b/goscan_test.go
@@ -19,16 +19,6 @@ import (
 	"github.com/podhmo/go-scan/scanner"
 )
 
-// Helper to create a temporary directory for testing scanner cache
-func tempScannerDir(t *testing.T) (string, func()) {
-	t.Helper()
-	dir, err := os.MkdirTemp("", "scanner_cache_test_")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir for scanner test: %v", err)
-	}
-	return dir, func() { os.RemoveAll(dir) }
-}
-
 // TestNew_Integration tests the creation of a new Scanner and its underlying locator.
 func TestNew_Integration(t *testing.T) {
 	s, err := New(WithWorkDir("./scanner")) // Assuming this test runs from project root where ./scanner is a valid sub-package.
@@ -143,8 +133,7 @@ func TestScanner_WithSymbolCache(t *testing.T) {
 	expectedUserFilePath, _ := filepath.Abs(filepath.Join(moduleRootDir, "models/user.go"))
 
 	t.Run("ScanAndUpdateCache_FindSymbol_CacheHit", func(t *testing.T) {
-		testCacheDir, cleanupTestCacheDir := tempScannerDir(t)
-		defer cleanupTestCacheDir()
+		testCacheDir := t.TempDir()
 		cacheFilePath := filepath.Join(testCacheDir, "symbols.json")
 
 		s, err := New(WithWorkDir("./testdata/multipkg")) // Scanner for the test module
@@ -228,8 +217,7 @@ func TestScanner_WithSymbolCache(t *testing.T) {
 	})
 
 	t.Run("FindSymbol_CacheMiss_FallbackScanSuccess", func(t *testing.T) {
-		testCacheDir, cleanupTestCacheDir := tempScannerDir(t)
-		defer cleanupTestCacheDir()
+		testCacheDir := t.TempDir()
 		cacheFilePath := filepath.Join(testCacheDir, "symbols_fallback.json")
 
 		s, err := New(WithWorkDir("./testdata/multipkg"))
@@ -258,8 +246,7 @@ func TestScanner_WithSymbolCache(t *testing.T) {
 	})
 
 	t.Run("FindSymbol_CacheStale_FallbackScanSuccess", func(t *testing.T) {
-		testCacheDir, cleanupTestCacheDir := tempScannerDir(t)
-		defer cleanupTestCacheDir()
+		testCacheDir := t.TempDir()
 		cacheFilePath := filepath.Join(testCacheDir, "symbols_stale.json")
 
 		s, err := New(WithWorkDir("./testdata/multipkg"))
@@ -309,8 +296,7 @@ func TestScanner_WithSymbolCache(t *testing.T) {
 	})
 
 	t.Run("FindSymbol_NonExistentSymbol_FallbackScanFail", func(t *testing.T) {
-		testCacheDir, cleanupTestCacheDir := tempScannerDir(t)
-		defer cleanupTestCacheDir()
+		testCacheDir := t.TempDir()
 		cacheFilePath := filepath.Join(testCacheDir, "symbols_nonexist.json")
 
 		s, err := New(WithWorkDir("./testdata/multipkg"))
@@ -332,8 +318,7 @@ func TestScanner_WithSymbolCache(t *testing.T) {
 	})
 
 	t.Run("CacheDisabled_NoCacheFileCreated", func(t *testing.T) {
-		testCacheDir, cleanupTestCacheDir := tempScannerDir(t)
-		defer cleanupTestCacheDir()
+		testCacheDir := t.TempDir()
 		cacheFilePath := filepath.Join(testCacheDir, "symbols_disabled.json")
 
 		s, err := New(WithWorkDir("./testdata/multipkg"))
@@ -1004,8 +989,7 @@ func TestImplements(t *testing.T) {
 
 func TestSaveGoFile_Imports(t *testing.T) {
 	ctx := context.Background()
-	tempDir, cleanup := tempScannerDir(t)
-	defer cleanup()
+	tempDir := t.TempDir()
 
 	pkgDir := NewPackageDirectory(tempDir, "testpkg")
 

--- a/scantest/scantest.go
+++ b/scantest/scantest.go
@@ -64,10 +64,10 @@ func WithModuleRoot(path string) RunOption {
 // It returns a Result object if the action had side effects captured by the harness.
 //
 // By default, `Run` determines the module root for the scanner by performing a two-phase search for `go.mod`:
-// 1. It first searches from the temporary test directory (`dir`) upwards to the filesystem root.
-//    This is useful if the test's file layout (created via `WriteFiles`) constitutes a self-contained module.
-// 2. If not found, it searches from the current working directory (`os.Getwd()`) upwards.
-//    This allows the scanner to resolve dependencies against the actual project's `go.mod` file.
+//  1. It first searches from the temporary test directory (`dir`) upwards to the filesystem root.
+//     This is useful if the test's file layout (created via `WriteFiles`) constitutes a self-contained module.
+//  2. If not found, it searches from the current working directory (`os.Getwd()`) upwards.
+//     This allows the scanner to resolve dependencies against the actual project's `go.mod` file.
 //
 // This default behavior can be overridden by using the `WithModuleRoot()` option to specify an explicit path.
 func Run(t *testing.T, dir string, patterns []string, action ActionFunc, opts ...RunOption) (*Result, error) {


### PR DESCRIPTION
Refactored `goscan_test.go` to use the `scantest` package for setting up test cases that require virtual Go source files.

- Removed the redundant local helper function `writeTestFiles` and `tempScannerDir` from `goscan_test.go`. The former is replaced by `scantest.WriteFiles` and the latter by the standard library's `t.TempDir()`.

- Moved the test case `TestImplements_DerivingJSON_Scenario` into a new external test file `goscan_scantest_test.go` (with `package goscan_test`) to resolve a circular dependency issue that arose from using `scantest` within the `goscan` package's own tests.

- The new test now uses `scantest.Run` to simplify the test's structure, making it cleaner and more focused on the actual test logic.