### PR TITLE
feat: Add cross-package CI check for convert example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,16 @@ test:
 	go -C ./examples/derivingbind test ./...
 	go -C ./examples/minigo test ./...
 	go -C ./examples/convert test ./...
+	$(MAKE) test-example-convert
+
+test-example-convert:
+	@echo "Building convert tool..."
+	cd ./examples/convert && go build -o /tmp/convert .
+	@echo "Running convert tool integration test (cross-package)..."
+	cd ./examples/convert/ci-test && /tmp/convert -cwd . -pkg ci-test/source -output source/generated.go
+	@echo "Cleaning up generated file and binary..."
+	rm ./examples/convert/ci-test/source/generated.go
+	rm /tmp/convert
 
 clean:
 	go clean -cache -testcache # General Go clean

--- a/TODO.md
+++ b/TODO.md
@@ -121,8 +121,8 @@ Based on the plan in [docs/plan-multi-package-handling.md](./docs/plan-multi-pac
     *   [x] Verify that the generated code compiles, has correct imports, and works as expected.
 
 **Part 3: CI and Regression Prevention**
-*   [ ] **Add CI Check for `examples/convert`**:
-    *   [ ] Add a new target to the `Makefile` to run the `examples/convert` tool.
+*   [x] **Add CI Check for `examples/convert`**:
+    *   [x] Add a new target to the `Makefile` to run the `examples/convert` tool.
 
 ### Future Tasks (Post-Migration)
 *   **Expand Test Coverage**: Create a comprehensive test suite that verifies all features and edge cases.

--- a/examples/convert/ci-test/destination/destination.go
+++ b/examples/convert/ci-test/destination/destination.go
@@ -1,0 +1,6 @@
+package destination
+
+type Dst struct {
+	ID   string
+	Name string
+}

--- a/examples/convert/ci-test/go.mod
+++ b/examples/convert/ci-test/go.mod
@@ -1,0 +1,3 @@
+module ci-test
+
+go 1.22.4

--- a/examples/convert/ci-test/source/source.go
+++ b/examples/convert/ci-test/source/source.go
@@ -1,0 +1,11 @@
+package source
+
+import (
+	dest "ci-test/destination"
+)
+
+// @derivingconvert("dest.Dst")
+type Src struct {
+	ID   string
+	Name string
+}


### PR DESCRIPTION
This commit adds a new CI check to verify that the `examples/convert` tool works correctly for cross-package code generation.

A new test case in `examples/convert/ci-test` provides a multi-package structure with `source` and `destination` packages. The `source` package uses a `@derivingconvert` annotation to generate a converter for a type in the `destination` package.

A `test-example-convert` target has been added to the `Makefile` to build and run the `convert` tool against this new test case. This target is integrated into the main `test` target.

`TODO.md` has been updated to mark this task as complete.