### PR TITLE
docs: Synchronize plan and future docs with current state

### DIFF
--- a/docs/near-future.md
+++ b/docs/near-future.md
@@ -31,6 +31,14 @@ This document outlines the current status, planned features, and areas for impro
 -   **Testing Harness (`scantest`):** Implemented the `scantest` library to provide a testing harness for `go-scan` based tools. The implementation, detailed in [docs/plan-scantest.md](./docs/plan-scantest.md), uses a significant enhancement not in the original plan: I/O operations are intercepted via `context.Context`. This allows `scantest` to capture file generation output in memory without altering the tool's own code, a key difference from initial concepts.
 -   **In-Memory File Overlay:** Added an "overlay" feature to `go-scan` to allow providing in-memory file content. This is useful for tools that generate or modify Go source code without writing to the filesystem. This was implemented as described in [docs/plan-overlay.md](./docs/plan-overlay.md).
 -   **Integration Tests for Examples:** Added integration tests for the code generation tools in the `examples/` directory using the new `scantest` library.
+-   **Recursive Type and Dependency Handling**: Gracefully handles recursive type definitions and circular dependencies between packages, preventing infinite loops during type resolution.
+-   **External and Standard Library Package Resolution**: Can resolve packages from GOROOT and GOMODCACHE via `WithGoModuleResolver`.
+-   **Variadic Parameter Parsing**: Correctly parses variadic parameters (e.g., `...string`) as slices.
+-   **Fix for Standard Library Scanning in Tests**: Resolved `mismatched package names` errors that occurred during tests via an enhanced `ExternalTypeOverride` mechanism.
+-   **On-Demand, Multi-Package AST Scanning**: Implemented a lazy, on-demand scanning system to robustly support multi-package analysis.
+-   **`convert` Tool**: A powerful, annotation-driven tool for generating type conversion functions has been fully implemented as detailed in `docs/plan-neo-convert.md`.
+-   **Generator Logic Enhancements**: The code generator now supports recursive converter generation, pointer-aware global rules, and has improved type resolution for generics and pointers.
+-   **CLI and Build Fixes**: Corrected underlying issues with `make e2e` and other build/test targets, which are now integrated into the main test suite.
 
 ## Partially Implemented/Experimental/Needs Refinement
 
@@ -71,16 +79,6 @@ This document outlines the current status, planned features, and areas for impro
     -   (Covered above) List of package-level variables.
 -   **`iota` Evaluation for Constants:** Implement basic logic to correctly evaluate the integer values of constants defined using `iota` (e.g., for simple enums).
     -   *More complex `iota` scenarios and deeper semantic understanding are discussed in [./dream2.md](./dream2.md).*
-
-## CLI and Tooling Improvements
-
--   **Implement Improved Scanning Logic in Example Tools:**
-    -   **Description:** The command-line tools in `examples/` should be updated to handle file and directory paths more intelligently, as outlined in the proposal. This involves distinguishing between file and directory arguments and grouping multiple file arguments by package.
-    -   **Proposal Document:** [./scan-improvement.md](./scan-improvement.md)
-    -   **Subtasks:**
-        1.  **Refactor `examples/derivingjson`:** Modify `main.go` to implement the proposed scanning logic.
-        2.  **Refactor `examples/derivingbind`:** Modify `main.go` to implement the same logic.
-        3.  **Verify Behavior:** Add simple test cases or manual verification steps to confirm that the tools correctly handle single-file, multi-file, and directory inputs.
 
 ## Broader Vision & Advanced Features
 

--- a/docs/plan-multi-package-handling.md
+++ b/docs/plan-multi-package-handling.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This feature has been implemented.
+
 # Plan for On-Demand, Multi-Package AST Scanning
 
 ## 1. Overview

--- a/docs/plan-neo-convert.md
+++ b/docs/plan-neo-convert.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This feature has been implemented.
+
 # Plan for `convert`: A Guide to Re-implementation and Migration
 
 This document outlines the progress, key decisions, and future tasks for rebuilding the `examples/convert` tool. It is intended to be detailed enough for a developer to re-implement the tool and migrate from the old prototype.

--- a/docs/plan-support-recursive-definition.md
+++ b/docs/plan-support-recursive-definition.md
@@ -1,8 +1,9 @@
+> [!NOTE]
+> This feature has been implemented.
+
 # Handling of Recursive Type Definitions and Circular Dependencies
 
 This document outlines how `go-scan` robustly handles recursive type definitions (e.g., a struct containing a field that is a pointer to itself) and circular dependencies between packages during type resolution.
-
-**Status: Implemented.** The logic described here is implemented and tested.
 
 ## The Challenge: Infinite Loops
 


### PR DESCRIPTION
- I updated `docs/near-future.md` to reflect the extensive list of implemented features from `TODO.md`, providing an accurate high-level status of the project.
- I added an 'implemented' banner to all `docs/plan-*.md` files corresponding to completed features (`plan-neo-convert.md`, `plan-multi-package-handling.md`, etc.) to clarify that they are historical design documents.