### PR TITLE
refactor(convert): Use blocks instead of IIFEs in generator

### DIFF
--- a/examples/convert/testdata/complex.go.golden
+++ b/examples/convert/testdata/complex.go.golden
@@ -18,30 +18,30 @@ func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *D
 		return dst
 	}
 	ec.Enter("Items")
-	dst.Items = func() []*DstItem {
+	{
 		convertedSlice := make([]*DstItem, len(src.Items))
 		for i, item := range src.Items {
 			ec.Enter(fmt.Sprintf("[%d]", i))
 			convertedSlice[i] = convertSrcItemToDstItem(ctx, ec, item)
 			ec.Leave()
 		}
-		return convertedSlice
-	}()
+		dst.Items = convertedSlice
+	}
 
 	ec.Leave()
 	if ec.MaxErrorsReached() {
 		return dst
 	}
 	ec.Enter("ItemMap")
-	dst.ItemMap = func() map[string]*DstItem {
+	{
 		convertedMap := make(map[string]*DstItem, len(src.ItemMap))
 		for key, value := range src.ItemMap {
 			ec.Enter(fmt.Sprintf("[%v]", key))
 			convertedMap[key] = convertSrcItemToDstItem(ctx, ec, value)
 			ec.Leave()
 		}
-		return convertedMap
-	}()
+		dst.ItemMap = convertedMap
+	}
 
 	ec.Leave()
 	return dst

--- a/examples/convert/testdata/mapkeys.go.golden
+++ b/examples/convert/testdata/mapkeys.go.golden
@@ -18,15 +18,15 @@ func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *D
 		return dst
 	}
 	ec.Enter("Data")
-	dst.Data = func() map[string]string {
+	{
 		convertedMap := make(map[string]string, len(src.Data))
 		for key, value := range src.Data {
 			ec.Enter(fmt.Sprintf("[%v]", key))
 			convertedMap[key] = value
 			ec.Leave()
 		}
-		return convertedMap
-	}()
+		dst.Data = convertedMap
+	}
 
 	ec.Leave()
 	return dst

--- a/examples/convert/testdata/maps.go.golden
+++ b/examples/convert/testdata/maps.go.golden
@@ -18,30 +18,30 @@ func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *D
 		return dst
 	}
 	ec.Enter("Items")
-	dst.Items = func() map[string]DstItem {
+	{
 		convertedMap := make(map[string]DstItem, len(src.Items))
 		for key, value := range src.Items {
 			ec.Enter(fmt.Sprintf("[%v]", key))
 			convertedMap[key] = *convertSrcItemToDstItem(ctx, ec, &value)
 			ec.Leave()
 		}
-		return convertedMap
-	}()
+		dst.Items = convertedMap
+	}
 
 	ec.Leave()
 	if ec.MaxErrorsReached() {
 		return dst
 	}
 	ec.Enter("ItemPtrs")
-	dst.ItemPtrs = func() map[string]*DstItem {
+	{
 		convertedMap := make(map[string]*DstItem, len(src.ItemPtrs))
 		for key, value := range src.ItemPtrs {
 			ec.Enter(fmt.Sprintf("[%v]", key))
 			convertedMap[key] = convertSrcItemToDstItem(ctx, ec, value)
 			ec.Leave()
 		}
-		return convertedMap
-	}()
+		dst.ItemPtrs = convertedMap
+	}
 
 	ec.Leave()
 	return dst

--- a/examples/convert/testdata/pointers.go.golden
+++ b/examples/convert/testdata/pointers.go.golden
@@ -18,15 +18,15 @@ func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *D
 		return dst
 	}
 	ec.Enter("Items")
-	dst.Items = func() []*DstItem {
+	{
 		convertedSlice := make([]*DstItem, len(src.Items))
 		for i, item := range src.Items {
 			ec.Enter(fmt.Sprintf("[%d]", i))
 			convertedSlice[i] = convertSrcItemToDstItem(ctx, ec, item)
 			ec.Leave()
 		}
-		return convertedSlice
-	}()
+		dst.Items = convertedSlice
+	}
 
 	ec.Leave()
 	if ec.MaxErrorsReached() {

--- a/examples/convert/testdata/slices.go.golden
+++ b/examples/convert/testdata/slices.go.golden
@@ -18,15 +18,15 @@ func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *D
 		return dst
 	}
 	ec.Enter("Items")
-	dst.Items = func() []DstItem {
+	{
 		convertedSlice := make([]DstItem, len(src.Items))
 		for i, item := range src.Items {
 			ec.Enter(fmt.Sprintf("[%d]", i))
 			convertedSlice[i] = *convertSrcItemToDstItem(ctx, ec, &item)
 			ec.Leave()
 		}
-		return convertedSlice
-	}()
+		dst.Items = convertedSlice
+	}
 
 	ec.Leave()
 	return dst


### PR DESCRIPTION
The code generator for conversions in `examples/convert` previously used immediately-invoked function expressions (IIFEs) of the form `func() { ... }()` to create new scopes for temporary variables during slice and map conversions.

While this is a valid way to create an expression from a block of statements, it is not necessary when the result is immediately assigned to a field. In Go, a simple block `{ ... }` is sufficient to create a new scope for variables, which is cleaner and more readable.

This commit refactors the code generator to produce simple blocks for slice and map conversions when they are part of a direct assignment. This makes the generated code simpler and easier to understand. The generator still uses IIFEs in contexts where an expression is required.