### PR TITLE
feat(generator): Document unmapped fields in generated code

### DIFF
--- a/examples/convert/Makefile
+++ b/examples/convert/Makefile
@@ -1,10 +1,17 @@
-.PHONY: test clean e2e
+.PHONY: test clean e2e update-golden
 
 test: clean
 	go test -v ./...
 
+# The 'e2e' and 'test' targets are separate because in CI,
+# the generation step (e2e) and the testing step (test) are run independently.
+# The 'update-golden' target is for local development to update testdata.
+update-golden:
+	go test -v . -update
+
 clean:
 	rm -rf sampledata/generated
+	rm -rf generated_test
 
 e2e:
 	mkdir -p sampledata/generated

--- a/examples/convert/TODO.md
+++ b/examples/convert/TODO.md
@@ -1,0 +1,2 @@
+- [x] Document unpopulated fields in the docstrings of generated converter functions.
+- [x] Add a test to verify that the documented fields are indeed unpopulated.

--- a/examples/convert/generated_test/generated_test.go
+++ b/examples/convert/generated_test/generated_test.go
@@ -1,0 +1,110 @@
+package generated_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/podhmo/go-scan/examples/convert/sampledata/destination"
+	"github.com/podhmo/go-scan/examples/convert/sampledata/generated"
+	"github.com/podhmo/go-scan/examples/convert/sampledata/source"
+)
+
+func TestGeneratedUserConversion(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	updatedAt := now.Add(time.Hour)
+
+	src := &source.SrcUser{
+		ID:        101,
+		FirstName: "John",
+		LastName:  "Doe",
+		SrcAddress: source.SrcAddress{
+			Street: "123 Main St",
+			City:   "Anytown",
+		},
+		ContactInfo: source.SrcContact{
+			Email: "john.doe@example.com",
+		},
+		Details: []source.SrcInternalDetail{
+			{Code: 1, Description: "Detail 1"},
+		},
+		CreatedAt: now,
+		UpdatedAt: &updatedAt,
+	}
+
+	// Expected result from the *generated* converter.
+	// Note that many fields will be zero-valued because the generator
+	// doesn't handle name mismatches or custom logic.
+	expected := &destination.DstUser{
+		// UserID is not mapped (ID vs UserID)
+		// FullName is not mapped (requires combining FirstName and LastName)
+		// Address is not mapped (SrcAddress vs Address)
+		// Contact is not mapped (ContactInfo vs Contact)
+		Details: []destination.DstInternalDetail{
+			{}, // Inner fields are not mapped (Code vs ItemCode, etc.)
+		},
+		CreatedAt: now.Format(time.RFC3339),
+		UpdatedAt: updatedAt.Format(time.RFC3339),
+	}
+
+	got, err := generated.ConvertSrcUserToDstUser(ctx, src)
+	if err != nil {
+		t.Fatalf("ConvertSrcUserToDstUser() failed: %v", err)
+	}
+
+	// We can't use reflect.DeepEqual because of the unexported fields in time.Time
+	// and the fact that we have zero-valued structs with potentially unexported fields.
+	// Let's check the fields we care about.
+	if got.UserID != expected.UserID {
+		t.Errorf("got UserID %q, want %q", got.UserID, expected.UserID)
+	}
+	if got.FullName != expected.FullName {
+		t.Errorf("got FullName %q, want %q", got.FullName, expected.FullName)
+	}
+	if !reflect.DeepEqual(got.Address, expected.Address) {
+		t.Errorf("got Address %+v, want %+v", got.Address, expected.Address)
+	}
+	if !reflect.DeepEqual(got.Contact, expected.Contact) {
+		t.Errorf("got Contact %+v, want %+v", got.Contact, expected.Contact)
+	}
+	if got.CreatedAt != expected.CreatedAt {
+		t.Errorf("got CreatedAt %q, want %q", got.CreatedAt, expected.CreatedAt)
+	}
+	if got.UpdatedAt != expected.UpdatedAt {
+		t.Errorf("got UpdatedAt %q, want %q", got.UpdatedAt, expected.UpdatedAt)
+	}
+
+	// Check inner slice details
+	if len(got.Details) != len(expected.Details) {
+		t.Fatalf("got %d details, want %d", len(got.Details), len(expected.Details))
+	}
+	if !reflect.DeepEqual(got.Details[0], expected.Details[0]) {
+		t.Errorf("got Details[0] %+v, want %+v", got.Details[0], expected.Details[0])
+	}
+}
+
+func TestGeneratedOrderConversion(t *testing.T) {
+	ctx := context.Background()
+	src := &source.SrcOrder{
+		OrderID: "ORD-001",
+		Amount:  99.99,
+		Items: []source.SrcItem{
+			{SKU: "item-1", Quantity: 2},
+		},
+	}
+
+	// The generated function is currently empty, so all fields should be zero-valued.
+	expected := &destination.DstOrder{}
+
+	got, err := generated.ConvertSrcOrderToDstOrder(ctx, src)
+	if err != nil {
+		t.Fatalf("ConvertSrcOrderToDstOrder() failed: %v", err)
+	}
+
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Errorf("ConvertSrcOrderToDstOrder() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/examples/convert/generator/generator.go
+++ b/examples/convert/generator/generator.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -28,6 +29,14 @@ import (
 )
 
 {{ range .Pairs -}}
+// convert{{ .SrcType.Name }}To{{ .DstType.Name }} converts {{ getQualifiedTypeName $.Im .SrcType }} to {{ getQualifiedTypeName $.Im .DstType }}.
+{{- if .UnmappedFields }}
+//
+// Fields that are not populated by this converter:
+{{- range .UnmappedFields }}
+//   - {{ . }}
+{{- end }}
+{{- end }}
 func convert{{ .SrcType.Name }}To{{ .DstType.Name }}(ctx context.Context, ec *model.ErrorCollector, src *{{ getQualifiedTypeName $.Im .SrcType }}) *{{ getQualifiedTypeName $.Im .DstType }} {
 	if src == nil {
 		return nil
@@ -51,6 +60,13 @@ func convert{{ .SrcType.Name }}To{{ .DstType.Name }}(ctx context.Context, ec *mo
 }
 
 // Convert{{ .SrcType.Name }}To{{ .DstType.Name }} converts {{ getQualifiedTypeName $.Im .SrcType }} to {{ getQualifiedTypeName $.Im .DstType }}.
+{{- if .UnmappedFields }}
+//
+// Fields that are not populated by this converter:
+{{- range .UnmappedFields }}
+//   - {{ . }}
+{{- end }}
+{{- end }}
 func Convert{{ .SrcType.Name }}To{{ .DstType.Name }}(ctx context.Context, src *{{ getQualifiedTypeName $.Im .SrcType }}) (*{{ getQualifiedTypeName $.Im .DstType }}, error) {
 	if src == nil {
 		return nil, nil
@@ -74,10 +90,11 @@ type TemplateData struct {
 }
 
 type TemplatePair struct {
-	SrcType *model.StructInfo
-	DstType *model.StructInfo
-	Fields  []FieldMap
-	Pair    model.ConversionPair
+	SrcType        *model.StructInfo
+	DstType        *model.StructInfo
+	Fields         []FieldMap
+	Pair           model.ConversionPair
+	UnmappedFields []string
 }
 
 type FieldMap struct {
@@ -133,7 +150,7 @@ func Generate(s *goscan.Scanner, info *model.ParsedInfo) ([]byte, error) {
 			registerImports(im, field.FieldType)
 		}
 
-		fieldMaps, err := createFieldMaps(ctx, s, srcStruct, dstStruct)
+		fieldMaps, unmappedFields, err := createFieldMaps(ctx, s, srcStruct, dstStruct)
 		if err != nil {
 			return nil, fmt.Errorf("creating field maps for %s -> %s: %w", srcStruct.Name, dstStruct.Name, err)
 		}
@@ -165,10 +182,11 @@ func Generate(s *goscan.Scanner, info *model.ParsedInfo) ([]byte, error) {
 		}
 
 		allPairs = append(allPairs, TemplatePair{
-			SrcType: srcStruct,
-			DstType: dstStruct,
-			Fields:  fieldMaps,
-			Pair:    pair,
+			SrcType:        srcStruct,
+			DstType:        dstStruct,
+			Fields:         fieldMaps,
+			Pair:           pair,
+			UnmappedFields: unmappedFields,
 		})
 	}
 
@@ -223,11 +241,12 @@ func Generate(s *goscan.Scanner, info *model.ParsedInfo) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func createFieldMaps(ctx context.Context, s *goscan.Scanner, src, dst *model.StructInfo) ([]FieldMap, error) {
+func createFieldMaps(ctx context.Context, s *goscan.Scanner, src, dst *model.StructInfo) ([]FieldMap, []string, error) {
 	var maps []FieldMap
 	dstFieldsByName := make(map[string]model.FieldInfo)
 	dstFieldsByNormalizedJSONTag := make(map[string]model.FieldInfo)
 	dstFieldsByNormalizedName := make(map[string]model.FieldInfo)
+	unmappedDstFields := make(map[string]bool)
 
 	slog.DebugContext(ctx, "Destination struct", "name", dst.Name)
 	for _, f := range dst.Fields {
@@ -240,6 +259,7 @@ func createFieldMaps(ctx context.Context, s *goscan.Scanner, src, dst *model.Str
 		normalized := normalizeFieldName(f.Name)
 		dstFieldsByNormalizedName[normalized] = f
 		slog.DebugContext(ctx, "dst field", "name", f.Name, "normalized_name", normalized)
+		unmappedDstFields[f.Name] = true
 	}
 
 	slog.DebugContext(ctx, "Source struct", "name", src.Name)
@@ -280,6 +300,7 @@ func createFieldMaps(ctx context.Context, s *goscan.Scanner, src, dst *model.Str
 		}
 
 		slog.DebugContext(ctx, "src field matched", "src", srcField.Name, "dst", dstField.Name, "reason", reason)
+		delete(unmappedDstFields, dstField.Name)
 		_ = resolveFieldType(ctx, dstField.FieldType)
 		maps = append(maps, FieldMap{
 			SrcName:   srcField.Name,
@@ -289,7 +310,16 @@ func createFieldMaps(ctx context.Context, s *goscan.Scanner, src, dst *model.Str
 			DstFieldT: dstField.FieldType,
 		})
 	}
-	return maps, nil
+
+	// Collect unmapped fields
+	var unmapped []string
+	for fieldName := range unmappedDstFields {
+		unmapped = append(unmapped, fieldName)
+	}
+	// sort for deterministic output
+	slices.Sort(unmapped)
+
+	return maps, unmapped, nil
 }
 
 func normalizeFieldName(name string) string {

--- a/examples/convert/sampledata/generated/generated.go
+++ b/examples/convert/sampledata/generated/generated.go
@@ -12,6 +12,13 @@ import (
 	source "github.com/podhmo/go-scan/examples/convert/sampledata/source"
 )
 
+// convertSrcUserToDstUser converts source.SrcUser to destination.DstUser.
+//
+// Fields that are not populated by this converter:
+//   - Address
+//   - Contact
+//   - FullName
+//   - UserID
 func convertSrcUserToDstUser(ctx context.Context, ec *model.ErrorCollector, src *source.SrcUser) *destination.DstUser {
 	if src == nil {
 		return nil
@@ -21,15 +28,15 @@ func convertSrcUserToDstUser(ctx context.Context, ec *model.ErrorCollector, src 
 		return dst
 	}
 	ec.Enter("Details")
-	dst.Details = func() []destination.DstInternalDetail {
+	{
 		convertedSlice := make([]destination.DstInternalDetail, len(src.Details))
 		for i, item := range src.Details {
 			ec.Enter(fmt.Sprintf("[%d]", i))
 			convertedSlice[i] = *convertSrcInternalDetailToDstInternalDetail(ctx, ec, &item)
 			ec.Leave()
 		}
-		return convertedSlice
-	}()
+		dst.Details = convertedSlice
+	}
 
 	ec.Leave()
 	if ec.MaxErrorsReached() {
@@ -50,6 +57,12 @@ func convertSrcUserToDstUser(ctx context.Context, ec *model.ErrorCollector, src 
 }
 
 // ConvertSrcUserToDstUser converts source.SrcUser to destination.DstUser.
+//
+// Fields that are not populated by this converter:
+//   - Address
+//   - Contact
+//   - FullName
+//   - UserID
 func ConvertSrcUserToDstUser(ctx context.Context, src *source.SrcUser) (*destination.DstUser, error) {
 	if src == nil {
 		return nil, nil
@@ -61,6 +74,13 @@ func ConvertSrcUserToDstUser(ctx context.Context, src *source.SrcUser) (*destina
 	}
 	return dst, nil
 }
+
+// convertSrcOrderToDstOrder converts source.SrcOrder to destination.DstOrder.
+//
+// Fields that are not populated by this converter:
+//   - ID
+//   - LineItems
+//   - TotalAmount
 func convertSrcOrderToDstOrder(ctx context.Context, ec *model.ErrorCollector, src *source.SrcOrder) *destination.DstOrder {
 	if src == nil {
 		return nil
@@ -70,6 +90,11 @@ func convertSrcOrderToDstOrder(ctx context.Context, ec *model.ErrorCollector, sr
 }
 
 // ConvertSrcOrderToDstOrder converts source.SrcOrder to destination.DstOrder.
+//
+// Fields that are not populated by this converter:
+//   - ID
+//   - LineItems
+//   - TotalAmount
 func ConvertSrcOrderToDstOrder(ctx context.Context, src *source.SrcOrder) (*destination.DstOrder, error) {
 	if src == nil {
 		return nil, nil
@@ -81,6 +106,8 @@ func ConvertSrcOrderToDstOrder(ctx context.Context, src *source.SrcOrder) (*dest
 	}
 	return dst, nil
 }
+
+// convertComplexSourceToComplexTarget converts source.ComplexSource to destination.ComplexTarget.
 func convertComplexSourceToComplexTarget(ctx context.Context, ec *model.ErrorCollector, src *source.ComplexSource) *destination.ComplexTarget {
 	if src == nil {
 		return nil
@@ -109,30 +136,30 @@ func convertComplexSourceToComplexTarget(ctx context.Context, ec *model.ErrorCol
 		return dst
 	}
 	ec.Enter("Slice")
-	dst.Slice = func() []destination.SubTarget {
+	{
 		convertedSlice := make([]destination.SubTarget, len(src.Slice))
 		for i, item := range src.Slice {
 			ec.Enter(fmt.Sprintf("[%d]", i))
 			convertedSlice[i] = *convertSubSourceToSubTarget(ctx, ec, &item)
 			ec.Leave()
 		}
-		return convertedSlice
-	}()
+		dst.Slice = convertedSlice
+	}
 
 	ec.Leave()
 	if ec.MaxErrorsReached() {
 		return dst
 	}
 	ec.Enter("SliceOfPtrs")
-	dst.SliceOfPtrs = func() []*destination.SubTarget {
+	{
 		convertedSlice := make([]*destination.SubTarget, len(src.SliceOfPtrs))
 		for i, item := range src.SliceOfPtrs {
 			ec.Enter(fmt.Sprintf("[%d]", i))
 			convertedSlice[i] = convertSubSourceToSubTarget(ctx, ec, item)
 			ec.Leave()
 		}
-		return convertedSlice
-	}()
+		dst.SliceOfPtrs = convertedSlice
+	}
 
 	ec.Leave()
 	return dst
@@ -150,6 +177,8 @@ func ConvertComplexSourceToComplexTarget(ctx context.Context, src *source.Comple
 	}
 	return dst, nil
 }
+
+// convertSourceWithMapToTargetWithMap converts source.SourceWithMap to destination.TargetWithMap.
 func convertSourceWithMapToTargetWithMap(ctx context.Context, ec *model.ErrorCollector, src *source.SourceWithMap) *destination.TargetWithMap {
 	if src == nil {
 		return nil
@@ -159,45 +188,45 @@ func convertSourceWithMapToTargetWithMap(ctx context.Context, ec *model.ErrorCol
 		return dst
 	}
 	ec.Enter("ValueMap")
-	dst.ValueMap = func() map[string]destination.SubTarget {
+	{
 		convertedMap := make(map[string]destination.SubTarget, len(src.ValueMap))
 		for key, value := range src.ValueMap {
 			ec.Enter(fmt.Sprintf("[%v]", key))
 			convertedMap[key] = *convertSubSourceToSubTarget(ctx, ec, &value)
 			ec.Leave()
 		}
-		return convertedMap
-	}()
+		dst.ValueMap = convertedMap
+	}
 
 	ec.Leave()
 	if ec.MaxErrorsReached() {
 		return dst
 	}
 	ec.Enter("PtrMap")
-	dst.PtrMap = func() map[string]*destination.SubTarget {
+	{
 		convertedMap := make(map[string]*destination.SubTarget, len(src.PtrMap))
 		for key, value := range src.PtrMap {
 			ec.Enter(fmt.Sprintf("[%v]", key))
 			convertedMap[key] = convertSubSourceToSubTarget(ctx, ec, value)
 			ec.Leave()
 		}
-		return convertedMap
-	}()
+		dst.PtrMap = convertedMap
+	}
 
 	ec.Leave()
 	if ec.MaxErrorsReached() {
 		return dst
 	}
 	ec.Enter("StringToStr")
-	dst.StringToStr = func() map[string]string {
+	{
 		convertedMap := make(map[string]string, len(src.StringToStr))
 		for key, value := range src.StringToStr {
 			ec.Enter(fmt.Sprintf("[%v]", key))
 			convertedMap[key] = value
 			ec.Leave()
 		}
-		return convertedMap
-	}()
+		dst.StringToStr = convertedMap
+	}
 
 	ec.Leave()
 	return dst
@@ -215,6 +244,12 @@ func ConvertSourceWithMapToTargetWithMap(ctx context.Context, src *source.Source
 	}
 	return dst, nil
 }
+
+// convertSrcInternalDetailToDstInternalDetail converts source.SrcInternalDetail to destination.DstInternalDetail.
+//
+// Fields that are not populated by this converter:
+//   - ItemCode
+//   - LocalizedDesc
 func convertSrcInternalDetailToDstInternalDetail(ctx context.Context, ec *model.ErrorCollector, src *source.SrcInternalDetail) *destination.DstInternalDetail {
 	if src == nil {
 		return nil
@@ -224,6 +259,10 @@ func convertSrcInternalDetailToDstInternalDetail(ctx context.Context, ec *model.
 }
 
 // ConvertSrcInternalDetailToDstInternalDetail converts source.SrcInternalDetail to destination.DstInternalDetail.
+//
+// Fields that are not populated by this converter:
+//   - ItemCode
+//   - LocalizedDesc
 func ConvertSrcInternalDetailToDstInternalDetail(ctx context.Context, src *source.SrcInternalDetail) (*destination.DstInternalDetail, error) {
 	if src == nil {
 		return nil, nil
@@ -235,6 +274,8 @@ func ConvertSrcInternalDetailToDstInternalDetail(ctx context.Context, src *sourc
 	}
 	return dst, nil
 }
+
+// convertSubSourceToSubTarget converts source.SubSource to destination.SubTarget.
 func convertSubSourceToSubTarget(ctx context.Context, ec *model.ErrorCollector, src *source.SubSource) *destination.SubTarget {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/complex.go.golden
+++ b/examples/convert/testdata/complex.go.golden
@@ -9,6 +9,7 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSrcToDst converts Src to Dst.
 func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *Dst {
 	if src == nil {
 		return nil
@@ -59,6 +60,8 @@ func ConvertSrcToDst(ctx context.Context, src *Src) (*Dst, error) {
 	}
 	return dst, nil
 }
+
+// convertSrcItemToDstItem converts SrcItem to DstItem.
 func convertSrcItemToDstItem(ctx context.Context, ec *model.ErrorCollector, src *SrcItem) *DstItem {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/embedded.go.golden
+++ b/examples/convert/testdata/embedded.go.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSourceToDestination converts Source to Destination.
 func convertSourceToDestination(ctx context.Context, ec *model.ErrorCollector, src *Source) *Destination {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/errors.go.golden
+++ b/examples/convert/testdata/errors.go.golden
@@ -9,6 +9,7 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSrcToDst converts Src to Dst.
 func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *Dst {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/fieldmatching.go.golden
+++ b/examples/convert/testdata/fieldmatching.go.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSrcToDst converts Src to Dst.
 func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *Dst {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/imports.go.golden
+++ b/examples/convert/testdata/imports.go.golden
@@ -9,6 +9,7 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSrcToDst converts Src to Dst.
 func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *Dst {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/mapkeys.go.golden
+++ b/examples/convert/testdata/mapkeys.go.golden
@@ -9,6 +9,7 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSrcToDst converts Src to Dst.
 func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *Dst {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/maps.go.golden
+++ b/examples/convert/testdata/maps.go.golden
@@ -9,6 +9,7 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSrcToDst converts Src to Dst.
 func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *Dst {
 	if src == nil {
 		return nil
@@ -59,6 +60,8 @@ func ConvertSrcToDst(ctx context.Context, src *Src) (*Dst, error) {
 	}
 	return dst, nil
 }
+
+// convertSrcItemToDstItem converts SrcItem to DstItem.
 func convertSrcItemToDstItem(ctx context.Context, ec *model.ErrorCollector, src *SrcItem) *DstItem {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/pointer_rules.go.golden
+++ b/examples/convert/testdata/pointer_rules.go.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSrcToDst converts Src to Dst.
 func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *Dst {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/pointers.go.golden
+++ b/examples/convert/testdata/pointers.go.golden
@@ -9,6 +9,7 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSrcToDst converts Src to Dst.
 func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *Dst {
 	if src == nil {
 		return nil
@@ -84,6 +85,8 @@ func ConvertSrcToDst(ctx context.Context, src *Src) (*Dst, error) {
 	}
 	return dst, nil
 }
+
+// convertSrcItemToDstItem converts SrcItem to DstItem.
 func convertSrcItemToDstItem(ctx context.Context, ec *model.ErrorCollector, src *SrcItem) *DstItem {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/recursive.go.golden
+++ b/examples/convert/testdata/recursive.go.golden
@@ -10,6 +10,7 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSrcParentToDstParent converts source.SrcParent to destination.DstParent.
 func convertSrcParentToDstParent(ctx context.Context, ec *model.ErrorCollector, src *source.SrcParent) *destination.DstParent {
 	if src == nil {
 		return nil
@@ -44,6 +45,8 @@ func ConvertSrcParentToDstParent(ctx context.Context, src *source.SrcParent) (*d
 	}
 	return dst, nil
 }
+
+// convertSrcChildToDstChild converts source.SrcChild to destination.DstChild.
 func convertSrcChildToDstChild(ctx context.Context, ec *model.ErrorCollector, src *source.SrcChild) *destination.DstChild {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/rules.go.golden
+++ b/examples/convert/testdata/rules.go.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSrcToDst converts Src to Dst.
 func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *Dst {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/slices.go.golden
+++ b/examples/convert/testdata/slices.go.golden
@@ -9,6 +9,7 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSrcToDst converts Src to Dst.
 func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *Dst {
 	if src == nil {
 		return nil
@@ -44,6 +45,8 @@ func ConvertSrcToDst(ctx context.Context, src *Src) (*Dst, error) {
 	}
 	return dst, nil
 }
+
+// convertSrcItemToDstItem converts SrcItem to DstItem.
 func convertSrcItemToDstItem(ctx context.Context, ec *model.ErrorCollector, src *SrcItem) *DstItem {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/tags.go.golden
+++ b/examples/convert/testdata/tags.go.golden
@@ -9,6 +9,7 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSrcWithTagsToDstWithTags converts SrcWithTags to DstWithTags.
 func convertSrcWithTagsToDstWithTags(ctx context.Context, ec *model.ErrorCollector, src *SrcWithTags) *DstWithTags {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/timetime.go.golden
+++ b/examples/convert/testdata/timetime.go.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSrcToDst converts Src to Dst.
 func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *Dst {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/validator.go.golden
+++ b/examples/convert/testdata/validator.go.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSrcToDst converts Src to Dst.
 func convertSrcToDst(ctx context.Context, ec *model.ErrorCollector, src *Src) *Dst {
 	if src == nil {
 		return nil

--- a/examples/convert/testdata/variable.go.golden
+++ b/examples/convert/testdata/variable.go.golden
@@ -9,6 +9,10 @@ import (
 	"github.com/podhmo/go-scan/examples/convert/model"
 )
 
+// convertSrcVariableToDstVariable converts SrcVariable to DstVariable.
+//
+// Fields that are not populated by this converter:
+//   - FullName
 func convertSrcVariableToDstVariable(ctx context.Context, ec *model.ErrorCollector, src *SrcVariable) *DstVariable {
 	if src == nil {
 		return nil
@@ -19,6 +23,9 @@ func convertSrcVariableToDstVariable(ctx context.Context, ec *model.ErrorCollect
 }
 
 // ConvertSrcVariableToDstVariable converts SrcVariable to DstVariable.
+//
+// Fields that are not populated by this converter:
+//   - FullName
 func ConvertSrcVariableToDstVariable(ctx context.Context, src *SrcVariable) (*DstVariable, error) {
 	if src == nil {
 		return nil, nil


### PR DESCRIPTION
The code generator has been updated to identify and document fields in the destination struct that are not populated during the conversion process.

Key changes:
- The generator now tracks which destination fields are not mapped from a source field.
- The public and private conversion functions' docstrings now include a list of these unmapped fields if there are any. If all fields are populated, no extra docstring is added.
- A new test suite (`generated_test`) has been added to verify that the generated code behaves as documented (i.e., that unmapped fields are zero-valued).
- The build process (`Makefile`) has been improved to correctly handle testing of generated code and updating of golden files, with a comment explaining the CI/CD workflow.
- A `TODO.md` file has been added to track the completion of this feature.