### PR TITLE
I've just committed a change to add markers to your sample data, whic…

### DIFF
--- a/examples/convert/sampledata/converter/converter.go
+++ b/examples/convert/sampledata/converter/converter.go
@@ -35,7 +35,7 @@ func ConvertUser(ctx context.Context, src source.SrcUser) destination.DstUser {
 
 	dst.UserID = fmt.Sprintf("user-%d", src.ID)
 	dst.FullName = src.FirstName + " " + src.LastName
-	dst.Address = srcAddressToDstAddress(ctx, src.SrcAddress)
+	dst.Address = srcAddressToDstAddress(ctx, src.Address)
 	dst.Contact = srcContactToDstContact(ctx, src.ContactInfo)
 
 	if src.Details != nil {

--- a/examples/convert/sampledata/converter/converter_test.go
+++ b/examples/convert/sampledata/converter/converter_test.go
@@ -20,7 +20,7 @@ func TestConvertUser(t *testing.T) {
 		ID:        101,
 		FirstName: "John",
 		LastName:  "Doe",
-		SrcAddress: source.SrcAddress{
+		Address: source.SrcAddress{
 			Street: "123 Main St",
 			City:   "Anytown",
 		},
@@ -70,7 +70,7 @@ func TestConvertUser_NilFields(t *testing.T) {
 		ID:        102,
 		FirstName: "Jane",
 		LastName:  "Doe",
-		SrcAddress: source.SrcAddress{
+		Address: source.SrcAddress{
 			Street: "456 Oak St",
 			City:   "Otherville",
 		},

--- a/examples/convert/sampledata/funcs/funcs.go
+++ b/examples/convert/sampledata/funcs/funcs.go
@@ -1,0 +1,40 @@
+package funcs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/podhmo/go-scan/examples/convert/model"
+	"github.com/podhmo/go-scan/examples/convert/sampledata/destination"
+	"github.com/podhmo/go-scan/examples/convert/sampledata/source"
+)
+
+// UserIDToString converts user id from int64 to string with prefix
+func UserIDToString(ctx context.Context, ec *model.ErrorCollector, id int64) string {
+	return fmt.Sprintf("user-%d", id)
+}
+
+// Translate translates description
+func Translate(ctx context.Context, ec *model.ErrorCollector, description string) string {
+	// simulate translation
+	return "翻訳済み (JP): " + description
+}
+
+// ConvertSrcContactToDstContact converts source.SrcContact to destination.DstContact
+func ConvertSrcContactToDstContact(ctx context.Context, ec *model.ErrorCollector, src source.SrcContact) destination.DstContact {
+	dst := destination.DstContact{
+		EmailAddress: src.Email,
+	}
+	if src.Phone != nil {
+		dst.PhoneNumber = *src.Phone
+	} else {
+		dst.PhoneNumber = "N/A"
+	}
+	return dst
+}
+
+// ConcatName combines first and last name to create a full name.
+func ConcatName(ctx context.Context, ec *model.ErrorCollector, firstName string, lastName string) string {
+	return strings.TrimSpace(fmt.Sprintf("%s %s", firstName, lastName))
+}

--- a/examples/convert/sampledata/source/source.go
+++ b/examples/convert/sampledata/source/source.go
@@ -3,24 +3,26 @@ package source
 import "time"
 
 // convert:import convutil "github.com/podhmo/go-scan/examples/convert/convutil"
+// convert:import funcs "github.com/podhmo/go-scan/examples/convert/sampledata/funcs"
 // convert:rule "time.Time" -> "string", using=convutil.TimeToString
 // convert:rule "*time.Time" -> "string", using=convutil.PtrTimeToString
 
 // @derivingconvert("github.com/podhmo/go-scan/examples/convert/sampledata/destination.DstUser")
 type SrcUser struct {
-	ID        int64
-	FirstName string
-	LastName  string
-	SrcAddress
-	ContactInfo SrcContact
+	ID          int64 `convert:"UserID,using=funcs.UserIDToString"`
+	FirstName   string
+	LastName    string
+	Address     SrcAddress
+	ContactInfo SrcContact `convert:"Contact,using=funcs.ConvertSrcContactToDstContact"`
 	Details     []SrcInternalDetail
 	CreatedAt   time.Time
 	UpdatedAt   *time.Time
 }
 
+// @derivingconvert("github.com/podhmo/go-scan/examples/convert/sampledata/destination.DstAddress")
 type SrcAddress struct {
-	Street string
-	City   string
+	Street string `convert:"FullStreet"`
+	City   string `convert:"CityName"`
 }
 
 type SrcContact struct {
@@ -28,21 +30,23 @@ type SrcContact struct {
 	Phone *string
 }
 
+// @derivingconvert("github.com/podhmo/go-scan/examples/convert/sampledata/destination.DstInternalDetail")
 type SrcInternalDetail struct {
-	Code        int
-	Description string
+	Code        int    `convert:"ItemCode"`
+	Description string `convert:"LocalizedDesc,using=funcs.Translate"`
 }
 
 // @derivingconvert("github.com/podhmo/go-scan/examples/convert/sampledata/destination.DstOrder")
 type SrcOrder struct {
-	OrderID string
-	Amount  float64
-	Items   []SrcItem
+	OrderID string    `convert:"ID"`
+	Amount  float64   `convert:"TotalAmount"`
+	Items   []SrcItem `convert:"LineItems"`
 }
 
+// @derivingconvert("github.com/podhmo/go-scan/examples/convert/sampledata/destination.DstItem")
 type SrcItem struct {
-	SKU      string
-	Quantity int
+	SKU      string `convert:"ProductCode"`
+	Quantity int    `convert:"Count"`
 }
 
 // @derivingconvert("github.com/podhmo/go-scan/examples/convert/sampledata/destination.ComplexTarget")


### PR DESCRIPTION
…h will improve the conversion process. Here is a summary of my work:

I added annotations and struct tags to the source files in `examples/convert/sampledata/source`. This makes the output of the auto-generated converter closer to the manually-implemented one.

Here are the key changes:
- I created a new `funcs` package to hold custom conversion functions (`UserIDToString`, `Translate`, `ConvertSrcContactToDstContact`) to avoid circular dependencies.
- I added `@derivingconvert` annotations to all necessary source structs (`SrcItem`, `SrcInternalDetail`, `SrcAddress`).
- I used `convert` struct tags to map fields with mismatched names (e.g., `OrderID` -> `ID`).
- I used the `using=` option in `convert` tags to apply custom conversion logic for complex fields.
- I changed `SrcUser.SrcAddress` from an embedded field to a named field (`Address`) to allow for correct mapping.
- I updated test files (`converter_test.go`, `generated_test.go`) to reflect the changes in the source structs and the improved generator output.

I wasn't able to generate the `FullName` field in `DstUser` because it requires combining multiple source fields. This feature appears to require modifying the destination struct, which I considered out of scope. However, all other conversions now work as expected, and all tests, including the e2e comparison test, are passing.