### PR TITLE
feat(examples): add e2e test for deriving-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ test:
 
 test-e2e:
 	make -C examples/convert e2e
+	make -C examples/deriving-all e2e
 
 clean:
 	go clean -cache -testcache # General Go clean

--- a/examples/deriving-all/Makefile
+++ b/examples/deriving-all/Makefile
@@ -1,0 +1,14 @@
+.PHONY: test clean e2e
+
+# run unit tests
+test:
+	go test -v ./...
+
+# run e2e tests
+e2e:
+	go run . ./testdata/e2e/models
+	go test -v -tags=e2e ./...
+
+# clean generated files
+clean:
+	rm -f testdata/e2e/models/models_deriving.go

--- a/examples/deriving-all/go.mod
+++ b/examples/deriving-all/go.mod
@@ -5,12 +5,17 @@ go 1.24
 toolchain go1.24.3
 
 require (
+	github.com/google/go-cmp v0.7.0
 	github.com/podhmo/go-scan v0.0.0
 	github.com/podhmo/go-scan/examples/derivingbind v0.0.0
 	github.com/podhmo/go-scan/examples/derivingjson v0.0.0
+	golang.org/x/tools v0.34.0
 )
 
-require golang.org/x/mod v0.26.0 // indirect
+require (
+	golang.org/x/mod v0.26.0 // indirect
+	golang.org/x/sync v0.15.0 // indirect
+)
 
 replace github.com/podhmo/go-scan => ../../
 

--- a/examples/deriving-all/go.sum
+++ b/examples/deriving-all/go.sum
@@ -2,3 +2,7 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 golang.org/x/mod v0.26.0 h1:EGMPT//Ezu+ylkCijjPc+f4Aih7sZvaAr+O3EHBxvZg=
 golang.org/x/mod v0.26.0/go.mod h1:/j6NAhSk8iQ723BGAUyoAcn7SlD7s15Dp9Nd/SfeaFQ=
+golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
+golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
+golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=

--- a/examples/deriving-all/integrationtest/main_test.go
+++ b/examples/deriving-all/integrationtest/main_test.go
@@ -1,0 +1,157 @@
+//go:build e2e
+
+package integrationtest
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/podhmo/go-scan/examples/deriving-all/testdata/e2e/models"
+)
+
+func TestUnmarshalUser(t *testing.T) {
+	t.Run("valid json", func(t *testing.T) {
+		jsonData := `{"id": "user-001", "name": "John Doe", "birthDate": "1990-01-15T00:00:00Z"}`
+		expectedBirthDate, _ := time.Parse(time.RFC3339, "1990-01-15T00:00:00Z")
+		expected := models.User{
+			ID:        "user-001",
+			Name:      "John Doe",
+			BirthDate: expectedBirthDate,
+		}
+
+		var got models.User
+		if err := json.Unmarshal([]byte(jsonData), &got); err != nil {
+			t.Fatalf("Unmarshal() failed: %v", err)
+		}
+
+		if diff := cmp.Diff(expected, got); diff != "" {
+			t.Errorf("Unmarshal() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("invalid json field", func(t *testing.T) {
+		// oneof validation in generated code should fail this
+		jsonData := `{"id": "user-001", "name": "John Doe", "birthDate": "invalid-date"}`
+		var got models.User
+		err := json.Unmarshal([]byte(jsonData), &got)
+		if err == nil {
+			t.Fatal("expected an error during unmarshalling, but got nil")
+		}
+		if !strings.Contains(err.Error(), "could not parse birthDate") {
+			t.Errorf("expected error to be about 'birthDate' parsing, but got %q", err.Error())
+		}
+	})
+}
+
+func TestBindUser(t *testing.T) {
+	t.Run("valid request body", func(t *testing.T) {
+		jsonData := `{"id": "user-002", "name": "Jane Smith", "birthDate": "1988-05-20T10:00:00Z"}`
+		req := httptest.NewRequest("POST", "/users", bytes.NewBufferString(jsonData))
+		req.Header.Set("Content-Type", "application/json")
+
+		var got models.User
+		if err := got.Bind(req, nil); err != nil {
+			t.Fatalf("Bind() failed: %v", err)
+		}
+
+		expectedBirthDate, _ := time.Parse(time.RFC3339, "1988-05-20T10:00:00Z")
+		expected := models.User{
+			ID:        "user-002",
+			Name:      "Jane Smith",
+			BirthDate: expectedBirthDate,
+		}
+
+		if diff := cmp.Diff(expected, got); diff != "" {
+			t.Errorf("Bind() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("empty request body", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/users", nil) // nil body
+		var got models.User
+		err := got.Bind(req, nil)
+		if err == nil {
+			t.Fatal("expected an error for nil body, but got nil")
+		}
+	})
+}
+
+func TestUnmarshalEvent(t *testing.T) {
+	t.Run("user created event", func(t *testing.T) {
+		jsonData := `{
+			"id": "evt-001",
+			"createdAt": "2023-01-01T12:00:00Z",
+			"data": {
+				"type": "usercreated",
+				"userId": "user-123",
+				"username": "tester"
+			}
+		}`
+		expectedTime, _ := time.Parse(time.RFC3339, "2023-01-01T12:00:00Z")
+		expected := models.Event{
+			ID:        "evt-001",
+			CreatedAt: expectedTime,
+			Data:      &models.UserCreated{UserID: "user-123", Username: "tester"},
+		}
+
+		var got models.Event
+		if err := json.Unmarshal([]byte(jsonData), &got); err != nil {
+			t.Fatalf("Unmarshal() failed: %v", err)
+		}
+
+		if diff := cmp.Diff(expected, got); diff != "" {
+			t.Errorf("Unmarshal() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("message posted event", func(t *testing.T) {
+		jsonData := `{
+			"id": "evt-002",
+			"createdAt": "2023-01-02T15:30:00Z",
+			"data": {
+				"type": "messageposted",
+				"messageId": "msg-456",
+				"content": "Hello world"
+			}
+		}`
+		expectedTime, _ := time.Parse(time.RFC3339, "2023-01-02T15:30:00Z")
+		expected := models.Event{
+			ID:        "evt-002",
+			CreatedAt: expectedTime,
+			Data:      &models.MessagePosted{MessageID: "msg-456", Content: "Hello world"},
+		}
+
+		var got models.Event
+		if err := json.Unmarshal([]byte(jsonData), &got); err != nil {
+			t.Fatalf("Unmarshal() failed: %v", err)
+		}
+
+		if diff := cmp.Diff(expected, got); diff != "" {
+			t.Errorf("Unmarshal() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("unknown event type", func(t *testing.T) {
+		jsonData := `{
+			"id": "evt-003",
+			"createdAt": "2023-01-03T10:00:00Z",
+			"data": {
+				"type": "unknown_event"
+			}
+		}`
+		var got models.Event
+		err := json.Unmarshal([]byte(jsonData), &got)
+		if err == nil {
+			t.Fatal("expected an error for unknown event type, but got nil")
+		}
+		if !strings.Contains(err.Error(), "unknown data type 'unknown_event'") {
+			t.Errorf("expected error about unknown event type, but got: %v", err)
+		}
+	})
+}

--- a/examples/deriving-all/main_test.go
+++ b/examples/deriving-all/main_test.go
@@ -31,7 +31,7 @@ func TestUnifiedGenerator(t *testing.T) {
 package models
 import "time"
 // @deriving:unmarshal
-// @derivng:binding in:"body"
+// @deriving:binding in:"body"
 type Event struct {
 	ID        string    ` + "`json:\"id\"`" + `
 	CreatedAt time.Time ` + "`json:\"createdAt\"`" + `
@@ -82,7 +82,7 @@ func (UserCreated) isEventData() {}
 				"models.go": `
 package models
 import "time"
-// @derivng:binding in:"body"
+// @deriving:binding in:"body"
 type Event struct {
 	Name string ` + "`json:\"name\"`" + `
 }`,

--- a/examples/deriving-all/testdata/e2e/models/models.go
+++ b/examples/deriving-all/testdata/e2e/models/models.go
@@ -1,0 +1,39 @@
+package models
+
+import "time"
+
+// @deriving:unmarshal
+// @deriving:binding in:"body"
+type User struct {
+	// User's unique identifier
+	ID string `json:"id"`
+	// User's full name
+	Name string `json:"name"`
+	// User's birth date
+	BirthDate time.Time `json:"birthDate"`
+}
+
+// @deriving:unmarshal
+type Event struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"createdAt"`
+	Data      EventData `json:"data"`
+}
+
+type EventData interface {
+	isEventData()
+}
+
+type UserCreated struct {
+	UserID   string `json:"userId"`
+	Username string `json:"username"`
+}
+
+func (UserCreated) isEventData() {}
+
+type MessagePosted struct {
+	MessageID string `json:"messageId"`
+	Content   string `json:"content"`
+}
+
+func (MessagePosted) isEventData() {}

--- a/examples/deriving-all/testdata/e2e/models/models_deriving.go
+++ b/examples/deriving-all/testdata/e2e/models/models_deriving.go
@@ -1,0 +1,99 @@
+package models
+
+import (
+	json "encoding/json"
+	errors "errors"
+	fmt "fmt"
+	io "io"
+	http "net/http"
+)
+
+func (s *Event) UnmarshalJSON(data []byte) error {
+	// Define an alias type to prevent infinite recursion with UnmarshalJSON.
+	type Alias Event
+	aux := &struct {
+		Data json.RawMessage `json:"data"`
+
+		// All other fields will be handled by the standard unmarshaler via the Alias.
+		*Alias
+	}{
+		Alias: (*Alias)(s),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return fmt.Errorf("failed to unmarshal into aux struct for Event: %w", err)
+	}
+
+	// Process Data
+	if aux.Data != nil && string(aux.Data) != "null" {
+		var discriminatorDoc struct {
+			Type string `json:"type"` // Discriminator field
+		}
+		if err := json.Unmarshal(aux.Data, &discriminatorDoc); err != nil {
+			return fmt.Errorf("could not detect type from field 'data' (content: %s): %w", string(aux.Data), err)
+		}
+
+		switch discriminatorDoc.Type {
+
+		case "usercreated":
+			var content *UserCreated
+			if err := json.Unmarshal(aux.Data, &content); err != nil {
+				return fmt.Errorf("failed to unmarshal 'data' as *UserCreated for type 'usercreated' (content: %s): %w", string(aux.Data), err)
+			}
+			s.Data = content
+
+		case "messageposted":
+			var content *MessagePosted
+			if err := json.Unmarshal(aux.Data, &content); err != nil {
+				return fmt.Errorf("failed to unmarshal 'data' as *MessagePosted for type 'messageposted' (content: %s): %w", string(aux.Data), err)
+			}
+			s.Data = content
+
+		default:
+			if discriminatorDoc.Type == "" {
+				return fmt.Errorf("discriminator field 'type' missing or empty in 'data' (content: %s)", string(aux.Data))
+			}
+			return fmt.Errorf("unknown data type '%s' for field 'data' (content: %s)", discriminatorDoc.Type, string(aux.Data))
+		}
+	} else {
+		s.Data = nil // Explicitly set to nil if null or empty
+	}
+
+	return nil
+}
+
+func (s *User) Bind(req *http.Request, pathVar func(string) string) error {
+	var errs []error
+
+	bodyErr := func() error { // Anonymous function to handle body binding logic
+		if req.Body != nil && req.Body != http.NoBody {
+			var bodyHandledBySpecificField = false
+
+			// If no specific field was designated 'in:"body"', decode into the struct 's' itself.
+			if !bodyHandledBySpecificField {
+				if decErr := json.NewDecoder(req.Body).Decode(s); decErr != nil {
+					if decErr != io.EOF { // EOF might be acceptable if body is optional and empty
+						return fmt.Errorf("binding: failed to decode request body into struct User: %w", decErr)
+					}
+				}
+			}
+			return nil // Body processed (or EOF ignored)
+		} else {
+			// Check if body was required.
+			isStructOrFieldBodyRequired := false
+
+			if isStructOrFieldBodyRequired {
+				return errors.New("binding: request body is required but was not provided or was empty")
+			}
+		}
+		return nil // No body or body not required
+	}()
+	if bodyErr != nil {
+		errs = append(errs, bodyErr)
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}

--- a/examples/derivingbind/gen/bind_method.tmpl
+++ b/examples/derivingbind/gen/bind_method.tmpl
@@ -27,71 +27,87 @@ FieldBindingInfo struct {
 }
 */}}
 func (s *{{.StructName}}) Bind(req *http.Request, pathVar func(string) string) error {
+	var errs []error
+
+	{{if .HasNonBodyFields}}
 	b := binding.New(req, pathVar)
-	return errors.Join(
-	{{range .Fields}}
-		{{if not .IsBody}}
-		{{$bindSource := ""}}
-		{{if eq .BindFrom "query"}}{{$bindSource = "binding.Query"}}
-		{{else if eq .BindFrom "header"}}{{$bindSource = "binding.Header"}}
-		{{else if eq .BindFrom "cookie"}}{{$bindSource = "binding.Cookie"}}
-		{{else if eq .BindFrom "path"}}{{$bindSource = "binding.Path"}}
-		{{end}}
-		{{$requiredVar := "binding.Optional"}}{{if .IsRequired}}{{$requiredVar = "binding.Required"}}{{end}}
-		{{if .IsSlice}}
-			{{if .IsSliceElementPointer}}
-			binding.SlicePtr(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}), // Field: {{.FieldName}} ({{.OriginalFieldTypeString}})
-			{{else}}
-			binding.Slice(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}), // Field: {{.FieldName}} ({{.OriginalFieldTypeString}})
-			{{end}}
-		{{else}}
-			{{if .IsPointer}}
-			binding.OnePtr(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}), // Field: {{.FieldName}} ({{.OriginalFieldTypeString}})
-			{{else}}
-			binding.One(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}), // Field: {{.FieldName}} ({{.OriginalFieldTypeString}})
-			{{end}}
-		{{end}}
-		{{end}}
-	{{end}}
-	{{if .NeedsBody}}
-		func() error { // Anonymous function to handle body binding logic
-			if req.Body != nil && req.Body != http.NoBody {
-				var bodyHandledBySpecificField = false
-				{{range .Fields}}
-				{{if .IsBody}}
-				// Field {{.FieldName}} (type {{.OriginalFieldTypeString}}) is the target for the entire request body
-				if decErr := json.NewDecoder(req.Body).Decode(&s.{{.FieldName}}); decErr != nil {
-					if decErr != io.EOF { // EOF might be acceptable if body is optional and empty
-						return fmt.Errorf("binding: failed to decode request body into field {{.FieldName}}: %w", decErr)
-					}
-				}
-				bodyHandledBySpecificField = true
-				return nil // Successfully handled specific body field
+	var err error
+		{{range .Fields}}
+			{{if not .IsBody}}
+				{{$bindSource := ""}}
+				{{if eq .BindFrom "query"}}{{$bindSource = "binding.Query"}}
+				{{else if eq .BindFrom "header"}}{{$bindSource = "binding.Header"}}
+				{{else if eq .BindFrom "cookie"}}{{$bindSource = "binding.Cookie"}}
+				{{else if eq .BindFrom "path"}}{{$bindSource = "binding.Path"}}
 				{{end}}
-				{{end}}
-				// If no specific field was designated 'in:"body"', decode into the struct 's' itself.
-				if !bodyHandledBySpecificField {
-					if decErr := json.NewDecoder(req.Body).Decode(s); decErr != nil {
-						if decErr != io.EOF { // EOF might be acceptable if body is optional and empty
-							return fmt.Errorf("binding: failed to decode request body into struct {{.StructName}}: %w", decErr)
-						}
-					}
-				}
-				return nil // Body processed (or EOF ignored)
-			} else {
-				// Check if body was required.
-				isStructOrFieldBodyRequired := false
-				{{range .Fields}}
-					{{if and .IsBody .IsRequired}}
-					isStructOrFieldBodyRequired = true
+				{{$requiredVar := "binding.Optional"}}{{if .IsRequired}}{{$requiredVar = "binding.Required"}}{{end}}
+
+				{{if .IsSlice}}
+					{{if .IsSliceElementPointer}}
+						err = binding.SlicePtr(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}) // Field: {{.FieldName}} ({{.OriginalFieldTypeString}})
+					{{else}}
+						err = binding.Slice(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}) // Field: {{.FieldName}} ({{.OriginalFieldTypeString}})
+					{{end}}
+				{{else}}
+					{{if .IsPointer}}
+						err = binding.OnePtr(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}) // Field: {{.FieldName}} ({{.OriginalFieldTypeString}})
+					{{else}}
+						err = binding.One(b, &s.{{.FieldName}}, {{$bindSource}}, "{{.BindName}}", {{.ParserFunc}}, {{$requiredVar}}) // Field: {{.FieldName}} ({{.OriginalFieldTypeString}})
 					{{end}}
 				{{end}}
-				if isStructOrFieldBodyRequired {
-					return errors.New("binding: request body is required but was not provided or was empty")
+				if err != nil {
+					errs = append(errs, err)
+				}
+			{{end}}
+		{{end}}
+	{{end}}
+
+	{{if .NeedsBody}}
+	bodyErr := func() error { // Anonymous function to handle body binding logic
+		if req.Body != nil && req.Body != http.NoBody {
+			var bodyHandledBySpecificField = false
+			{{range .Fields}}
+			{{if .IsBody}}
+			// Field {{.FieldName}} (type {{.OriginalFieldTypeString}}) is the target for the entire request body
+			if decErr := json.NewDecoder(req.Body).Decode(&s.{{.FieldName}}); decErr != nil {
+				if decErr != io.EOF { // EOF might be acceptable if body is optional and empty
+					return fmt.Errorf("binding: failed to decode request body into field {{.FieldName}}: %w", decErr)
 				}
 			}
-			return nil // No body or body not required
-		}(),
+			bodyHandledBySpecificField = true
+			return nil // Successfully handled specific body field
+			{{end}}
+			{{end}}
+			// If no specific field was designated 'in:"body"', decode into the struct 's' itself.
+			if !bodyHandledBySpecificField {
+				if decErr := json.NewDecoder(req.Body).Decode(s); decErr != nil {
+					if decErr != io.EOF { // EOF might be acceptable if body is optional and empty
+						return fmt.Errorf("binding: failed to decode request body into struct {{.StructName}}: %w", decErr)
+					}
+				}
+			}
+			return nil // Body processed (or EOF ignored)
+		} else {
+			// Check if body was required.
+			isStructOrFieldBodyRequired := false
+			{{range .Fields}}
+				{{if and .IsBody .IsRequired}}
+				isStructOrFieldBodyRequired = true
+				{{end}}
+			{{end}}
+			if isStructOrFieldBodyRequired {
+				return errors.New("binding: request body is required but was not provided or was empty")
+			}
+		}
+		return nil // No body or body not required
+	}()
+	if bodyErr != nil {
+		errs = append(errs, bodyErr)
+	}
 	{{end}}
-	)
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
 }

--- a/examples/derivingbind/main_test.go
+++ b/examples/derivingbind/main_test.go
@@ -31,7 +31,7 @@ go 1.22.4
 `,
 				"models.go": `
 package models
-// @derivng:binding
+// @deriving:binding
 type Input struct {
 	Name string ` + "`in:\"query\" query:\"name\"`" + `
 }


### PR DESCRIPTION
Adds a new end-to-end test for the `deriving-all` example, modeled after the existing test for the `convert` example.

This includes:
- A new `integrationtest` package with e2e tests that run against generated code.
- New sample data in `testdata/e2e/models` to act as a meaningful source for the generator.
- A new `Makefile` in `examples/deriving-all` to orchestrate the generation and testing steps.
- An update to the top-level `Makefile` to include the new e2e test in the `test-e2e` target.

In the process of adding the test, several underlying bugs in the example generators were discovered and fixed:
- Corrected a persistent typo in an annotation from `@derivng:binding` to the correct `@deriving:binding` in the generator and its unit tests.
- Fixed the `derivingbind` template to prevent compilation errors (unused variables) when handling whole-struct body bindings.
- Made the import-adding logic in the `derivingbind` generator conditional to avoid unused import errors.
- Added a `goimports` processing step to the `deriving-all` main tool to automatically clean up imports in the final generated file, making the entire process more robust.