### PR TITLE
feat(derivingjson): Add MarshalJSON generation with discriminator

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -107,6 +107,9 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
     -   [x] Refactored `derivingjson` and `derivingbind` to separate generation logic from file I/O.
     -   [x] Implemented the `deriving-all` orchestrator tool.
     -   [x] Added integration tests for the unified tool using `scantest`.
+-   **`derivingjson` Tool**:
+    -   [x] `UnmarshalJSON` generation for `oneOf` style interfaces using `@deriving:unmarshall`.
+    -   [x] `MarshalJSON` generation for `oneOf` concrete types using `@derivingmarshall` to add a type discriminator.
 
 ## To Be Implemented
 

--- a/examples/derivingjson/README.md
+++ b/examples/derivingjson/README.md
@@ -1,24 +1,28 @@
 # Deriving JSON for oneOf
 
-`derivingjson` is an experimental tool that leverages the `github.com/podhmo/go-scan` library to automatically generate `UnmarshalJSON` methods for Go structs that have a structure analogous to JSON Schema's `oneOf`.
+`derivingjson` is an experimental tool that leverages the `github.com/podhmo/go-scan` library to automatically generate `UnmarshalJSON` and `MarshalJSON` methods for Go structs that have a structure analogous to JSON Schema's `oneOf`.
 
 ## Overview
 
 In JSON Schema, `oneOf` signifies that a field can be one of several types. A common way to represent this concept in Go involves using an interface type, a set of concrete structs that implement this interface, and a container struct that includes a discriminator field to identify the specific type.
 
-This tool aims to generate an `UnmarshalJSON` method for such container structs, enabling unmarshalling into the appropriate concrete type based on the discriminator's value.
+This tool aims to generate:
+- An `UnmarshalJSON` method for container structs, enabling unmarshalling into the appropriate concrete type based on the discriminator's value.
+- A `MarshalJSON` method for the concrete types, which injects the discriminator field and value into the JSON output.
 
 ## Features
 
 -   Type information analysis using `github.com/podhmo/go-scan`.
--   Targets structs annotated with a specific comment: `@deriving:unmarshall`.
--   Identifies the discriminator field (e.g., `Type string `json:"type"``) and the `oneOf` target interface field to generate the appropriate unmarshalling logic.
+-   **Unmarshalling**: Targets container structs annotated with `@deriving:unmarshall`.
+-   **Marshalling**: Targets concrete implementer structs annotated with `@derivingmarshall`.
+-   Identifies the discriminator field (e.g., `Type string `json:"type"``) and the `oneOf` target interface field to generate the appropriate logic.
 -   The tool searches for concrete types implementing the interface within the same package.
 
 ## Usage (Conceptual)
 
-1.  Add the `@deriving:unmarshall` annotation in the comment of the container struct for which you want to generate `UnmarshalJSON`.
-2.  Run `derivingjson` from the command line, specifying the target package path.
+1.  Add the `@deriving:unmarshall` annotation in the comment of the **container struct** (the one with the interface field) to generate `UnmarshalJSON` for it.
+2.  Add the `@derivingmarshall` annotation in the comment of each **concrete struct** that implements the `oneOf` interface to generate `MarshalJSON` for it.
+3.  Run `derivingjson` from the command line, specifying the target package path.
 
     ```bash
     go run examples/derivingjson/main.go <file_path_1.go> [file_path_2.go ...]

--- a/examples/derivingjson/gen/marshal.tmpl
+++ b/examples/derivingjson/gen/marshal.tmpl
@@ -1,0 +1,10 @@
+func (s *{{.StructName}}) MarshalJSON() ([]byte, error) {
+	type Alias {{.StructName}}
+	return json.Marshal(&struct {
+		*Alias
+		Type string `json:"{{.DiscriminatorFieldJSONName}}"`
+	}{
+		Alias: (*Alias)(s),
+		Type:  "{{.DiscriminatorValue}}",
+	})
+}

--- a/examples/derivingjson/integrationtest/integrationtest_deriving.go
+++ b/examples/derivingjson/integrationtest/integrationtest_deriving.go
@@ -3,8 +3,8 @@
 package integrationtest
 
 import (
-	"encoding/json"
-	"fmt"
+	json "encoding/json"
+	fmt "fmt"
 )
 
 func (s *APIResponse) UnmarshalJSON(data []byte) error {
@@ -325,4 +325,81 @@ func (s *PetOwner) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+func (s *UserProfile) MarshalJSON() ([]byte, error) {
+	type Alias UserProfile
+	return json.Marshal(&struct {
+		*Alias
+		Type string `json:"type"`
+	}{
+		Alias: (*Alias)(s),
+		Type:  "userprofile",
+	})
+}
+
+func (s *ProductInfo) MarshalJSON() ([]byte, error) {
+	type Alias ProductInfo
+	return json.Marshal(&struct {
+		*Alias
+		Type string `json:"type"`
+	}{
+		Alias: (*Alias)(s),
+		Type:  "productinfo",
+	})
+}
+
+func (s *Dog) MarshalJSON() ([]byte, error) {
+	type Alias Dog
+	return json.Marshal(&struct {
+		*Alias
+		Type string `json:"type"`
+	}{
+		Alias: (*Alias)(s),
+		Type:  "dog",
+	})
+}
+
+func (s *Cat) MarshalJSON() ([]byte, error) {
+	type Alias Cat
+	return json.Marshal(&struct {
+		*Alias
+		Type string `json:"type"`
+	}{
+		Alias: (*Alias)(s),
+		Type:  "cat",
+	})
+}
+
+func (s *Car) MarshalJSON() ([]byte, error) {
+	type Alias Car
+	return json.Marshal(&struct {
+		*Alias
+		Type string `json:"type"`
+	}{
+		Alias: (*Alias)(s),
+		Type:  "car",
+	})
+}
+
+func (s *Bicycle) MarshalJSON() ([]byte, error) {
+	type Alias Bicycle
+	return json.Marshal(&struct {
+		*Alias
+		Type string `json:"type"`
+	}{
+		Alias: (*Alias)(s),
+		Type:  "bicycle",
+	})
+}
+
+func (s *Goldfish) MarshalJSON() ([]byte, error) {
+	type Alias Goldfish
+	return json.Marshal(&struct {
+		*Alias
+		Type string `json:"type"`
+	}{
+		Alias: (*Alias)(s),
+		Type:  "goldfish",
+	})
 }

--- a/examples/derivingjson/integrationtest/main_test.go
+++ b/examples/derivingjson/integrationtest/main_test.go
@@ -407,3 +407,143 @@ func TestUnmarshalMultiOneOfStructs(t *testing.T) {
 		}
 	})
 }
+
+// TestMarshalAPIResponse tests the custom MarshalJSON functionality.
+func TestMarshalAPIResponse(t *testing.T) {
+	t.Run("UserProfile", func(t *testing.T) {
+		response := APIResponse{
+			Status: "ok",
+			Data: &UserProfile{
+				UserID:   "u-123",
+				UserName: "Taro",
+			},
+		}
+
+		b, err := json.Marshal(response)
+		if err != nil {
+			t.Fatalf("json.Marshal() error = %v", err)
+		}
+
+		jsonString := string(b)
+		fmt.Printf("Marshalled JSON (UserProfile): %s\n", jsonString)
+
+		// Check for discriminator and other fields.
+		if !strings.Contains(jsonString, `"type":"userprofile"`) {
+			t.Errorf("marshalled JSON does not contain type discriminator for UserProfile")
+		}
+		if !strings.Contains(jsonString, `"userId":"u-123"`) {
+			t.Errorf("marshalled JSON does not contain userId field")
+		}
+	})
+
+	t.Run("ProductInfo", func(t *testing.T) {
+		response := APIResponse{
+			Status: "ok",
+			Data: &ProductInfo{
+				ProductID:   "p-456",
+				ProductName: "Book",
+				Price:       1500,
+			},
+		}
+
+		b, err := json.Marshal(response)
+		if err != nil {
+			t.Fatalf("json.Marshal() error = %v", err)
+		}
+
+		jsonString := string(b)
+		fmt.Printf("Marshalled JSON (ProductInfo): %s\n", jsonString)
+
+		if !strings.Contains(jsonString, `"type":"productinfo"`) {
+			t.Errorf("marshalled JSON does not contain type discriminator for ProductInfo")
+		}
+		if !strings.Contains(jsonString, `"productId":"p-456"`) {
+			t.Errorf("marshalled JSON does not contain productId field")
+		}
+	})
+
+	t.Run("NilData", func(t *testing.T) {
+		response := APIResponse{
+			Status: "ok",
+			Data:   nil,
+		}
+
+		b, err := json.Marshal(response)
+		if err != nil {
+			t.Fatalf("json.Marshal() error = %v", err)
+		}
+
+		jsonString := string(b)
+		fmt.Printf("Marshalled JSON (NilData): %s\n", jsonString)
+
+		if !strings.Contains(jsonString, `"data":null`) {
+			t.Errorf("marshalled JSON should have null for data field")
+		}
+	})
+}
+
+func TestMarshalMultiOneOfStructs(t *testing.T) {
+	t.Run("Scene: with dog and bicycle", func(t *testing.T) {
+		scene := Scene{
+			Name: "Park Life",
+			MainAnimal: &Dog{
+				Breed: "Golden Retriever",
+				Noise: "Bark",
+			},
+			MainVehicle: &Bicycle{
+				Gears:   18,
+				HasBell: true,
+			},
+		}
+
+		b, err := json.Marshal(scene)
+		if err != nil {
+			t.Fatalf("json.Marshal() error = %v", err)
+		}
+
+		jsonString := string(b)
+		fmt.Printf("Marshalled JSON (Scene): %s\n", jsonString)
+
+		if !strings.Contains(jsonString, `"type":"dog"`) {
+			t.Errorf("marshalled JSON does not contain type discriminator for Dog")
+		}
+		if !strings.Contains(jsonString, `"type":"bicycle"`) {
+			t.Errorf("marshalled JSON does not contain type discriminator for Bicycle")
+		}
+		if !strings.Contains(jsonString, `"breed":"Golden Retriever"`) {
+			t.Errorf("marshalled JSON does not contain breed")
+		}
+		if !strings.Contains(jsonString, `"gears":18`) {
+			t.Errorf("marshalled JSON does not contain gears")
+		}
+	})
+
+	t.Run("Parade: with cat and dog", func(t *testing.T) {
+		parade := Parade{
+			EventName: "Pet Parade",
+			LeadAnimal: &Cat{
+				Color: "black",
+				Purr:  true,
+			},
+			TrailingAnimal: &Dog{
+				Breed: "Poodle",
+				Noise: "Yap",
+			},
+		}
+
+		b, err := json.Marshal(parade)
+		if err != nil {
+			t.Fatalf("json.Marshal() error = %v", err)
+		}
+
+		jsonString := string(b)
+		fmt.Printf("Marshalled JSON (Parade): %s\n", jsonString)
+
+		if !strings.Contains(jsonString, `"type":"cat"`) {
+			t.Errorf("marshalled JSON does not contain type discriminator for Cat")
+		}
+		if !strings.Contains(jsonString, `"type":"dog"`) {
+			t.Errorf("marshalled JSON does not contain type discriminator for Dog")
+		}
+	})
+}

--- a/examples/derivingjson/integrationtest/models.go
+++ b/examples/derivingjson/integrationtest/models.go
@@ -17,6 +17,7 @@ type APIResponse struct {
 
 // UserProfile is one of the possible types for the Data field.
 // It represents a user's profile information.
+// @derivingmarshall
 type UserProfile struct {
 	Type     string `json:"type"` // Discriminator: "user_profile" (expected value based on original user request)
 	UserID   string `json:"userId"`
@@ -28,6 +29,7 @@ func (UserProfile) isData() {}
 
 // ProductInfo is another possible type for the Data field.
 // It represents information about a product.
+// @derivingmarshall
 type ProductInfo struct {
 	Type        string `json:"type"` // Discriminator: "product_info" (expected value based on original user request)
 	ProductID   string `json:"productId"`

--- a/examples/derivingjson/integrationtest/multioneof.go
+++ b/examples/derivingjson/integrationtest/multioneof.go
@@ -17,6 +17,7 @@ type Vehicle interface {
 // --- Implementers for Animal ---
 
 // Dog implements Animal
+// @derivingmarshall
 type Dog struct {
 	Breed string `json:"breed"`
 	Noise string `json:"noise"`
@@ -26,6 +27,7 @@ func (d *Dog) Speak() string      { return d.Noise }
 func (d *Dog) AnimalKind() string { return "dog" }
 
 // Cat implements Animal
+// @derivingmarshall
 type Cat struct {
 	Color string `json:"color"`
 	Purr  bool   `json:"purr"`
@@ -37,6 +39,7 @@ func (c *Cat) AnimalKind() string { return "cat" }
 // --- Implementers for Vehicle ---
 
 // Car implements Vehicle
+// @derivingmarshall
 type Car struct {
 	Make   string `json:"make"`
 	Wheels int    `json:"wheels"`
@@ -46,6 +49,7 @@ func (c *Car) Move() string        { return "vroom" }
 func (c *Car) VehicleType() string { return "car" }
 
 // Bicycle implements Vehicle
+// @derivingmarshall
 type Bicycle struct {
 	Gears   int  `json:"gears"`
 	HasBell bool `json:"has_bell"`
@@ -88,6 +92,7 @@ type Pet interface {
 	PetKind() string
 }
 
+// @derivingmarshall
 type Goldfish struct {
 	Name      string `json:"name"`
 	BowlShape string `json:"bowl_shape"`


### PR DESCRIPTION
I've updated the `derivingjson` tool, adding the capability to generate `MarshalJSON` methods for concrete types that are part of a `oneOf` interface.

I introduced a new `@derivingmarshall` annotation. When you add this to a struct, the generator will create a `MarshalJSON` method for it. This method injects a 'type' field into the JSON output, using the lowercased struct name as the discriminator value, which is consistent with the `UnmarshalJSON` implementation.

To support this, I updated the core generator to recognize the new annotation and use a new `marshal.tmpl` template.

I've also added integration tests to verify that marshalling works correctly for:
- Simple oneOf implementations (`UserProfile`, `ProductInfo`)
- Cases where the interface field is `nil`
- More complex structs with multiple `oneOf` fields of different or same interface types.

Finally, I've updated the `derivingjson/README.md` and the root `TODO.md` to document this new functionality.