### PR TITLE
I've corrected misspellings of "Marshal", "Unmarshal", and their vari…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -108,8 +108,8 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
     -   [x] Implemented the `deriving-all` orchestrator tool.
     -   [x] Added integration tests for the unified tool using `scantest`.
 -   **`derivingjson` Tool**:
-    -   [x] `UnmarshalJSON` generation for `oneOf` style interfaces using `@deriving:unmarshall`.
-    -   [x] `MarshalJSON` generation for `oneOf` concrete types using `@derivingmarshall` to add a type discriminator.
+    -   [x] `UnmarshalJSON` generation for `oneOf` style interfaces using `@deriving:unmarshal`.
+    -   [x] `MarshalJSON` generation for `oneOf` concrete types using `@deriving:marshal` to add a type discriminator.
 
 ## To Be Implemented
 

--- a/cache.go
+++ b/cache.go
@@ -96,7 +96,7 @@ func (sc *symbolCache) load(ctx context.Context) error {
 	var newContent cacheContent
 	err = json.Unmarshal(data, &newContent)
 	if err != nil {
-		// If unmarshalling fails, treat it as a corrupted cache and start fresh
+		// If unmarshaling fails, treat it as a corrupted cache and start fresh
 		slog.WarnContext(ctx, "Failed to unmarshal cache file, starting with an empty cache", slog.String("path", sc.filePath), slog.Any("error", err))
 		sc.content = cacheContent{ // Initialize with empty maps
 			Symbols: make(map[string]string),

--- a/docs/ja/from-derivingjson.md
+++ b/docs/ja/from-derivingjson.md
@@ -7,7 +7,7 @@
 ## 1. アノテーション/コメントベースの型フィルタリング
 
 *   **現状の `derivingjson`**:
-    `go-scan` でパッケージ内の全ての型情報を取得した後、ループ処理で各 `TypeInfo` の `Doc` 文字列を調べ、特定のマーカーコメント（`@deriving:unmarshall`）が含まれているかを確認することで、処理対象の構造体をフィルタリングしています。
+    `go-scan` でパッケージ内の全ての型情報を取得した後、ループ処理で各 `TypeInfo` の `Doc` 文字列を調べ、特定のマーカーコメント（`@deriving:unmarshal`）が含まれているかを確認することで、処理対象の構造体をフィルタリングしています。
 
     ```go
     // examples/derivingjson/generator.go より抜粋

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,12 +15,12 @@ This directory contains example projects that demonstrate the capabilities and u
 
 The `derivingjson` example showcases an experimental tool that leverages the `go-scan` library.
 
-**Purpose**: To automatically generate `UnmarshalJSON` methods for Go structs that are structured to represent `oneOf` semantics (similar to JSON Schema's `oneOf`). This is useful when a field can be one of several distinct types, and a discriminator field is used to determine the actual type during unmarshalling.
+**Purpose**: To automatically generate `UnmarshalJSON` methods for Go structs that are structured to represent `oneOf` semantics (similar to JSON Schema's `oneOf`). This is useful when a field can be one of several distinct types, and a discriminator field is used to determine the actual type during unmarshaling.
 
 **Key Features**:
 - Uses `go-scan` for type information analysis.
-- Targets structs specifically annotated with `@deriving:unmarshall` in their GoDoc comments.
-- Identifies a discriminator field (e.g., `Type string \`json:"type"\``) and a target interface field to generate the appropriate unmarshalling logic.
+- Targets structs specifically annotated with `@deriving:unmarshal` in their GoDoc comments.
+- Identifies a discriminator field (e.g., `Type string \`json:"type"\``) and a target interface field to generate the appropriate unmarshaling logic.
 - Searches for concrete types that implement the target interface within the same package.
 
 This example demonstrates how `go-scan` can be used to build tools for advanced code generation tasks based on static analysis of Go source code.

--- a/examples/derivingbind/README.md
+++ b/examples/derivingbind/README.md
@@ -45,7 +45,7 @@ Fields use a combination of an `in` tag to specify the source and a source-speci
     -   Example: `SessionID string \`in:"cookie" cookie:"session_id"\``
 
 -   **Request Body (Field-Specific):**
-    -   `in:"body"`: If this tag is on a specific field, the entire JSON request body will be unmarshalled into this field. The field's type should be a struct or a pointer to a struct suitable for `json.Unmarshal`.
+    -   `in:"body"`: If this tag is on a specific field, the entire JSON request body will be unmarshaled into this field. The field's type should be a struct or a pointer to a struct suitable for `json.Unmarshal`.
     -   Example: `Payload MyPayloadStruct \`in:"body"\``
 
 **Supported Field Types:**
@@ -64,7 +64,7 @@ For path, query, header, and cookie binding, the generator supports a comprehens
     - Cookie parameters: Parsed from comma-separated values within a single cookie (e.g., `Cookie: key=val1,val2,val3`). This corresponds to OpenAPI's `style: form, explode: false`.
     - Path parameters: Slice binding is not supported for path parameters.
 
-For fields bound from the request body (`in:"body"`), any type compatible with `encoding/json` Unmarshalling is supported.
+For fields bound from the request body (`in:"body"`), any type compatible with `encoding/json` Unmarshaling is supported.
 
 The `required:"true"` tag can be used with any of these field types to indicate that the parameter must be present.
 

--- a/examples/derivingbind/testdata/simple/models.go
+++ b/examples/derivingbind/testdata/simple/models.go
@@ -23,7 +23,7 @@ type ComprehensiveBind struct {
 // This struct demonstrates a specific field being the target for `in:"body"`.
 type SpecificBodyFieldBind struct {
 	RequestID       string      `in:"header" header:"X-Request-ID"`
-	Payload         RequestBody `in:"body"` // The entire request body will be unmarshalled into this field
+	Payload         RequestBody `in:"body"` // The entire request body will be unmarshaled into this field
 	OtherQueryParam string      `in:"query" query:"other"`
 }
 

--- a/examples/derivingjson/README.md
+++ b/examples/derivingjson/README.md
@@ -7,21 +7,21 @@
 In JSON Schema, `oneOf` signifies that a field can be one of several types. A common way to represent this concept in Go involves using an interface type, a set of concrete structs that implement this interface, and a container struct that includes a discriminator field to identify the specific type.
 
 This tool aims to generate:
-- An `UnmarshalJSON` method for container structs, enabling unmarshalling into the appropriate concrete type based on the discriminator's value.
+- An `UnmarshalJSON` method for container structs, enabling unmarshaling into the appropriate concrete type based on the discriminator's value.
 - A `MarshalJSON` method for the concrete types, which injects the discriminator field and value into the JSON output.
 
 ## Features
 
 -   Type information analysis using `github.com/podhmo/go-scan`.
--   **Unmarshalling**: Targets container structs annotated with `@deriving:unmarshall`.
--   **Marshalling**: Targets concrete implementer structs annotated with `@derivingmarshall`.
+-   **Unmarshaling**: Targets container structs annotated with `@deriving:unmarshal`.
+-   **Marshaling**: Targets concrete implementer structs annotated with `@deriving:marshal`.
 -   Identifies the discriminator field (e.g., `Type string `json:"type"``) and the `oneOf` target interface field to generate the appropriate logic.
 -   The tool searches for concrete types implementing the interface within the same package.
 
 ## Usage (Conceptual)
 
-1.  Add the `@deriving:unmarshall` annotation in the comment of the **container struct** (the one with the interface field) to generate `UnmarshalJSON` for it.
-2.  Add the `@derivingmarshall` annotation in the comment of each **concrete struct** that implements the `oneOf` interface to generate `MarshalJSON` for it.
+1.  Add the `@deriving:unmarshal` annotation in the comment of the **container struct** (the one with the interface field) to generate `UnmarshalJSON` for it.
+2.  Add the `@deriving:marshal` annotation in the comment of each **concrete struct** that implements the `oneOf` interface to generate `MarshalJSON` for it.
 3.  Run `derivingjson` from the command line, specifying the target package path.
 
     ```bash

--- a/examples/derivingjson/gen/generate.go
+++ b/examples/derivingjson/gen/generate.go
@@ -18,7 +18,7 @@ import (
 var templateFile embed.FS
 
 const unmarshalAnnotation = "deriving:unmarshal"
-const marshalAnnotation = "derivingmarshall"
+const marshalAnnotation = "deriving:marshal"
 
 type TemplateData struct {
 	StructName                 string
@@ -233,7 +233,7 @@ func Generate(ctx context.Context, gscn *goscan.Scanner, pkgInfo *scanner.Packag
 			continue
 		}
 
-		// Prepare data for the marshalling template
+		// Prepare data for the marshaling template
 		marshalData := MarshalTemplateData{
 			StructName:                 typeInfo.Name,
 			DiscriminatorFieldJSONName: "type", // Hardcoded for now

--- a/examples/derivingjson/integrationtest/main_test.go
+++ b/examples/derivingjson/integrationtest/main_test.go
@@ -120,7 +120,7 @@ func TestUnmarshalAPIResponse(t *testing.T) {
 						t.Errorf("Expected response.Data to be *UserProfile, but it's not")
 					} else {
 						if userProfile.UserID == "" || userProfile.UserName == "" {
-							t.Errorf("UserProfile fields are not correctly unmarshalled: %+v", userProfile)
+							t.Errorf("UserProfile fields are not correctly unmarshaled: %+v", userProfile)
 						}
 					}
 				}
@@ -131,7 +131,7 @@ func TestUnmarshalAPIResponse(t *testing.T) {
 						t.Errorf("Expected response.Data to be *ProductInfo, but it's not")
 					} else {
 						if productInfo.ProductID == "" || productInfo.ProductName == "" || productInfo.Price == 0 {
-							t.Errorf("ProductInfo fields are not correctly unmarshalled: %+v", productInfo)
+							t.Errorf("ProductInfo fields are not correctly unmarshaled: %+v", productInfo)
 						}
 					}
 				}
@@ -425,14 +425,14 @@ func TestMarshalAPIResponse(t *testing.T) {
 		}
 
 		jsonString := string(b)
-		fmt.Printf("Marshalled JSON (UserProfile): %s\n", jsonString)
+		fmt.Printf("Marshaled JSON (UserProfile): %s\n", jsonString)
 
 		// Check for discriminator and other fields.
 		if !strings.Contains(jsonString, `"type":"userprofile"`) {
-			t.Errorf("marshalled JSON does not contain type discriminator for UserProfile")
+			t.Errorf("marshaled JSON does not contain type discriminator for UserProfile")
 		}
 		if !strings.Contains(jsonString, `"userId":"u-123"`) {
-			t.Errorf("marshalled JSON does not contain userId field")
+			t.Errorf("marshaled JSON does not contain userId field")
 		}
 	})
 
@@ -452,13 +452,13 @@ func TestMarshalAPIResponse(t *testing.T) {
 		}
 
 		jsonString := string(b)
-		fmt.Printf("Marshalled JSON (ProductInfo): %s\n", jsonString)
+		fmt.Printf("Marshaled JSON (ProductInfo): %s\n", jsonString)
 
 		if !strings.Contains(jsonString, `"type":"productinfo"`) {
-			t.Errorf("marshalled JSON does not contain type discriminator for ProductInfo")
+			t.Errorf("marshaled JSON does not contain type discriminator for ProductInfo")
 		}
 		if !strings.Contains(jsonString, `"productId":"p-456"`) {
-			t.Errorf("marshalled JSON does not contain productId field")
+			t.Errorf("marshaled JSON does not contain productId field")
 		}
 	})
 
@@ -474,10 +474,10 @@ func TestMarshalAPIResponse(t *testing.T) {
 		}
 
 		jsonString := string(b)
-		fmt.Printf("Marshalled JSON (NilData): %s\n", jsonString)
+		fmt.Printf("Marshaled JSON (NilData): %s\n", jsonString)
 
 		if !strings.Contains(jsonString, `"data":null`) {
-			t.Errorf("marshalled JSON should have null for data field")
+			t.Errorf("marshaled JSON should have null for data field")
 		}
 	})
 }
@@ -502,19 +502,19 @@ func TestMarshalMultiOneOfStructs(t *testing.T) {
 		}
 
 		jsonString := string(b)
-		fmt.Printf("Marshalled JSON (Scene): %s\n", jsonString)
+		fmt.Printf("Marshaled JSON (Scene): %s\n", jsonString)
 
 		if !strings.Contains(jsonString, `"type":"dog"`) {
-			t.Errorf("marshalled JSON does not contain type discriminator for Dog")
+			t.Errorf("marshaled JSON does not contain type discriminator for Dog")
 		}
 		if !strings.Contains(jsonString, `"type":"bicycle"`) {
-			t.Errorf("marshalled JSON does not contain type discriminator for Bicycle")
+			t.Errorf("marshaled JSON does not contain type discriminator for Bicycle")
 		}
 		if !strings.Contains(jsonString, `"breed":"Golden Retriever"`) {
-			t.Errorf("marshalled JSON does not contain breed")
+			t.Errorf("marshaled JSON does not contain breed")
 		}
 		if !strings.Contains(jsonString, `"gears":18`) {
-			t.Errorf("marshalled JSON does not contain gears")
+			t.Errorf("marshaled JSON does not contain gears")
 		}
 	})
 
@@ -537,13 +537,13 @@ func TestMarshalMultiOneOfStructs(t *testing.T) {
 		}
 
 		jsonString := string(b)
-		fmt.Printf("Marshalled JSON (Parade): %s\n", jsonString)
+		fmt.Printf("Marshaled JSON (Parade): %s\n", jsonString)
 
 		if !strings.Contains(jsonString, `"type":"cat"`) {
-			t.Errorf("marshalled JSON does not contain type discriminator for Cat")
+			t.Errorf("marshaled JSON does not contain type discriminator for Cat")
 		}
 		if !strings.Contains(jsonString, `"type":"dog"`) {
-			t.Errorf("marshalled JSON does not contain type discriminator for Dog")
+			t.Errorf("marshaled JSON does not contain type discriminator for Dog")
 		}
 	})
 }

--- a/examples/derivingjson/integrationtest/models.go
+++ b/examples/derivingjson/integrationtest/models.go
@@ -9,7 +9,7 @@ type DataInterface interface {
 
 // APIResponse is a generic API response structure where the Data field
 // can contain different types of objects that implement DataInterface.
-// @deriving:unmarshall
+// @deriving:unmarshal
 type APIResponse struct {
 	Status string        `json:"status"`
 	Data   DataInterface `json:"data"` // Changed from interface{} to DataInterface
@@ -17,7 +17,7 @@ type APIResponse struct {
 
 // UserProfile is one of the possible types for the Data field.
 // It represents a user's profile information.
-// @derivingmarshall
+// @deriving:marshal
 type UserProfile struct {
 	Type     string `json:"type"` // Discriminator: "user_profile" (expected value based on original user request)
 	UserID   string `json:"userId"`
@@ -29,7 +29,7 @@ func (UserProfile) isData() {}
 
 // ProductInfo is another possible type for the Data field.
 // It represents information about a product.
-// @derivingmarshall
+// @deriving:marshal
 type ProductInfo struct {
 	Type        string `json:"type"` // Discriminator: "product_info" (expected value based on original user request)
 	ProductID   string `json:"productId"`

--- a/examples/derivingjson/integrationtest/multioneof.go
+++ b/examples/derivingjson/integrationtest/multioneof.go
@@ -17,7 +17,7 @@ type Vehicle interface {
 // --- Implementers for Animal ---
 
 // Dog implements Animal
-// @derivingmarshall
+// @deriving:marshal
 type Dog struct {
 	Breed string `json:"breed"`
 	Noise string `json:"noise"`
@@ -27,7 +27,7 @@ func (d *Dog) Speak() string      { return d.Noise }
 func (d *Dog) AnimalKind() string { return "dog" }
 
 // Cat implements Animal
-// @derivingmarshall
+// @deriving:marshal
 type Cat struct {
 	Color string `json:"color"`
 	Purr  bool   `json:"purr"`
@@ -39,7 +39,7 @@ func (c *Cat) AnimalKind() string { return "cat" }
 // --- Implementers for Vehicle ---
 
 // Car implements Vehicle
-// @derivingmarshall
+// @deriving:marshal
 type Car struct {
 	Make   string `json:"make"`
 	Wheels int    `json:"wheels"`
@@ -49,7 +49,7 @@ func (c *Car) Move() string        { return "vroom" }
 func (c *Car) VehicleType() string { return "car" }
 
 // Bicycle implements Vehicle
-// @derivingmarshall
+// @deriving:marshal
 type Bicycle struct {
 	Gears   int  `json:"gears"`
 	HasBell bool `json:"has_bell"`
@@ -61,7 +61,7 @@ func (b *Bicycle) VehicleType() string { return "bicycle" }
 // --- Structs with multiple oneOf fields ---
 
 // Scene contains multiple different oneOf fields
-// @deriving:unmarshall
+// @deriving:unmarshal
 type Scene struct {
 	Name        string  `json:"name"`
 	MainAnimal  Animal  `json:"main_animal,omitempty"`  // oneOf
@@ -70,7 +70,7 @@ type Scene struct {
 }
 
 // Parade contains multiple oneOf fields of the same interface type
-// @deriving:unmarshall
+// @deriving:unmarshal
 type Parade struct {
 	EventName      string `json:"event_name"`
 	LeadAnimal     Animal `json:"lead_animal,omitempty"`     // oneOf (Animal)
@@ -92,7 +92,7 @@ type Pet interface {
 	PetKind() string
 }
 
-// @derivingmarshall
+// @deriving:marshal
 type Goldfish struct {
 	Name      string `json:"name"`
 	BowlShape string `json:"bowl_shape"`
@@ -101,7 +101,7 @@ type Goldfish struct {
 func (g *Goldfish) IsFriendly() bool { return true }
 func (g *Goldfish) PetKind() string  { return "goldfish" }
 
-// @deriving:unmarshall
+// @deriving:unmarshal
 type PetOwner struct {
 	OwnerName string  `json:"owner_name"`
 	Pet       Pet     `json:"pet_data,omitempty"`  // oneOf

--- a/examples/derivingjson/testdata/separated/models/models.go
+++ b/examples/derivingjson/testdata/separated/models/models.go
@@ -3,7 +3,7 @@ package models
 import "github.com/podhmo/go-scan/examples/derivingjson/testdata/separated/shapes"
 
 // Container holds a shape.
-// @deriving:unmarshall
+// @deriving:unmarshal
 type Container struct {
 	Content shapes.Shape `json:"content"`
 }

--- a/examples/derivingjson/testdata/separated/shapes/shapes.go
+++ b/examples/derivingjson/testdata/separated/shapes/shapes.go
@@ -1,14 +1,14 @@
 package shapes
 
 // Shape is an interface for geometric shapes.
-// @deriving:unmarshall
+// @deriving:unmarshal
 type Shape interface {
 	isShape()
 	GetType() string
 }
 
 // Circle represents a circle.
-// @deriving:unmarshall
+// @deriving:unmarshal
 type Circle struct {
 	Type   string `json:"type"` // Discriminator field
 	Radius int    `json:"radius"`
@@ -23,7 +23,7 @@ func (c Circle) GetType() string {
 }
 
 // Rectangle represents a rectangle.
-// @deriving:unmarshall
+// @deriving:unmarshal
 type Rectangle struct {
 	Type   string `json:"type"` // Discriminator field
 	Width  int    `json:"width"`

--- a/examples/derivingjson/testdata/simple/models.go
+++ b/examples/derivingjson/testdata/simple/models.go
@@ -1,14 +1,14 @@
 package simple
 
 // Shape is an interface for geometric shapes.
-// @deriving:unmarshall
+// @deriving:unmarshal
 type Shape interface {
 	isShape()
 	GetType() string // Added: Method to get discriminator value
 }
 
 // Circle represents a circle.
-// @deriving:unmarshall
+// @deriving:unmarshal
 type Circle struct {
 	Type   string `json:"type"` // Added: Discriminator field
 	Radius int    `json:"radius"`
@@ -26,7 +26,7 @@ func (c Circle) GetType() string {
 }
 
 // Rectangle represents a rectangle.
-// @deriving:unmarshall
+// @deriving:unmarshal
 type Rectangle struct {
 	Type   string `json:"type"` // Added: Discriminator field
 	Width  int    `json:"width"`
@@ -44,13 +44,13 @@ func (r Rectangle) GetType() string {
 	return r.Type
 }
 
-// @deriving:unmarshall
+// @deriving:unmarshal
 // Other is a struct that is not part of the oneOf
 type Other struct {
 	Name string `json:"name"`
 }
 
-// @deriving:unmarshall
+// @deriving:unmarshal
 type Container struct {
 	Content Shape `json:"content"` // oneOf
 	// Type field removed from Container


### PR DESCRIPTION
…ations throughout the codebase.

Here are the changes I made:
- `marshall` -> `marshal`
- `unmarshall` -> `unmarshal`
- `derivingmarshall` -> `deriving:marshal`

I applied these changes globally and then ran all tests, including the e2e tests. Everything passed, so I can confirm no regressions were introduced.