### PR TITLE
I've made a fix to remove unnecessary `deriving:unmarshal` markers.

### DIFF
--- a/examples/derivingjson/testdata/separated/shapes/shapes.go
+++ b/examples/derivingjson/testdata/separated/shapes/shapes.go
@@ -1,14 +1,12 @@
 package shapes
 
 // Shape is an interface for geometric shapes.
-// @deriving:unmarshal
 type Shape interface {
 	isShape()
 	GetType() string
 }
 
 // Circle represents a circle.
-// @deriving:unmarshal
 type Circle struct {
 	Type   string `json:"type"` // Discriminator field
 	Radius int    `json:"radius"`
@@ -23,7 +21,6 @@ func (c Circle) GetType() string {
 }
 
 // Rectangle represents a rectangle.
-// @deriving:unmarshal
 type Rectangle struct {
 	Type   string `json:"type"` // Discriminator field
 	Width  int    `json:"width"`

--- a/examples/derivingjson/testdata/simple/models.go
+++ b/examples/derivingjson/testdata/simple/models.go
@@ -1,14 +1,12 @@
 package simple
 
 // Shape is an interface for geometric shapes.
-// @deriving:unmarshal
 type Shape interface {
 	isShape()
 	GetType() string // Added: Method to get discriminator value
 }
 
 // Circle represents a circle.
-// @deriving:unmarshal
 type Circle struct {
 	Type   string `json:"type"` // Added: Discriminator field
 	Radius int    `json:"radius"`
@@ -26,7 +24,6 @@ func (c Circle) GetType() string {
 }
 
 // Rectangle represents a rectangle.
-// @deriving:unmarshal
 type Rectangle struct {
 	Type   string `json:"type"` // Added: Discriminator field
 	Width  int    `json:"width"`
@@ -44,7 +41,6 @@ func (r Rectangle) GetType() string {
 	return r.Type
 }
 
-// @deriving:unmarshal
 // Other is a struct that is not part of the oneOf
 type Other struct {
 	Name string `json:"name"`


### PR DESCRIPTION
The `deriving:unmarshal` marker is only required on structs that contain one-of-like fields (interfaces) to trigger the custom unmarshaler generation.

I found it was incorrectly placed on the interface definitions themselves and on the concrete types that implement those interfaces in the testdata directories. The scanner correctly finds implementers of an interface without them needing to be explicitly marked.

I have removed the superfluous markers from:
- `examples/derivingjson/testdata/simple/models.go`
- `examples/derivingjson/testdata/separated/shapes/shapes.go`

To confirm that the generator still works as expected after this change, I ran the test suite for `derivingjson`.