### PR TITLE
feat(deriving-all): Add MarshalJSON test for oneOf

### DIFF
--- a/examples/deriving-all/testdata/e2e/models/models.go
+++ b/examples/deriving-all/testdata/e2e/models/models.go
@@ -24,6 +24,7 @@ type EventData interface {
 	isEventData()
 }
 
+// @deriving:marshal
 type UserCreated struct {
 	UserID   string `json:"userId"`
 	Username string `json:"username"`
@@ -31,6 +32,7 @@ type UserCreated struct {
 
 func (UserCreated) isEventData() {}
 
+// @deriving:marshal
 type MessagePosted struct {
 	MessageID string `json:"messageId"`
 	Content   string `json:"content"`

--- a/examples/deriving-all/testdata/e2e/models/models_deriving.go
+++ b/examples/deriving-all/testdata/e2e/models/models_deriving.go
@@ -62,6 +62,28 @@ func (s *Event) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *UserCreated) MarshalJSON() ([]byte, error) {
+	type Alias UserCreated
+	return json.Marshal(&struct {
+		*Alias
+		Type string `json:"type"`
+	}{
+		Alias: (*Alias)(s),
+		Type:  "usercreated",
+	})
+}
+
+func (s *MessagePosted) MarshalJSON() ([]byte, error) {
+	type Alias MessagePosted
+	return json.Marshal(&struct {
+		*Alias
+		Type string `json:"type"`
+	}{
+		Alias: (*Alias)(s),
+		Type:  "messageposted",
+	})
+}
+
 func (s *User) Bind(req *http.Request, pathVar func(string) string) error {
 	var errs []error
 


### PR DESCRIPTION
Adds a new integration test for the `MarshalJSON` functionality on structs that use a `oneOf`-style interface field.

- Adds the `@deriving:marshal` annotation to the concrete `EventData` implementers (`UserCreated`, `MessagePosted`).
- Implements `TestMarshalEvent` in the `integrationtest` package to verify that marshaling an `Event` struct correctly produces a JSON object with the appropriate `type` discriminator field for the `data` payload.
- Makes the test assertions more robust by comparing the structure of the JSON (by unmarshaling to maps) rather than relying on brittle string comparison, which can fail due to key order changes.