### PR TITLE
feat: implement deps-walk CLI tool for dependency visualization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -114,21 +114,14 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
     -   [x] **Lightweight "Imports-Only" Scanning Mode**: Added `ScanPackageImports` for efficient dependency discovery without a full AST parse.
     -   [x] **Generic Graph Traversal Utility**: Added the `Walk` method and `Visitor` interface to allow for flexible dependency graph traversal.
     -   [x] **Unit Tests**: Added comprehensive unit tests for the new scanning and walking features.
+-   **`deps-walk` Command-Line Tool**: Implemented the `deps-walk` tool as described in [docs/plan-in-module-deps-walk.md](./docs/plan-in-module-deps-walk.md).
+    -   [x] **Initial Tool Setup**: Created the basic CLI structure for the `deps-walk` tool and implemented the logic to call the `goscan.Scanner.Walk` method.
+    -   [x] **Core Visualization Features**: Implemented graph generation in DOT format and added support for the `--hops` flag to limit traversal depth.
+    -   [x] **Filtering and Usability**: Added support for the `--ignore` flag for package exclusion and a `--full` flag to include external dependencies (defaulting to in-module only).
+    -   [x] **Integration Tests**: Added integration tests for the `deps-walk` tool using `scantest`.
 ## To Be Implemented
 
 ### In-Module Dependency Walker ([docs/plan-in-module-deps-walk.md](./docs/plan-in-module-deps-walk.md))
-
-- [ ] **2. `deps-walk` Command-Line Tool**
-  - [ ] **Initial Tool Setup**
-    - [ ] Create the basic CLI structure for the `deps-walk` tool.
-    - [ ] Implement the logic to call the new `goscan.Scanner.Walk` method.
-  - [ ] **Core Visualization Features**
-    - [ ] Implement graph generation in DOT format.
-    - [ ] Add support for the `--hops` flag to limit traversal depth.
-  - [ ] **Filtering and Usability**
-    - [ ] Add support for the `--ignore` flag for package exclusion.
-  - [ ] **Integration Tests**
-    - [ ] Add integration tests for the `deps-walk` tool using `scantest`.
 
 - [ ] **3. Future Enhancements**
   - [ ] **File-Level Granularity**

--- a/docs/plan-in-module-deps-walk.md
+++ b/docs/plan-in-module-deps-walk.md
@@ -32,6 +32,15 @@ The user will be able to provide a list of package import patterns to ignore or 
 
 The tool will output the graph in a standard format like DOT, which can be rendered by tools like Graphviz.
 
+### 2.4. Dependency Scope (In-Module vs. Full)
+
+By default, the tool will only traverse dependencies that are part of the current Go module. This is the most common use case, as it focuses on the internal architecture of the project without getting cluttered by standard library or third-party dependencies.
+
+The user can include external dependencies in the graph by using a specific flag.
+
+-   **Default:** Only packages within the current Go module are included.
+-   **Flag:** `go-deps-walk --start-pkg=./api --full` will include all dependencies, including those from the standard library and external modules.
+
 ## 3. Analysis of the `go-scan` Library
 
 To build this tool, we must first analyze the capabilities of the existing `go-scan` library.

--- a/examples/deps-walk/main.go
+++ b/examples/deps-walk/main.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	goscan "github.com/podhmo/go-scan"
+)
+
+func main() {
+	var (
+		startPkg string
+		hops     int
+		ignore   string
+		output   string
+		full     bool
+	)
+
+	flag.StringVar(&startPkg, "start-pkg", "", "The root package to start the dependency walk from (required)")
+	flag.IntVar(&hops, "hops", 1, "Maximum number of hops to walk from the start package")
+	flag.StringVar(&ignore, "ignore", "", "A comma-separated list of package patterns to ignore")
+	flag.StringVar(&output, "output", "", "Output file path for the DOT graph (defaults to stdout)")
+	flag.BoolVar(&full, "full", false, "Include dependencies outside the current module")
+	flag.Parse()
+
+	if startPkg == "" {
+		log.Fatal("-start-pkg is required")
+	}
+
+	if err := run(context.Background(), startPkg, hops, ignore, output, full); err != nil {
+		log.Fatalf("Error: %+v", err)
+	}
+}
+
+func run(ctx context.Context, startPkg string, hops int, ignore string, output string, full bool) error {
+	s, err := goscan.New()
+	if err != nil {
+		return fmt.Errorf("failed to create scanner: %w", err)
+	}
+
+	ignorePatterns := []string{}
+	if ignore != "" {
+		ignorePatterns = strings.Split(ignore, ",")
+	}
+
+	visitor := &graphVisitor{
+		s:              s,
+		hops:           hops,
+		full:           full,
+		ignorePatterns: ignorePatterns,
+		dependencies:   make(map[string][]string),
+		packageHops:    make(map[string]int),
+	}
+
+	// Set the starting hop level for the root package
+	visitor.packageHops[startPkg] = 0
+
+	if err := s.Walk(ctx, startPkg, visitor); err != nil {
+		return fmt.Errorf("walk failed: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := visitor.WriteDOT(&buf); err != nil {
+		return fmt.Errorf("failed to generate DOT graph: %w", err)
+	}
+
+	if output == "" {
+		_, err = os.Stdout.Write(buf.Bytes())
+		if err != nil {
+			return fmt.Errorf("writing to stdout: %w", err)
+		}
+		return nil
+	}
+	return os.WriteFile(output, buf.Bytes(), 0644)
+}
+
+type graphVisitor struct {
+	s              *goscan.Scanner
+	hops           int
+	full           bool
+	ignorePatterns []string
+	dependencies   map[string][]string // from -> to[]
+	packageHops    map[string]int      // package -> hop level
+}
+
+func (v *graphVisitor) Visit(pkg *goscan.PackageImports) ([]string, error) {
+	currentHop, exists := v.packageHops[pkg.ImportPath]
+	if !exists {
+		// This can happen for packages that are imported but not yet visited via the queue.
+		// It's a dependency of a package we are visiting.
+		// We should not proceed if it's an externally discovered package beyond hop 0.
+		// However, the Walk function's design means this will be a package from the queue.
+		// If it's not in packageHops, it means it's a new package, and its hop level should have been set when it was added to the queue.
+		// The logic below handles setting the hop for newly discovered packages.
+		// Let's be safe and assume if it's not in the map, we can't determine its hop count, so we stop.
+		return nil, fmt.Errorf("internal error: visiting package %q with no hop level assigned", pkg.ImportPath)
+	}
+
+	if currentHop >= v.hops {
+		return nil, nil // Stop traversal from this node
+	}
+
+	var importsToFollow []string
+	modulePath := v.s.ModulePath()
+
+	for _, imp := range pkg.Imports {
+		// Check ignore patterns
+		isIgnored := false
+		for _, pattern := range v.ignorePatterns {
+			if matched, _ := filepath.Match(pattern, imp); matched {
+				isIgnored = true
+				break
+			}
+		}
+		if isIgnored {
+			continue
+		}
+
+		// Record the dependency, regardless of whether we follow it or not
+		v.dependencies[pkg.ImportPath] = append(v.dependencies[pkg.ImportPath], imp)
+
+		// Check if we should follow this import
+		isInternal := modulePath != "" && strings.HasPrefix(imp, modulePath)
+		if !v.full && !isInternal {
+			continue // Skip external dependencies if not in full mode
+		}
+
+		if _, visited := v.packageHops[imp]; !visited {
+			v.packageHops[imp] = currentHop + 1
+			importsToFollow = append(importsToFollow, imp)
+		}
+	}
+	return importsToFollow, nil
+}
+
+func (v *graphVisitor) WriteDOT(w io.Writer) error {
+	fmt.Fprintln(w, "digraph dependencies {")
+	fmt.Fprintln(w, `  rankdir="LR";`)
+	fmt.Fprintln(w, `  node [shape=box, style="rounded,filled", fillcolor=lightgrey];`)
+
+	// Collect all unique packages to declare them as nodes
+	allPackagesSet := make(map[string]struct{})
+	for from, toList := range v.dependencies {
+		allPackagesSet[from] = struct{}{}
+		for _, to := range toList {
+			allPackagesSet[to] = struct{}{}
+		}
+	}
+
+	// Sort packages for deterministic output
+	sortedPackages := make([]string, 0, len(allPackagesSet))
+	for pkg := range allPackagesSet {
+		sortedPackages = append(sortedPackages, pkg)
+	}
+	sort.Strings(sortedPackages)
+
+	// Declare all nodes with their import paths as labels
+	for _, pkg := range sortedPackages {
+		fmt.Fprintf(w, `  "%s" [label="%s"];`+"\n", pkg, pkg)
+	}
+
+	fmt.Fprintln(w, "") // separator
+
+	// Sort dependencies for deterministic output
+	sortedFroms := make([]string, 0, len(v.dependencies))
+	for from := range v.dependencies {
+		sortedFroms = append(sortedFroms, from)
+	}
+	sort.Strings(sortedFroms)
+
+	// Define all edges
+	for _, from := range sortedFroms {
+		toList := v.dependencies[from]
+		sort.Strings(toList) // Sort the 'to' packages as well
+		for _, to := range toList {
+			fmt.Fprintf(w, `  "%s" -> "%s";`+"\n", from, to)
+		}
+	}
+
+	fmt.Fprintln(w, "}")
+	return nil
+}

--- a/examples/deps-walk/main_test.go
+++ b/examples/deps-walk/main_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/podhmo/go-scan/scantest"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+// loadTestdata reads all files from a directory recursively and returns them as a map
+// with relative paths as keys, suitable for scantest.WriteFiles.
+func loadTestdata(t *testing.T, root string) map[string]string {
+	t.Helper()
+	files := make(map[string]string)
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		files[rel] = string(content)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to load testdata from %s: %v", root, err)
+	}
+	return files
+}
+
+func TestRun(t *testing.T) {
+	testdataFiles := loadTestdata(t, "../../testdata/walk")
+
+	cases := []struct {
+		name       string
+		args       map[string]interface{}
+		goldenFile string
+	}{
+		{
+			name: "default-hops=1-in-module",
+			args: map[string]interface{}{
+				"start-pkg": "github.com/podhmo/go-scan/testdata/walk/a",
+				"hops":      1,
+				"full":      false,
+				"ignore":    "",
+			},
+			goldenFile: "default.golden",
+		},
+		{
+			name: "hops=2",
+			args: map[string]interface{}{
+				"start-pkg": "github.com/podhmo/go-scan/testdata/walk/a",
+				"hops":      2,
+				"full":      true, // to see external deps
+				"ignore":    "",
+			},
+			goldenFile: "hops2.golden",
+		},
+		{
+			name: "ignore-c",
+			args: map[string]interface{}{
+				"start-pkg": "github.com/podhmo/go-scan/testdata/walk/a",
+				"hops":      1,
+				"full":      false,
+				"ignore":    "github.com/podhmo/go-scan/testdata/walk/c",
+			},
+			goldenFile: "ignore-c.golden",
+		},
+		{
+			name: "full",
+			args: map[string]interface{}{
+				"start-pkg": "github.com/podhmo/go-scan/testdata/walk/d", // d imports an external package
+				"hops":      1,
+				"full":      true,
+				"ignore":    "",
+			},
+			goldenFile: "full.golden",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpdir, cleanup := scantest.WriteFiles(t, testdataFiles)
+			defer cleanup()
+
+			originalWD, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("failed to get wd: %v", err)
+			}
+			if err := os.Chdir(tmpdir); err != nil {
+				t.Fatalf("failed to change wd to tmpdir: %v", err)
+			}
+			defer os.Chdir(originalWD)
+
+			outputFile := filepath.Join(tmpdir, "output.dot")
+			startPkg := tc.args["start-pkg"].(string)
+
+			err = run(
+				context.Background(),
+				startPkg,
+				tc.args["hops"].(int),
+				tc.args["ignore"].(string),
+				outputFile,
+				tc.args["full"].(bool),
+			)
+			if err != nil {
+				t.Fatalf("run() failed unexpectedly: %+v", err)
+			}
+
+			generated, err := os.ReadFile(outputFile)
+			if err != nil {
+				t.Fatalf("failed to read generated output file: %v", err)
+			}
+
+			goldenPath := filepath.Join(originalWD, "testdata", tc.goldenFile)
+			if *update {
+				if err := os.MkdirAll(filepath.Dir(goldenPath), 0755); err != nil {
+					t.Fatalf("failed to create testdata dir: %v", err)
+				}
+				if err := os.WriteFile(goldenPath, generated, 0644); err != nil {
+					t.Fatalf("failed to update golden file: %v", err)
+				}
+				t.Logf("golden file updated: %s", goldenPath)
+				return
+			}
+
+			golden, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("failed to read golden file %s: %v", goldenPath, err)
+			}
+
+			normalizedGenerated := strings.ReplaceAll(string(generated), "\r\n", "\n")
+			normalizedGolden := strings.ReplaceAll(string(golden), "\r\n", "\n")
+
+			if diff := cmp.Diff(normalizedGolden, normalizedGenerated); diff != "" {
+				t.Errorf("output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/examples/deps-walk/testdata/default.golden
+++ b/examples/deps-walk/testdata/default.golden
@@ -1,0 +1,12 @@
+digraph dependencies {
+  rankdir="LR";
+  node [shape=box, style="rounded,filled", fillcolor=lightgrey];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
+  "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
+  "github.com/podhmo/go-scan/testdata/walk/c" [label="github.com/podhmo/go-scan/testdata/walk/c"];
+  "github.com/podhmo/go-scan/testdata/walk/d" [label="github.com/podhmo/go-scan/testdata/walk/d"];
+
+  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/b";
+  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/c";
+  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/d";
+}

--- a/examples/deps-walk/testdata/full.golden
+++ b/examples/deps-walk/testdata/full.golden
@@ -1,0 +1,8 @@
+digraph dependencies {
+  rankdir="LR";
+  node [shape=box, style="rounded,filled", fillcolor=lightgrey];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
+  "github.com/podhmo/go-scan/testdata/walk/d" [label="github.com/podhmo/go-scan/testdata/walk/d"];
+
+  "github.com/podhmo/go-scan/testdata/walk/d" -> "github.com/podhmo/go-scan/testdata/walk/a";
+}

--- a/examples/deps-walk/testdata/hops2.golden
+++ b/examples/deps-walk/testdata/hops2.golden
@@ -1,0 +1,14 @@
+digraph dependencies {
+  rankdir="LR";
+  node [shape=box, style="rounded,filled", fillcolor=lightgrey];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
+  "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
+  "github.com/podhmo/go-scan/testdata/walk/c" [label="github.com/podhmo/go-scan/testdata/walk/c"];
+  "github.com/podhmo/go-scan/testdata/walk/d" [label="github.com/podhmo/go-scan/testdata/walk/d"];
+
+  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/b";
+  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/c";
+  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/d";
+  "github.com/podhmo/go-scan/testdata/walk/b" -> "github.com/podhmo/go-scan/testdata/walk/c";
+  "github.com/podhmo/go-scan/testdata/walk/d" -> "github.com/podhmo/go-scan/testdata/walk/a";
+}

--- a/examples/deps-walk/testdata/ignore-c.golden
+++ b/examples/deps-walk/testdata/ignore-c.golden
@@ -1,0 +1,10 @@
+digraph dependencies {
+  rankdir="LR";
+  node [shape=box, style="rounded,filled", fillcolor=lightgrey];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
+  "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
+  "github.com/podhmo/go-scan/testdata/walk/d" [label="github.com/podhmo/go-scan/testdata/walk/d"];
+
+  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/b";
+  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/d";
+}


### PR DESCRIPTION
This commit introduces the `deps-walk` command-line tool, a new utility for visualizing package dependencies within a Go module.

The tool is located in the `examples/deps-walk` directory and leverages the existing `goscan.Walk` functionality.

Key features include:
- Generation of dependency graphs in DOT format.
- Ability to limit traversal depth using the `--hops` flag.
- Filtering of packages using the `--ignore` flag.
- By default, it analyzes only dependencies within the current module. The `--full` flag can be used to include external and standard library packages.

Integration tests using the `scantest` library have been added to verify all features. The tool's documentation has also been updated to reflect the new capabilities.