### PR TITLE
feat(deps-walk): add mermaid output format

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -124,6 +124,11 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
 ### In-Module Dependency Walker ([docs/plan-in-module-deps-walk.md](./docs/plan-in-module-deps-walk.md))
 
 - [ ] **3. Future Enhancements**
+  - [x] **Mermaid Output Format**
+    - [x] Add a `-format` flag to `deps-walk` (default: "dot", options: "mermaid").
+    - [x] Implement `WriteMermaid` in the `graphVisitor`.
+    - [x] Add a test case with a golden file for the Mermaid output.
+    - [ ] Update documentation for the new format.
   - [ ] **File-Level Granularity**
     - [ ] Extend `goscan.PackageImports` to include a file-by-file breakdown of imports.
     - [ ] Add a `--granularity=file` flag to the `deps-walk` tool.

--- a/docs/plan-in-module-deps-walk.md
+++ b/docs/plan-in-module-deps-walk.md
@@ -30,7 +30,9 @@ The user will be able to provide a list of package import patterns to ignore or 
 
 ### 2.3. Output Format
 
-The tool will output the graph in a standard format like DOT, which can be rendered by tools like Graphviz.
+The tool will output the graph in standard formats. The initial implementation will support:
+- **DOT**: A graph description language that can be rendered by tools like Graphviz.
+- **Mermaid**: A Markdown-inspired syntax for generating diagrams and charts.
 
 ### 2.4. Dependency Scope (In-Module vs. Full)
 

--- a/examples/deps-walk/main_test.go
+++ b/examples/deps-walk/main_test.go
@@ -58,6 +58,7 @@ func TestRun(t *testing.T) {
 				"hops":      1,
 				"full":      false,
 				"ignore":    "",
+				"format":    "dot",
 			},
 			goldenFile: "default.golden",
 		},
@@ -68,6 +69,7 @@ func TestRun(t *testing.T) {
 				"hops":      2,
 				"full":      true, // to see external deps
 				"ignore":    "",
+				"format":    "dot",
 			},
 			goldenFile: "hops2.golden",
 		},
@@ -78,6 +80,7 @@ func TestRun(t *testing.T) {
 				"hops":      1,
 				"full":      false,
 				"ignore":    "github.com/podhmo/go-scan/testdata/walk/c",
+				"format":    "dot",
 			},
 			goldenFile: "ignore-c.golden",
 		},
@@ -88,8 +91,20 @@ func TestRun(t *testing.T) {
 				"hops":      1,
 				"full":      true,
 				"ignore":    "",
+				"format":    "dot",
 			},
 			goldenFile: "full.golden",
+		},
+		{
+			name: "mermaid-output",
+			args: map[string]interface{}{
+				"start-pkg": "github.com/podhmo/go-scan/testdata/walk/a",
+				"hops":      1,
+				"full":      false,
+				"ignore":    "",
+				"format":    "mermaid",
+			},
+			goldenFile: "mermaid.golden",
 		},
 	}
 
@@ -107,7 +122,7 @@ func TestRun(t *testing.T) {
 			}
 			defer os.Chdir(originalWD)
 
-			outputFile := filepath.Join(tmpdir, "output.dot")
+			outputFile := filepath.Join(tmpdir, "output.txt") // generic name
 			startPkg := tc.args["start-pkg"].(string)
 
 			err = run(
@@ -116,6 +131,7 @@ func TestRun(t *testing.T) {
 				tc.args["hops"].(int),
 				tc.args["ignore"].(string),
 				outputFile,
+				tc.args["format"].(string),
 				tc.args["full"].(bool),
 			)
 			if err != nil {

--- a/examples/deps-walk/testdata/mermaid.golden
+++ b/examples/deps-walk/testdata/mermaid.golden
@@ -1,0 +1,4 @@
+graph TD;
+    github.com/podhmo/go-scan/testdata/walk/a[github.com/podhmo/go-scan/testdata/walk/a] --> github.com/podhmo/go-scan/testdata/walk/b[github.com/podhmo/go-scan/testdata/walk/b]
+    github.com/podhmo/go-scan/testdata/walk/a[github.com/podhmo/go-scan/testdata/walk/a] --> github.com/podhmo/go-scan/testdata/walk/c[github.com/podhmo/go-scan/testdata/walk/c]
+    github.com/podhmo/go-scan/testdata/walk/a[github.com/podhmo/go-scan/testdata/walk/a] --> github.com/podhmo/go-scan/testdata/walk/d[github.com/podhmo/go-scan/testdata/walk/d]


### PR DESCRIPTION
Adds a new `-format=mermaid` option to the `deps-walk` tool, allowing it to generate dependency graphs in Mermaid's graph syntax.

The implementation includes:
- A new `WriteMermaid` method on the `graphVisitor`.
- A `-format` flag to select between `dot` and `mermaid` output.
- A new test case with a golden file to verify the Mermaid output.