### PR TITLE
feat(deps-walk): add file-level granularity

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -126,9 +126,9 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
 
 ### In-Module Dependency Walker ([docs/plan-in-module-deps-walk.md](./docs/plan-in-module-deps-walk.md))
 
-- [ ] **3. Future Enhancements**
-  - [ ] **File-Level Granularity**
-    - [ ] Extend `goscan.PackageImports` to include a file-by-file breakdown of imports.
-    - [ ] Add a `--granularity=file` flag to the `deps-walk` tool.
+- [x] **3. Future Enhancements**
+  - [x] **File-Level Granularity**
+    - [x] Extend `goscan.PackageImports` to include a file-by-file breakdown of imports.
+    - [x] Add a `--granularity=file` flag to the `deps-walk` tool.
   - [ ] **Reverse Dependencies (Importers)**
     - [ ] Investigate strategies for finding reverse dependencies (e.g., text search, pre-built index).

--- a/examples/deps-walk/testdata/default-mermaid-short.golden
+++ b/examples/deps-walk/testdata/default-mermaid-short.golden
@@ -1,6 +1,7 @@
 graph LR
 
   subgraph module [github.com/podhmo/go-scan/testdata/walk]
+
     id0["a"]
     id1["b"]
     id2["c"]

--- a/examples/deps-walk/testdata/default-mermaid.golden
+++ b/examples/deps-walk/testdata/default-mermaid.golden
@@ -1,4 +1,5 @@
 graph LR
+
   id0["github.com/podhmo/go-scan/testdata/walk/a"]
   id1["github.com/podhmo/go-scan/testdata/walk/b"]
   id2["github.com/podhmo/go-scan/testdata/walk/c"]

--- a/examples/deps-walk/testdata/file-granularity.golden
+++ b/examples/deps-walk/testdata/file-granularity.golden
@@ -1,0 +1,11 @@
+digraph dependencies {
+  rankdir="LR";
+  "<tmp>/a/a.go" [label="a/a.go", shape=note, style=filled, fillcolor=khaki];
+  "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b", shape=box, style="rounded,filled", fillcolor=lightgrey];
+  "github.com/podhmo/go-scan/testdata/walk/c" [label="github.com/podhmo/go-scan/testdata/walk/c", shape=box, style="rounded,filled", fillcolor=lightgrey];
+  "github.com/podhmo/go-scan/testdata/walk/d" [label="github.com/podhmo/go-scan/testdata/walk/d", shape=box, style="rounded,filled", fillcolor=lightgrey];
+
+  "<tmp>/a/a.go" -> "github.com/podhmo/go-scan/testdata/walk/b";
+  "<tmp>/a/a.go" -> "github.com/podhmo/go-scan/testdata/walk/c";
+  "<tmp>/a/a.go" -> "github.com/podhmo/go-scan/testdata/walk/d";
+}

--- a/scanner/models.go
+++ b/scanner/models.go
@@ -381,9 +381,10 @@ func (ft *FieldType) SetResolver(r PackageResolver) {
 
 // PackageImports holds the minimal information about a package's direct imports.
 type PackageImports struct {
-	Name       string
-	ImportPath string
-	Imports    []string
+	Name        string
+	ImportPath  string
+	Imports     []string
+	FileImports map[string][]string // file path -> import paths
 }
 
 // Visitor defines the interface for operations to be performed at each node

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -92,7 +92,8 @@ func (s *Scanner) ScanFilesWithKnownImportPath(ctx context.Context, filePaths []
 // ScanPackageImports parses only the import declarations from a set of Go files.
 func (s *Scanner) ScanPackageImports(ctx context.Context, filePaths []string, pkgDirPath string, canonicalImportPath string) (*PackageImports, error) {
 	info := &PackageImports{
-		ImportPath: canonicalImportPath,
+		ImportPath:  canonicalImportPath,
+		FileImports: make(map[string][]string),
 	}
 	imports := make(map[string]struct{})
 	var firstPackageName string
@@ -123,11 +124,16 @@ func (s *Scanner) ScanPackageImports(ctx context.Context, filePaths []string, pk
 			return nil, fmt.Errorf("mismatched package names: %s and %s in directory %s", firstPackageName, fileAst.Name.Name, pkgDirPath)
 		}
 
+		var fileImports []string
 		for _, imp := range fileAst.Imports {
 			if imp.Path != nil {
 				importPath := strings.Trim(imp.Path.Value, `"`)
 				imports[importPath] = struct{}{}
+				fileImports = append(fileImports, importPath)
 			}
+		}
+		if len(fileImports) > 0 {
+			info.FileImports[filePath] = fileImports
 		}
 	}
 


### PR DESCRIPTION
This commit implements file-level granularity for the `deps-walk` tool.

The `goscan.PackageImports` struct has been extended to include a `FileImports` map, which provides a file-by-file breakdown of imports.

The `deps-walk` tool now has a `--granularity` flag that can be set to "file" to enable the new functionality. When enabled, the tool will output a graph showing dependencies from individual files to the packages they import.

The DOT and Mermaid output formats have been updated to render the new graph structure, using different shapes to distinguish between file and package nodes.

Tests have been added to verify the new functionality, and existing tests have been updated to ensure backward compatibility.