### PR TITLE
I've implemented an aggressive reverse dependency search for the `dep…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -133,7 +133,7 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
     - [x] Add a `--granularity=file` flag to the `deps-walk` tool.
   - [x] **Reverse Dependencies (Importers)**
     - [x] Implemented a reverse dependency search feature in the `deps-walk` tool via a `--reverse` flag. It uses a new `goscan.FindImporters` function that performs an efficient, module-wide text-based search for import statements.
-  - [ ] **Aggressive Reverse Dependency Search**
-    - [ ] Add an option (e.g., `--direction=reverse --aggressive`) that uses `git grep` to find all files containing an import path string and then parses only those files to confirm the import. This could be faster in very large repositories.
+  - [x] **Aggressive Reverse Dependency Search**
+    - [x] Add an option (e.g., `--direction=reverse --aggressive`) that uses `git grep` to find all files containing an import path string and then parses only those files to confirm the import. This could be faster in very large repositories.
   - [ ] **Bidirectional Dependency Graph**
     - [ ] Implement the `--direction=bidi` option to show both forward dependencies (up to `--hops`) and reverse dependencies (importers) in the same graph.

--- a/examples/deps-walk/README.md
+++ b/examples/deps-walk/README.md
@@ -83,3 +83,28 @@ digraph dependencies {
   "github.com/podhmo/go-scan/testdata/walk/b" -> "github.com/podhmo/go-scan/testdata/walk/d";
 }
 ```
+
+## Reverse Dependencies
+
+You can find which packages import a specific package by using the `--direction=reverse` flag.
+
+```bash
+$ go run ./examples/deps-walk \
+    -start-pkg=github.com/podhmo/go-scan/testdata/walk/c \
+    -direction=reverse
+```
+
+This will output a graph showing that packages `a` and `b` import package `c`.
+
+### Aggressive Search Mode
+
+In very large repositories, the default reverse dependency search can be slow because it inspects every package in the module. For a much faster search, you can use the `--aggressive` flag.
+
+```bash
+$ go run ./examples/deps-walk \
+    -start-pkg=github.com/podhmo/go-scan/testdata/walk/c \
+    -direction=reverse \
+    -aggressive
+```
+
+This mode uses `git grep` to quickly find files that contain the import path. It then parses only those files to confirm the dependency. This requires `git` to be installed and the project to be a git repository. The output will be identical to the non-aggressive search.

--- a/examples/deps-walk/main_test.go
+++ b/examples/deps-walk/main_test.go
@@ -206,6 +206,7 @@ func TestRun(t *testing.T) {
 				tc.args["full"].(bool),
 				tc.args["short"].(bool),
 				direction,
+				false, // aggressive
 			)
 			if err != nil {
 				t.Fatalf("run() failed unexpectedly: %+v", err)

--- a/goscan.go
+++ b/goscan.go
@@ -1048,7 +1048,7 @@ func (s *Scanner) FindImportersAggressively(ctx context.Context, targetImportPat
 	// `import "..."` and `import ( ... "..." ... )` forms.
 	pattern := fmt.Sprintf(`"%s"`, targetImportPath)
 
-	cmd := exec.CommandContext(ctx, "git", "grep", "-l", "-F", pattern)
+	cmd := exec.CommandContext(ctx, "git", "grep", "-l", "-F", pattern, "--", "*.go")
 	cmd.Dir = rootDir
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -1065,19 +1065,8 @@ func (s *Scanner) FindImportersAggressively(ctx context.Context, targetImportPat
 		return nil, fmt.Errorf("git grep failed: %w\n%s", err, stderr.String())
 	}
 
-	allPotentialFiles := strings.Split(strings.TrimSpace(stdout.String()), "\n")
-	if len(allPotentialFiles) == 0 {
-		return nil, nil
-	}
-
-	var potentialFiles []string
-	for _, file := range allPotentialFiles {
-		if strings.HasSuffix(file, ".go") {
-			potentialFiles = append(potentialFiles, file)
-		}
-	}
-
-	if len(potentialFiles) == 0 {
+	potentialFiles := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(potentialFiles) == 0 || (len(potentialFiles) == 1 && potentialFiles[0] == "") {
 		return nil, nil // No matches
 	}
 

--- a/goscan.go
+++ b/goscan.go
@@ -1048,7 +1048,7 @@ func (s *Scanner) FindImportersAggressively(ctx context.Context, targetImportPat
 	// `import "..."` and `import ( ... "..." ... )` forms.
 	pattern := fmt.Sprintf(`"%s"`, targetImportPath)
 
-	cmd := exec.CommandContext(ctx, "git", "grep", "-l", "-F", pattern, "--", "*.go")
+	cmd := exec.CommandContext(ctx, "git", "grep", "-l", "-F", pattern)
 	cmd.Dir = rootDir
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -1065,8 +1065,19 @@ func (s *Scanner) FindImportersAggressively(ctx context.Context, targetImportPat
 		return nil, fmt.Errorf("git grep failed: %w\n%s", err, stderr.String())
 	}
 
-	potentialFiles := strings.Split(strings.TrimSpace(stdout.String()), "\n")
-	if len(potentialFiles) == 0 || (len(potentialFiles) == 1 && potentialFiles[0] == "") {
+	allPotentialFiles := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(allPotentialFiles) == 0 {
+		return nil, nil
+	}
+
+	var potentialFiles []string
+	for _, file := range allPotentialFiles {
+		if strings.HasSuffix(file, ".go") {
+			potentialFiles = append(potentialFiles, file)
+		}
+	}
+
+	if len(potentialFiles) == 0 {
 		return nil, nil // No matches
 	}
 

--- a/goscan_reverse_walk_aggressive_test.go
+++ b/goscan_reverse_walk_aggressive_test.go
@@ -1,0 +1,125 @@
+package goscan
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFindImportersAggressively(t *testing.T) {
+	testDir := "./testdata/walk"
+
+	// Git requires a user and email to be set to make commits.
+	// We can use a temporary HOME directory to avoid interfering with the user's global git config.
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	// Set up a git repository in the test directory
+	gitInitCmd := exec.Command("git", "init")
+	gitInitCmd.Dir = testDir
+	if err := gitInitCmd.Run(); err != nil {
+		t.Fatalf("git init failed: %v", err)
+	}
+
+	// Clean up .git directory after test
+	t.Cleanup(func() {
+		os.RemoveAll(filepath.Join(testDir, ".git"))
+	})
+
+	// Configure git user
+	gitConfigUserCmd := exec.Command("git", "config", "user.name", "Test User")
+	gitConfigUserCmd.Dir = testDir
+	if err := gitConfigUserCmd.Run(); err != nil {
+		t.Fatalf("git config user.name failed: %v", err)
+	}
+	gitConfigEmailCmd := exec.Command("git", "config", "user.email", "test@example.com")
+	gitConfigEmailCmd.Dir = testDir
+	if err := gitConfigEmailCmd.Run(); err != nil {
+		t.Fatalf("git config user.email failed: %v", err)
+	}
+
+	// Add and commit all files
+	gitAddCmd := exec.Command("git", "add", ".")
+	gitAddCmd.Dir = testDir
+	if err := gitAddCmd.Run(); err != nil {
+		t.Fatalf("git add failed: %v", err)
+	}
+
+	gitCommitCmd := exec.Command("git", "commit", "-m", "initial commit")
+	gitCommitCmd.Dir = testDir
+	if err := gitCommitCmd.Run(); err != nil {
+		t.Fatalf("git commit failed: %v", err)
+	}
+
+	s, err := New(WithWorkDir(testDir))
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		targetPackage string
+		wantImporters []string
+	}{
+		{
+			name:          "importers of c",
+			targetPackage: "github.com/podhmo/go-scan/testdata/walk/c",
+			wantImporters: []string{
+				"github.com/podhmo/go-scan/testdata/walk/a",
+				"github.com/podhmo/go-scan/testdata/walk/b",
+			},
+		},
+		{
+			name:          "importers of a",
+			targetPackage: "github.com/podhmo/go-scan/testdata/walk/a",
+			wantImporters: []string{
+				"github.com/podhmo/go-scan/testdata/walk/d",
+			},
+		},
+		{
+			name:          "importers of b",
+			targetPackage: "github.com/podhmo/go-scan/testdata/walk/b",
+			wantImporters: []string{
+				"github.com/podhmo/go-scan/testdata/walk/a",
+			},
+		},
+		{
+			name:          "importers of d",
+			targetPackage: "github.com/podhmo/go-scan/testdata/walk/d",
+			wantImporters: []string{
+				"github.com/podhmo/go-scan/testdata/walk/a",
+			},
+		},
+		{
+			name:          "no importers",
+			targetPackage: "github.com/podhmo/go-scan/testdata/walk/e", // non-existent package
+			wantImporters: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			importers, err := s.FindImportersAggressively(context.Background(), tt.targetPackage)
+			if err != nil {
+				t.Fatalf("FindImportersAggressively() failed: %v", err)
+			}
+
+			gotImporters := make([]string, len(importers))
+			for i, pkg := range importers {
+				gotImporters[i] = pkg.ImportPath
+			}
+
+			sort.Strings(gotImporters)
+			sort.Strings(tt.wantImporters)
+
+			if diff := cmp.Diff(tt.wantImporters, gotImporters); diff != "" {
+				t.Errorf("mismatch importers (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…s-walk` tool.

You can activate this new mode with the `--aggressive` flag when using `--direction=reverse`. It works by rapidly searching for files that contain the target import path as a fixed string. This offers a substantial performance improvement in very large repositories because it significantly reduces the number of packages that need to be parsed compared to the default method.

To accomplish this, I made the following changes:
- Added a new `FindImportersAggressively` method to the `goscan` library.
- Added the `--aggressive` flag to the `deps-walk` CLI.
- Created a new test suite for the aggressive search that initializes a temporary git repository to ensure the file search works as expected.
- Fixed the `deps-walk` integration test to account for the new parameter.