### PR TITLE
feat(deps-walk): add rich json output format

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -125,3 +125,7 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
 -   **Refactoring**:
     -   [x] **Isolate `examples/deps-walk` Test Data**: Moved the test data for the `deps-walk` example from the root `testdata` directory to its own `examples/deps-walk/testdata` directory, making the example more self-contained.
 ## To Be Implemented
+
+-   **`deps-walk`**: Add hop count limiting for reverse dependency searches.
+    -   Currently, the `--hops` flag only applies to forward searches.
+    -   It would be useful to have a similar mechanism (e.g., `--reverse-hops`) to limit the scope of reverse and bidi searches.

--- a/docs/plan-in-module-deps-walk.md
+++ b/docs/plan-in-module-deps-walk.md
@@ -33,6 +33,7 @@ The user will be able to provide a list of package import patterns to ignore or 
 The tool will output the graph in standard formats. Initially, it will support:
 - **DOT**: For rendering with tools like Graphviz.
 - **Mermaid**: For easy embedding in Markdown documents (e.g., on GitHub).
+- **JSON**: For programmatic use or integration with other tools.
 
 ### 2.4. Dependency Scope (In-Module vs. Full)
 

--- a/examples/deps-walk/README.md
+++ b/examples/deps-walk/README.md
@@ -15,7 +15,7 @@ The tool outputs a dependency graph in the DOT language, which can be rendered i
 - **Package Filtering**: Supports ignoring specific packages or package patterns (e.g., common utilities, logging) using the `--ignore` flag to declutter the graph.
 - **Configurable Scope**: By default, it traverses only packages within the current Go module. The `--full` flag can be used to include external dependencies (from the standard library or third-party modules).
 - **DOT Output**: Generates a graph in the DOT format, ready for visualization.
-- **Multiple Output Formats**: Supports graph generation in DOT (default) and Mermaid formats via the `--format` flag.
+- **Multiple Output Formats**: Supports graph generation in DOT (default), Mermaid, and JSON formats via the `--format` flag.
 - **Path Shortening**: The `--short` flag simplifies package paths in the output by omitting the module prefix.
 
 ## Usage
@@ -31,6 +31,13 @@ $ go run ./examples/deps-walk -start-pkg=github.com/podhmo/go-scan/testdata/walk
 ```bash
 $ go run ./examples/deps-walk -start-pkg=github.com/podhmo/go-scan/testdata/walk/a -format=mermaid
 ```
+
+### Generating JSON output
+```bash
+$ go run ./examples/deps-walk -start-pkg=github.com/podhmo/go-scan/testdata/walk/a -format=json
+```
+
+The JSON output includes the configuration of the run and separate fields for forward and reverse dependencies.
 
 ### Basic Example
 

--- a/examples/deps-walk/main_test.go
+++ b/examples/deps-walk/main_test.go
@@ -76,6 +76,57 @@ func TestRun(t *testing.T) {
 			goldenFile: "default-mermaid.golden",
 		},
 		{
+			name: "default-json",
+			args: map[string]interface{}{
+				"start-pkg": "github.com/podhmo/go-scan/testdata/walk/a",
+				"hops":      1,
+				"format":    "json",
+				"full":      false,
+				"short":     false,
+				"ignore":    "",
+			},
+			goldenFile: "default-json.golden",
+		},
+		{
+			name: "default-json",
+			args: map[string]interface{}{
+				"start-pkg": "github.com/podhmo/go-scan/testdata/walk/a",
+				"hops":      1,
+				"format":    "json",
+				"full":      false,
+				"short":     false,
+				"ignore":    "",
+				"direction": "forward",
+			},
+			goldenFile: "default-json.golden",
+		},
+		{
+			name: "reverse-json",
+			args: map[string]interface{}{
+				"start-pkg": "github.com/podhmo/go-scan/testdata/walk/c",
+				"hops":      1,
+				"format":    "json",
+				"full":      false,
+				"short":     false,
+				"ignore":    "",
+				"direction": "reverse",
+			},
+			goldenFile: "reverse-json.golden",
+		},
+		{
+			name: "bidi-json",
+			args: map[string]interface{}{
+				"start-pkg": "github.com/podhmo/go-scan/testdata/walk/b",
+				"hops":      1,
+				"format":    "json",
+				"full":      false,
+				"short":     false,
+				"ignore":    "",
+				"direction": "bidi",
+			},
+			goldenFile: "bidi-json.golden",
+		},
+		{
 			name: "mermaid-short",
 			args: map[string]interface{}{
 				"start-pkg": "github.com/podhmo/go-scan/testdata/walk/a",

--- a/examples/deps-walk/testdata/bidi-json.golden
+++ b/examples/deps-walk/testdata/bidi-json.golden
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "direction": "bidi",
+    "hops": 1,
+    "startPkg": "github.com/podhmo/go-scan/testdata/walk/b"
+  },
+  "dependencies": {
+    "github.com/podhmo/go-scan/testdata/walk/b": [
+      "github.com/podhmo/go-scan/testdata/walk/d"
+    ]
+  },
+  "reverseDependencies": {
+    "github.com/podhmo/go-scan/testdata/walk/a": [
+      "github.com/podhmo/go-scan/testdata/walk/b"
+    ]
+  }
+}

--- a/examples/deps-walk/testdata/bidi.golden
+++ b/examples/deps-walk/testdata/bidi.golden
@@ -5,6 +5,6 @@ digraph dependencies {
   "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
   "github.com/podhmo/go-scan/testdata/walk/d" [label="github.com/podhmo/go-scan/testdata/walk/d"];
 
-  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/b";
   "github.com/podhmo/go-scan/testdata/walk/b" -> "github.com/podhmo/go-scan/testdata/walk/d";
+  "github.com/podhmo/go-scan/testdata/walk/b" -> "github.com/podhmo/go-scan/testdata/walk/a" [dir=back, style=dashed];
 }

--- a/examples/deps-walk/testdata/default-json.golden
+++ b/examples/deps-walk/testdata/default-json.golden
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "direction": "forward",
+    "hops": 1,
+    "startPkg": "github.com/podhmo/go-scan/testdata/walk/a"
+  },
+  "dependencies": {
+    "github.com/podhmo/go-scan/testdata/walk/a": [
+      "github.com/podhmo/go-scan/testdata/walk/b",
+      "github.com/podhmo/go-scan/testdata/walk/c",
+      "github.com/podhmo/go-scan/testdata/walk/d"
+    ]
+  },
+  "reverseDependencies": {}
+}

--- a/examples/deps-walk/testdata/reverse-json.golden
+++ b/examples/deps-walk/testdata/reverse-json.golden
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "direction": "reverse",
+    "hops": 1,
+    "startPkg": "github.com/podhmo/go-scan/testdata/walk/c"
+  },
+  "dependencies": {},
+  "reverseDependencies": {
+    "github.com/podhmo/go-scan/testdata/walk/a": [
+      "github.com/podhmo/go-scan/testdata/walk/c"
+    ]
+  }
+}

--- a/examples/deps-walk/testdata/reverse.golden
+++ b/examples/deps-walk/testdata/reverse.golden
@@ -4,5 +4,5 @@ digraph dependencies {
   "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
   "github.com/podhmo/go-scan/testdata/walk/c" [label="github.com/podhmo/go-scan/testdata/walk/c"];
 
-  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/c";
+  "github.com/podhmo/go-scan/testdata/walk/c" -> "github.com/podhmo/go-scan/testdata/walk/a" [dir=back, style=dashed];
 }


### PR DESCRIPTION
Adds a new, richer `json` output format to the `examples/deps-walk` tool and improves other output formats.

Based on your feedback, the JSON output now includes a `config` block with the run parameters and separate `dependencies` and `reverseDependencies` fields.

This change also improves the `dot` and `mermaid` outputs by visualizing reverse dependencies with a distinct style (dashed and backward-pointing edges), making the `bidi` mode more informative.

Includes:
- New JSON output structure.
- Updates to `dot` and `mermaid` to show reverse dependencies.
- New and updated tests and golden files for all formats.
- A `TODO.md` entry for a requested future enhancement.
- Updates to `README.md`.