### PR TITLE
feat(deps-walk): Add multi-hop support for reverse dependency search

### DIFF
--- a/examples/deps-walk/main_test.go
+++ b/examples/deps-walk/main_test.go
@@ -225,6 +225,19 @@ func TestRun(t *testing.T) {
 			},
 			goldenFile: "bidi.golden",
 		},
+		{
+			name: "reverse-hops2",
+			args: map[string]interface{}{
+				"start-pkg": "github.com/podhmo/go-scan/testdata/walk/c",
+				"hops":      2,
+				"format":    "dot",
+				"full":      false,
+				"short":     false,
+				"ignore":    "",
+				"direction": "reverse",
+			},
+			goldenFile: "reverse-hops2.golden",
+		},
 	}
 
 	for _, tc := range cases {

--- a/examples/deps-walk/testdata/reverse-hops2.golden
+++ b/examples/deps-walk/testdata/reverse-hops2.golden
@@ -1,0 +1,10 @@
+digraph dependencies {
+  rankdir="LR";
+  node [shape=box, style="rounded,filled", fillcolor=lightgrey];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
+  "github.com/podhmo/go-scan/testdata/walk/c" [label="github.com/podhmo/go-scan/testdata/walk/c"];
+  "github.com/podhmo/go-scan/testdata/walk/d" [label="github.com/podhmo/go-scan/testdata/walk/d"];
+
+  "github.com/podhmo/go-scan/testdata/walk/c" -> "github.com/podhmo/go-scan/testdata/walk/a" [dir=back, style=dashed];
+  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/d" [dir=back, style=dashed];
+}


### PR DESCRIPTION
This commit introduces multi-hop reverse dependency searches to the `deps-walk` tool.

The existing `--hops` flag is now used to control the depth of the reverse search, making the tool more powerful for exploring importer chains.

To support this efficiently, a new `BuildReverseDependencyMap()` method was added to the core `goscan` library. This method scans the module once to build a complete reverse dependency graph, which is then cached and used for the multi-hop traversal. This avoids the performance penalty of repeatedly scanning the module for each hop.

The implementation includes a new integration test with a golden file to validate the behavior of a 2-hop reverse search.