### PR TITLE
feat(deps-walk): Add -test flag to include test files

### DIFF
--- a/examples/deps-walk/main.go
+++ b/examples/deps-walk/main.go
@@ -28,6 +28,7 @@ func main() {
 		short       bool
 		direction   string
 		aggressive  bool
+		test        bool
 	)
 
 	flag.StringVar(&startPkg, "start-pkg", "", "The root package to start the dependency walk from (required)")
@@ -40,22 +41,24 @@ func main() {
 	flag.BoolVar(&short, "short", false, "Omit module prefix from package paths in the output")
 	flag.StringVar(&direction, "direction", "forward", "Direction of dependency walk (forward, reverse, bidi)")
 	flag.BoolVar(&aggressive, "aggressive", false, "Use aggressive git-grep based search for reverse mode")
+	flag.BoolVar(&test, "test", false, "Include test files in the analysis")
 	flag.Parse()
 
 	if startPkg == "" {
 		log.Fatal("-start-pkg is required")
 	}
 
-	if err := run(context.Background(), startPkg, hops, ignore, output, format, granularity, full, short, direction, aggressive); err != nil {
+	if err := run(context.Background(), startPkg, hops, ignore, output, format, granularity, full, short, direction, aggressive, test); err != nil {
 		log.Fatalf("Error: %+v", err)
 	}
 }
 
-func run(ctx context.Context, startPkg string, hops int, ignore string, output string, format string, granularity string, full bool, short bool, direction string, aggressive bool) error {
+func run(ctx context.Context, startPkg string, hops int, ignore string, output string, format string, granularity string, full bool, short bool, direction string, aggressive bool, test bool) error {
 	var scannerOpts []goscan.ScannerOption
 	if full {
 		scannerOpts = append(scannerOpts, goscan.WithGoModuleResolver())
 	}
+	scannerOpts = append(scannerOpts, goscan.WithIncludeTests(test))
 
 	s, err := goscan.New(scannerOpts...)
 	if err != nil {

--- a/examples/deps-walk/main_test.go
+++ b/examples/deps-walk/main_test.go
@@ -252,6 +252,19 @@ func TestRun(t *testing.T) {
 			},
 			goldenFile: "reverse-hops2-aggressive.golden",
 		},
+		{
+			name: "with-test-files",
+			args: map[string]interface{}{
+				"start-pkg": "github.com/podhmo/go-scan/testdata/walk/a",
+				"hops":      1,
+				"format":    "dot",
+				"full":      false,
+				"short":     false,
+				"ignore":    "",
+				"test":      true,
+			},
+			goldenFile: "with-test-files.golden",
+		},
 	}
 
 	for _, tc := range cases {
@@ -304,6 +317,10 @@ func TestRun(t *testing.T) {
 			if !ok {
 				aggressive = false
 			}
+			test, ok := tc.args["test"].(bool)
+			if !ok {
+				test = false
+			}
 
 			err = run(
 				context.Background(),
@@ -317,6 +334,7 @@ func TestRun(t *testing.T) {
 				tc.args["short"].(bool),
 				direction,
 				aggressive,
+				test,
 			)
 			if err != nil {
 				t.Fatalf("run() failed unexpectedly: %+v", err)

--- a/examples/deps-walk/testdata/walk/a/a_test.go
+++ b/examples/deps-walk/testdata/walk/a/a_test.go
@@ -1,0 +1,11 @@
+package a
+
+import (
+	"testing"
+
+	_ "github.com/podhmo/go-scan/testdata/walk/e"
+)
+
+func TestSomething(t *testing.T) {
+	// This test exists to create a test-only dependency on package e.
+}

--- a/examples/deps-walk/testdata/with-test-files.golden
+++ b/examples/deps-walk/testdata/with-test-files.golden
@@ -1,0 +1,10 @@
+digraph dependencies {
+  rankdir="LR";
+  node [shape=box, style="rounded,filled", fillcolor=lightgrey];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
+  "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
+  "github.com/podhmo/go-scan/testdata/walk/e" [label="github.com/podhmo/go-scan/testdata/walk/e"];
+
+  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/b";
+  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/e";
+}


### PR DESCRIPTION
The `examples/deps-walk` tool now defaults to excluding `_test.go` files from its dependency analysis.

A new `-test` boolean flag has been added. When this flag is provided, the tool will include `_test.go` files in its scan, allowing for the visualization of test-only dependencies.

This is implemented by adding a new `WithIncludeTests` option to the `goscan.Scanner`, which controls whether `_test.go` files are listed and parsed.

The documentation and test suite have been updated to reflect this new functionality.