### PR TITLE
feat(deps-walk): apply ignore to short path expressions

### DIFF
--- a/examples/deps-walk/main.go
+++ b/examples/deps-walk/main.go
@@ -255,9 +255,23 @@ func (v *graphVisitor) Visit(pkg *goscan.PackageImports) ([]string, error) {
 		for _, imp := range imps {
 			isIgnored := false
 			for _, pattern := range v.ignorePatterns {
+				// Check against full import path
 				if matched, _ := filepath.Match(pattern, imp); matched {
 					isIgnored = true
 					break
+				}
+
+				// If short is enabled, also check against the short package path
+				if v.short {
+					modulePath := v.s.ModulePath()
+					if modulePath != "" && strings.HasPrefix(imp, modulePath) {
+						shortImp := strings.TrimPrefix(imp, modulePath)
+						shortImp = strings.TrimPrefix(shortImp, "/")
+						if matched, _ := filepath.Match(pattern, shortImp); matched {
+							isIgnored = true
+							break
+						}
+					}
 				}
 			}
 			if isIgnored {

--- a/examples/deps-walk/main_test.go
+++ b/examples/deps-walk/main_test.go
@@ -187,6 +187,18 @@ func TestRun(t *testing.T) {
 			goldenFile: "ignore-c.golden",
 		},
 		{
+			name: "ignore-c-short",
+			args: map[string]interface{}{
+				"start-pkgs": []string{"github.com/podhmo/go-scan/testdata/walk/a"},
+				"hops":       1,
+				"format":     "dot",
+				"full":       false,
+				"short":      true,
+				"ignore":     "testdata/walk/c",
+			},
+			goldenFile: "ignore-c-short.golden",
+		},
+		{
 			name: "full",
 			args: map[string]interface{}{
 				"start-pkgs": []string{"github.com/podhmo/go-scan/testdata/walk/d"}, // d imports an external package
@@ -253,14 +265,14 @@ func TestRun(t *testing.T) {
 		{
 			name: "reverse-hops2-aggressive",
 			args: map[string]interface{}{
-				"start-pkgs":   []string{"github.com/podhmo/go-scan/testdata/walk/c"},
-				"hops":         2,
-				"format":       "dot",
-				"full":         false,
-				"short":        false,
-				"ignore":       "",
-				"direction":    "reverse",
-				"aggressive":   true,
+				"start-pkgs": []string{"github.com/podhmo/go-scan/testdata/walk/c"},
+				"hops":       2,
+				"format":     "dot",
+				"full":       false,
+				"short":      false,
+				"ignore":     "",
+				"direction":  "reverse",
+				"aggressive": true,
 			},
 			goldenFile: "reverse-hops2-aggressive.golden",
 		},

--- a/examples/deps-walk/testdata/ignore-c-short.golden
+++ b/examples/deps-walk/testdata/ignore-c-short.golden
@@ -1,0 +1,8 @@
+digraph dependencies {
+  rankdir="LR";
+  node [shape=box, style="rounded,filled", fillcolor=lightgrey];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="a"];
+  "github.com/podhmo/go-scan/testdata/walk/b" [label="b"];
+
+  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/b";
+}

--- a/examples/deps-walk/testdata/walk/a/a.go
+++ b/examples/deps-walk/testdata/walk/a/a.go
@@ -2,5 +2,6 @@ package a
 
 import (
 	_ "fmt"
+
 	_ "github.com/podhmo/go-scan/testdata/walk/b"
 )


### PR DESCRIPTION
When the -short flag is used, package paths in the output are shortened to be relative to the module root. However, the -ignore flag still only matched against the full, un-shortened package paths.

This change updates the logic so that when -short is active, the -ignore patterns are matched against both the full import path and the shortened version.

A new test case with a corresponding golden file has been added to verify this new behavior.