### PR TITLE
feat(deps-walk): Add -hide option to hide nodes from output

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -118,7 +118,7 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
     -   [x] **Initial Tool Setup**: Created the basic CLI structure for the `deps-walk` tool and implemented the logic to call the `goscan.Scanner.Walk` method.
     -   [x] **Core Visualization Features**: Implemented graph generation in DOT format and added support for the `--hops` flag to limit traversal depth.
     -   [x] **Multiple Output Formats**: Added support for Mermaid as an output format alongside DOT via the `--format` flag.
-    -   [x] **Filtering and Usability**: Added support for the `--ignore` flag for package exclusion and a `--full` flag to include external dependencies (defaulting to in-module only).
+    -   [x] **Filtering and Usability**: Added support for the `--ignore` flag for package exclusion and a `--full` flag to include external dependencies (defaulting to in-module only). Also added a `--hide` flag to hide packages from the output without affecting traversal.
     -   [x] **Integration Tests**: Added integration tests for the `deps-walk` tool using `scantest`.
     -   [x] **Reverse Dependency Search**: Added a `--direction=reverse` option to find and visualize reverse dependencies (importers). This is supported by a new `goscan.FindImporters` method that efficiently scans the module for import statements.
     -   [x] **Bidirectional Dependency Graph**: Added a `--direction=bidi` option to show both forward dependencies (up to `--hops`) and reverse dependencies (importers) in the same graph.

--- a/docs/plan-in-module-deps-walk.md
+++ b/docs/plan-in-module-deps-walk.md
@@ -24,7 +24,11 @@ The user will be able to specify the maximum number of hops (degrees of separati
 
 ### 2.2. Package Exclusion
 
-The user will be able to provide a list of package import patterns to ignore or exclude from the graph. This is useful for hiding ubiquitous dependencies like logging, configuration, or common utility packages to de-clutter the output. The patterns should support glob-style matching for more flexibility.
+The user will be able to provide a list of package import patterns to remove from the graph. This is useful for hiding ubiquitous dependencies like logging, configuration, or common utility packages to de-clutter the output. The patterns should support glob-style matching for more flexibility.
+
+Two flags will be provided for this:
+- **`--ignore`**: Excludes a package and its dependencies from the traversal.
+- **`--hide`**: Excludes a package only from the output graph, but still traverses its dependencies.
 
 -   **Example:** `go-deps-walk --start-pkg=./api --ignore="github.com/my-org/core/*,*.test"`
 

--- a/examples/deps-walk/README.md
+++ b/examples/deps-walk/README.md
@@ -12,7 +12,7 @@ The tool outputs a dependency graph in the DOT language, which can be rendered i
 
 - **Dependency Traversal**: Uses `go-scan`'s efficient "imports-only" scanning mode to walk the dependency tree.
 - **Hop Count Limiting**: Allows you to specify the maximum number of hops (degrees of separation) to explore from the starting package using the `--hops` flag.
-- **Package Filtering**: Supports ignoring specific packages or package patterns (e.g., common utilities, logging) using the `--ignore` flag to declutter the graph.
+- **Package Filtering**: Supports ignoring specific packages or package patterns (e.g., common utilities, logging) using the `--ignore` flag. You can also hide packages from the output without excluding them from the traversal using the `--hide` flag.
 - **Configurable Scope**: By default, it traverses only packages within the current Go module. The `--full` flag can be used to include external dependencies (from the standard library or third-party modules).
 - **DOT Output**: Generates a graph in the DOT format, ready for visualization.
 - **Multiple Output Formats**: Supports graph generation in DOT (default), Mermaid, and JSON formats via the `--format` flag.
@@ -114,6 +114,14 @@ digraph dependencies {
   "github.com/podhmo/go-scan/testdata/walk/b" -> "github.com/podhmo/go-scan/testdata/walk/d";
 }
 ```
+
+### Hiding vs. Ignoring Packages
+
+The tool provides two ways to exclude packages from the graph:
+
+-   `--ignore="<pattern>"`: This completely excludes a package from the analysis. The walker will not traverse through an ignored package, so neither the package itself nor any of its dependencies (that are not reached by other means) will appear in the graph. This is useful for removing large, irrelevant parts of the dependency tree (e.g., a logging framework).
+
+-   `--hide="<pattern>"`: This only hides a package from the final output. The walker *will* traverse through the package to discover its dependencies, but the package itself and any direct edges to or from it will not be rendered. This is useful for removing intermediate "glue" packages while still seeing the relationship between the packages they connect.
 
 ## Reverse Dependencies
 

--- a/examples/deps-walk/main_test.go
+++ b/examples/deps-walk/main_test.go
@@ -199,6 +199,32 @@ func TestRun(t *testing.T) {
 			goldenFile: "ignore-c-short.golden",
 		},
 		{
+			name: "hide-c",
+			args: map[string]interface{}{
+				"start-pkgs": []string{"github.com/podhmo/go-scan/testdata/walk/a"},
+				"hops":       2,
+				"format":     "dot",
+				"full":       false,
+				"short":      false,
+				"ignore":     "",
+				"hide":       "github.com/podhmo/go-scan/testdata/walk/c",
+			},
+			goldenFile: "hide-c.golden",
+		},
+		{
+			name: "hide-c-short",
+			args: map[string]interface{}{
+				"start-pkgs": []string{"github.com/podhmo/go-scan/testdata/walk/a"},
+				"hops":       2,
+				"format":     "dot",
+				"full":       false,
+				"short":      true,
+				"ignore":     "",
+				"hide":       "c",
+			},
+			goldenFile: "hide-c-short.golden",
+		},
+		{
 			name: "full",
 			args: map[string]interface{}{
 				"start-pkgs": []string{"github.com/podhmo/go-scan/testdata/walk/d"}, // d imports an external package
@@ -361,11 +387,17 @@ func TestRun(t *testing.T) {
 				test = false
 			}
 
+			hide, ok := tc.args["hide"].(string)
+			if !ok {
+				hide = ""
+			}
+
 			err = run(
 				context.Background(),
 				startPkgs,
 				tc.args["hops"].(int),
 				tc.args["ignore"].(string),
+				hide,
 				outputFile,
 				format,
 				granularity,

--- a/examples/deps-walk/testdata/hide-c-short.golden
+++ b/examples/deps-walk/testdata/hide-c-short.golden
@@ -1,0 +1,8 @@
+digraph dependencies {
+  rankdir="LR";
+  node [shape=box, style="rounded,filled", fillcolor=lightgrey];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="a"];
+  "github.com/podhmo/go-scan/testdata/walk/b" [label="b"];
+
+  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/b";
+}

--- a/examples/deps-walk/testdata/hide-c.golden
+++ b/examples/deps-walk/testdata/hide-c.golden
@@ -1,0 +1,8 @@
+digraph dependencies {
+  rankdir="LR";
+  node [shape=box, style="rounded,filled", fillcolor=lightgrey];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
+  "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
+
+  "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/b";
+}


### PR DESCRIPTION
I've introduced a new `-hide` command-line option to the `deps-walk` example tool.

The `-hide` flag allows you to specify a comma-separated list of package patterns to hide from the generated dependency graph. Unlike the existing `-ignore` flag, which prevents packages from being traversed at all, `-hide` only affects the final output. The dependency walker will still traverse through hidden nodes to discover their dependencies, but the hidden nodes themselves (and any edges connected to them) will not be rendered in the output graph.

This is useful for decluttering graphs by removing intermediate or "glue" packages while still visualizing the relationships between the packages they connect.

The feature includes:
- A new `-hide` string flag in `main.go`.
- Logic in the output generation methods (`WriteDOT`, `WriteMermaid`, `WriteJSON`) to filter nodes and edges based on the hide patterns.
- Support for matching patterns against both full and short package paths (when `-short` is enabled).
- New integration tests and golden files to verify the functionality.
- Updated `README.md`, `TODO.md`, and planning documents to reflect the new feature.