### PR TITLE
feat(deps-walk): Highlight start_pkg in graph output

### DIFF
--- a/examples/deps-walk/testdata/bidi.golden
+++ b/examples/deps-walk/testdata/bidi.golden
@@ -2,7 +2,7 @@ digraph dependencies {
   rankdir="LR";
   node [shape=box, style="rounded,filled", fillcolor=lightgrey];
   "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
-  "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
+  "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b", shape=box, style="rounded,filled", fillcolor=lightblue];
   "github.com/podhmo/go-scan/testdata/walk/c" [label="github.com/podhmo/go-scan/testdata/walk/c"];
 
   "github.com/podhmo/go-scan/testdata/walk/b" -> "github.com/podhmo/go-scan/testdata/walk/c";

--- a/examples/deps-walk/testdata/default-mermaid-short.golden
+++ b/examples/deps-walk/testdata/default-mermaid-short.golden
@@ -7,3 +7,5 @@ graph LR
 
     id0 --> id1
   end
+
+    style id0 fill:#add8e6,stroke:#333,stroke-width:2px

--- a/examples/deps-walk/testdata/default-mermaid.golden
+++ b/examples/deps-walk/testdata/default-mermaid.golden
@@ -4,3 +4,5 @@ graph LR
   id1["github.com/podhmo/go-scan/testdata/walk/b"]
 
   id0 --> id1
+
+  style id0 fill:#add8e6,stroke:#333,stroke-width:2px

--- a/examples/deps-walk/testdata/default-short.golden
+++ b/examples/deps-walk/testdata/default-short.golden
@@ -1,7 +1,7 @@
 digraph dependencies {
   rankdir="LR";
   node [shape=box, style="rounded,filled", fillcolor=lightgrey];
-  "github.com/podhmo/go-scan/testdata/walk/a" [label="a"];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="a", shape=box, style="rounded,filled", fillcolor=lightblue];
   "github.com/podhmo/go-scan/testdata/walk/b" [label="b"];
 
   "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/b";

--- a/examples/deps-walk/testdata/default.golden
+++ b/examples/deps-walk/testdata/default.golden
@@ -1,7 +1,7 @@
 digraph dependencies {
   rankdir="LR";
   node [shape=box, style="rounded,filled", fillcolor=lightgrey];
-  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a", shape=box, style="rounded,filled", fillcolor=lightblue];
   "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
 
   "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/b";

--- a/examples/deps-walk/testdata/full.golden
+++ b/examples/deps-walk/testdata/full.golden
@@ -2,7 +2,7 @@ digraph dependencies {
   rankdir="LR";
   node [shape=box, style="rounded,filled", fillcolor=lightgrey];
   "github.com/google/go-cmp/cmp" [label="github.com/google/go-cmp/cmp"];
-  "github.com/podhmo/go-scan/testdata/walk/d" [label="github.com/podhmo/go-scan/testdata/walk/d"];
+  "github.com/podhmo/go-scan/testdata/walk/d" [label="github.com/podhmo/go-scan/testdata/walk/d", shape=box, style="rounded,filled", fillcolor=lightblue];
   "github.com/podhmo/go-scan/testdata/walk/e" [label="github.com/podhmo/go-scan/testdata/walk/e"];
 
   "github.com/podhmo/go-scan/testdata/walk/d" -> "github.com/google/go-cmp/cmp";

--- a/examples/deps-walk/testdata/hide-c-short.golden
+++ b/examples/deps-walk/testdata/hide-c-short.golden
@@ -1,7 +1,7 @@
 digraph dependencies {
   rankdir="LR";
   node [shape=box, style="rounded,filled", fillcolor=lightgrey];
-  "github.com/podhmo/go-scan/testdata/walk/a" [label="a"];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="a", shape=box, style="rounded,filled", fillcolor=lightblue];
   "github.com/podhmo/go-scan/testdata/walk/b" [label="b"];
 
   "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/b";

--- a/examples/deps-walk/testdata/hide-c.golden
+++ b/examples/deps-walk/testdata/hide-c.golden
@@ -1,7 +1,7 @@
 digraph dependencies {
   rankdir="LR";
   node [shape=box, style="rounded,filled", fillcolor=lightgrey];
-  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a", shape=box, style="rounded,filled", fillcolor=lightblue];
   "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
 
   "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/b";

--- a/examples/deps-walk/testdata/hops2.golden
+++ b/examples/deps-walk/testdata/hops2.golden
@@ -3,7 +3,7 @@ digraph dependencies {
   node [shape=box, style="rounded,filled", fillcolor=lightgrey];
   "errors" [label="errors"];
   "fmt" [label="fmt"];
-  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a", shape=box, style="rounded,filled", fillcolor=lightblue];
   "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
   "github.com/podhmo/go-scan/testdata/walk/c" [label="github.com/podhmo/go-scan/testdata/walk/c"];
   "internal/fmtsort" [label="internal/fmtsort"];

--- a/examples/deps-walk/testdata/ignore-c-short.golden
+++ b/examples/deps-walk/testdata/ignore-c-short.golden
@@ -1,7 +1,7 @@
 digraph dependencies {
   rankdir="LR";
   node [shape=box, style="rounded,filled", fillcolor=lightgrey];
-  "github.com/podhmo/go-scan/testdata/walk/a" [label="a"];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="a", shape=box, style="rounded,filled", fillcolor=lightblue];
   "github.com/podhmo/go-scan/testdata/walk/b" [label="b"];
 
   "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/b";

--- a/examples/deps-walk/testdata/ignore-c.golden
+++ b/examples/deps-walk/testdata/ignore-c.golden
@@ -1,7 +1,7 @@
 digraph dependencies {
   rankdir="LR";
   node [shape=box, style="rounded,filled", fillcolor=lightgrey];
-  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a", shape=box, style="rounded,filled", fillcolor=lightblue];
   "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
 
   "github.com/podhmo/go-scan/testdata/walk/a" -> "github.com/podhmo/go-scan/testdata/walk/b";

--- a/examples/deps-walk/testdata/multiple.golden
+++ b/examples/deps-walk/testdata/multiple.golden
@@ -2,7 +2,7 @@ digraph dependencies {
   rankdir="LR";
   node [shape=box, style="rounded,filled", fillcolor=lightgrey];
   "fmt" [label="fmt"];
-  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a", shape=box, style="rounded,filled", fillcolor=lightblue];
   "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
 
   "github.com/podhmo/go-scan/testdata/walk/a" -> "fmt";
@@ -14,7 +14,7 @@ digraph dependencies {
   rankdir="LR";
   node [shape=box, style="rounded,filled", fillcolor=lightgrey];
   "github.com/google/go-cmp/cmp" [label="github.com/google/go-cmp/cmp"];
-  "github.com/podhmo/go-scan/testdata/walk/d" [label="github.com/podhmo/go-scan/testdata/walk/d"];
+  "github.com/podhmo/go-scan/testdata/walk/d" [label="github.com/podhmo/go-scan/testdata/walk/d", shape=box, style="rounded,filled", fillcolor=lightblue];
   "github.com/podhmo/go-scan/testdata/walk/e" [label="github.com/podhmo/go-scan/testdata/walk/e"];
 
   "github.com/podhmo/go-scan/testdata/walk/d" -> "github.com/google/go-cmp/cmp";

--- a/examples/deps-walk/testdata/reverse-hops2-aggressive.golden
+++ b/examples/deps-walk/testdata/reverse-hops2-aggressive.golden
@@ -3,7 +3,7 @@ digraph dependencies {
   node [shape=box, style="rounded,filled", fillcolor=lightgrey];
   "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
   "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
-  "github.com/podhmo/go-scan/testdata/walk/c" [label="github.com/podhmo/go-scan/testdata/walk/c"];
+  "github.com/podhmo/go-scan/testdata/walk/c" [label="github.com/podhmo/go-scan/testdata/walk/c", shape=box, style="rounded,filled", fillcolor=lightblue];
 
   "github.com/podhmo/go-scan/testdata/walk/b" -> "github.com/podhmo/go-scan/testdata/walk/a" [dir=back, style=dashed];
   "github.com/podhmo/go-scan/testdata/walk/c" -> "github.com/podhmo/go-scan/testdata/walk/b" [dir=back, style=dashed];

--- a/examples/deps-walk/testdata/reverse-hops2.golden
+++ b/examples/deps-walk/testdata/reverse-hops2.golden
@@ -3,7 +3,7 @@ digraph dependencies {
   node [shape=box, style="rounded,filled", fillcolor=lightgrey];
   "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
   "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
-  "github.com/podhmo/go-scan/testdata/walk/c" [label="github.com/podhmo/go-scan/testdata/walk/c"];
+  "github.com/podhmo/go-scan/testdata/walk/c" [label="github.com/podhmo/go-scan/testdata/walk/c", shape=box, style="rounded,filled", fillcolor=lightblue];
 
   "github.com/podhmo/go-scan/testdata/walk/b" -> "github.com/podhmo/go-scan/testdata/walk/a" [dir=back, style=dashed];
   "github.com/podhmo/go-scan/testdata/walk/c" -> "github.com/podhmo/go-scan/testdata/walk/b" [dir=back, style=dashed];

--- a/examples/deps-walk/testdata/reverse.golden
+++ b/examples/deps-walk/testdata/reverse.golden
@@ -2,7 +2,7 @@ digraph dependencies {
   rankdir="LR";
   node [shape=box, style="rounded,filled", fillcolor=lightgrey];
   "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
-  "github.com/podhmo/go-scan/testdata/walk/c" [label="github.com/podhmo/go-scan/testdata/walk/c"];
+  "github.com/podhmo/go-scan/testdata/walk/c" [label="github.com/podhmo/go-scan/testdata/walk/c", shape=box, style="rounded,filled", fillcolor=lightblue];
 
   "github.com/podhmo/go-scan/testdata/walk/c" -> "github.com/podhmo/go-scan/testdata/walk/b" [dir=back, style=dashed];
 }

--- a/examples/deps-walk/testdata/with-test-files.golden
+++ b/examples/deps-walk/testdata/with-test-files.golden
@@ -1,7 +1,7 @@
 digraph dependencies {
   rankdir="LR";
   node [shape=box, style="rounded,filled", fillcolor=lightgrey];
-  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a"];
+  "github.com/podhmo/go-scan/testdata/walk/a" [label="github.com/podhmo/go-scan/testdata/walk/a", shape=box, style="rounded,filled", fillcolor=lightblue];
   "github.com/podhmo/go-scan/testdata/walk/b" [label="github.com/podhmo/go-scan/testdata/walk/b"];
   "github.com/podhmo/go-scan/testdata/walk/e" [label="github.com/podhmo/go-scan/testdata/walk/e"];
 


### PR DESCRIPTION
This change enhances the `deps-walk` example to highlight the `start_pkg` in both Mermaid and Graphviz outputs. This makes it easier to identify the starting point of the dependency walk, which is especially useful when using the `bidi` (bidirectional) search.

- Add `startPkg` to `graphVisitor`
- Set `fillcolor=lightblue` for the `startPkg` in `WriteDOT`
- Add a style for the `startPkg` in `WriteMermaid`
- Update golden files