### PR TITLE
feat: Add inspect and dry-run modes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -126,16 +126,13 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
 -   **Refactoring**:
     -   [x] **Isolate `examples/deps-walk` Test Data**: Moved the test data for the `deps-walk` example from the root `testdata` directory to its own `examples/deps-walk/testdata` directory, making the example more self-contained.
     -   [x] **Centralize Path Resolution**: Moved the logic for resolving relative file paths to Go package paths from the `deps-walk` example into the core `locator` package (`locator.ResolvePkgPath`). This makes the functionality reusable for other tools.
+-   **Debuggability and Testing**:
+    -   [x] **Inspect Mode**: Implemented an `--inspect` flag and corresponding `WithInspect()` option to provide detailed structured logging (`slog`) of the annotation detection process. This helps in debugging why a type is or isn't being processed.
+    -   [x] **Dry-Run Mode**: Implemented a `--dry-run` flag and `WithDryRun()` option that prevents file generation, allowing users to preview the output without writing to disk.
+    -   [x] **CLI Tool Integration**: Added the `--inspect` and `--dry-run` flags to the following tools:
+        -   [x] `examples/derivingjson`
+        -   [x] `examples/derivingbind`
+        -   [x] `examples/convert`
+    -   [x] **Integration Tests**: Added tests using the `scantest` library to verify the functionality of the new inspect and dry-run modes.
 
 ## To Be Implemented
-
-### Inspect ([docs/plan-inspect.md](./docs/plan-inspect.md))
-- [ ] Goals
-- [ ] Technical Approach
-- [ ] Inspect Mode
-- [ ] Dry-Run Mode
-- [ ] Usage Example
-- [ ] Structured Logging Fields
-- [ ] `DEBUG` Level Log (Annotation Check)
-- [ ] `INFO` Level Log (Annotation Found)
-- [ ] Implementation Note for `resolution_path`

--- a/examples/derivingjson/main.go
+++ b/examples/derivingjson/main.go
@@ -15,14 +15,17 @@ import (
 )
 
 func main() {
-	logLevel := new(slog.LevelVar)
-	logLevel.Set(slog.LevelDebug)
-	opts := slog.HandlerOptions{Level: logLevel}
-	handler := slog.NewTextHandler(os.Stderr, &opts)
-	slog.SetDefault(slog.New(handler))
+	var (
+		cwd      string
+		dryRun   bool
+		inspect  bool
+		logLevel = new(slog.LevelVar)
+	)
 
-	var cwd string
 	flag.StringVar(&cwd, "cwd", ".", "current working directory")
+	flag.BoolVar(&dryRun, "dry-run", false, "don't write files, just print to stdout")
+	flag.BoolVar(&inspect, "inspect", false, "enable inspection logging for annotations")
+	flag.Var(logLevel, "log-level", "set log level (debug, info, warn, error)")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: derivingjson [options] <file_or_dir_path_1> [file_or_dir_path_2 ...]\n")
 		fmt.Fprintf(os.Stderr, "Example (file): derivingjson examples/derivingjson/testdata/simple/models.go\n")
@@ -31,13 +34,23 @@ func main() {
 	}
 	flag.Parse()
 
+	opts := slog.HandlerOptions{Level: logLevel}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &opts))
+	slog.SetDefault(logger)
+
 	ctx := context.Background()
 	if len(flag.Args()) == 0 {
 		flag.Usage()
 		os.Exit(1)
 	}
 
-	gscn, err := goscan.New(goscan.WithWorkDir(cwd))
+	scannerOptions := []goscan.ScannerOption{
+		goscan.WithWorkDir(cwd),
+		goscan.WithDryRun(dryRun),
+		goscan.WithInspect(inspect),
+		goscan.WithLogger(logger),
+	}
+	gscn, err := goscan.New(scannerOptions...)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to create go-scan scanner", slog.Any("error", err))
 		os.Exit(1)
@@ -93,12 +106,23 @@ func main() {
 		}
 
 		outputFilename := fmt.Sprintf("%s_deriving.go", strings.ToLower(pkgInfo.Name))
-		if err := outputDir.SaveGoFile(ctx, goFile, outputFilename); err != nil {
-			slog.ErrorContext(ctx, "Failed to save generated file for package", "path", pkgInfo.Path, slog.Any("error", err))
-			errorCount++
+		if gscn.DryRun {
+			slog.InfoContext(ctx, "Dry run: skipping file write", "path", filepath.Join(outputDir.Path, outputFilename))
+			fmt.Fprintf(os.Stdout, "---\n// file: %s\n---\n", filepath.Join(outputDir.Path, outputFilename))
+			if err := goFile.FormatAndWrite(os.Stdout); err != nil {
+				slog.ErrorContext(ctx, "Failed to format and write to stdout", "path", pkgInfo.Path, slog.Any("error", err))
+				errorCount++
+			} else {
+				successCount++
+			}
 		} else {
-			slog.InfoContext(ctx, "Successfully generated UnmarshalJSON for package", "path", pkgInfo.Path)
-			successCount++
+			if err := outputDir.SaveGoFile(ctx, goFile, outputFilename); err != nil {
+				slog.ErrorContext(ctx, "Failed to save generated file for package", "path", pkgInfo.Path, slog.Any("error", err))
+				errorCount++
+			} else {
+				slog.InfoContext(ctx, "Successfully generated UnmarshalJSON for package", "path", pkgInfo.Path)
+				successCount++
+			}
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,10 @@ require (
 	github.com/google/go-cmp v0.7.0
 	golang.org/x/mod v0.26.0
 )
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,13 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/mod v0.26.0 h1:EGMPT//Ezu+ylkCijjPc+f4Aih7sZvaAr+O3EHBxvZg=
 golang.org/x/mod v0.26.0/go.mod h1:/j6NAhSk8iQ723BGAUyoAcn7SlD7s15Dp9Nd/SfeaFQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/goscan_inspect_test.go
+++ b/goscan_inspect_test.go
@@ -1,0 +1,97 @@
+package goscan_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	goscan "github.com/podhmo/go-scan"
+	"github.com/podhmo/go-scan/scanner"
+	"github.com/podhmo/go-scan/scantest"
+)
+
+func TestInspectAndDryRun(t *testing.T) {
+	// 1. Setup: Create a temporary directory with a sample Go file.
+	files := map[string]string{
+		"go.mod": "module a.b/c",
+		"models/user.go": `
+package models
+
+// @deriving:json
+type User struct {
+	ID   int
+	Name string
+}
+
+type Group struct { // No annotation
+	ID int
+}
+`,
+	}
+	dir, cleanup := scantest.WriteFiles(t, files)
+	defer cleanup()
+
+	// 2. Capture logs
+	var logBuf bytes.Buffer
+	logLevel := new(slog.LevelVar)
+	logLevel.Set(slog.LevelDebug) // Ensure DEBUG logs are captured
+	handler := slog.NewTextHandler(&logBuf, &slog.HandlerOptions{
+		Level:       logLevel,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	})
+	logger := slog.New(handler)
+
+	// 3. Configure the scanner with inspect and dry-run options
+	scannerOptions := []goscan.ScannerOption{
+		goscan.WithInspect(true),
+		goscan.WithLogger(logger),
+		goscan.WithDryRun(true),
+		goscan.WithWorkDir(dir), // Set workdir to the temp dir
+	}
+	s, err := goscan.New(scannerOptions...)
+	require.NoError(t, err)
+
+	// 4. Define the test action
+	action := func(ctx context.Context, s *goscan.Scanner, pkgs []*scanner.PackageInfo) error {
+		for _, pkg := range pkgs {
+			for _, ti := range pkg.Types {
+				_, _ = ti.Annotation("deriving:json")
+			}
+		}
+		assert.True(t, s.DryRun, "DryRun flag should be true on the scanner instance")
+		return nil
+	}
+
+	// The patterns to scan, relative to the temp dir.
+	patterns := []string{"models"}
+
+	// 5. Run the test using the pre-configured scanner
+	result, err := scantest.Run(t, dir, patterns, action, scantest.WithScanner(s))
+	require.NoError(t, err)
+
+	// 6. Assertions
+	assert.Nil(t, result, "Expected no output files in dry-run mode")
+
+	logOutput := logBuf.String()
+	t.Logf("Captured logs:\n%s", logOutput)
+
+	// Check for the successful "hit" on User type
+	assert.Contains(t, logOutput, `level=INFO msg="found annotation"`)
+	assert.Contains(t, logOutput, `type_name=User`)
+	assert.Contains(t, logOutput, `annotation_name=@deriving:json`)
+	assert.Contains(t, logOutput, `annotation_value=""`)
+
+	// Check for the "miss" on Group type
+	assert.Contains(t, logOutput, `level=DEBUG msg="checking for annotation"`)
+	assert.Contains(t, logOutput, `type_name=Group`)
+	assert.Contains(t, logOutput, `result=miss`)
+}

--- a/scanner/enum_test.go
+++ b/scanner/enum_test.go
@@ -74,7 +74,7 @@ func TestEnumScanning_LazyLoaded(t *testing.T) {
 	}
 
 	// This scanner will be used by the MockResolver to perform the actual scanning.
-	s, err := New(token.NewFileSet(), nil, nil, "example.com/enums", absRootDir, &MockResolver{})
+	s, err := New(token.NewFileSet(), nil, nil, "example.com/enums", absRootDir, &MockResolver{}, false, nil)
 	if err != nil {
 		t.Fatalf("scanner.New failed: %v", err)
 	}

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -19,10 +19,12 @@ type Scanner struct {
 	Overlay               Overlay
 	modulePath            string
 	moduleRootDir         string
+	inspect               bool
+	logger                *slog.Logger
 }
 
 // New creates a new Scanner.
-func New(fset *token.FileSet, overrides ExternalTypeOverride, overlay Overlay, modulePath string, moduleRootDir string, resolver PackageResolver) (*Scanner, error) {
+func New(fset *token.FileSet, overrides ExternalTypeOverride, overlay Overlay, modulePath string, moduleRootDir string, resolver PackageResolver, inspect bool, logger *slog.Logger) (*Scanner, error) {
 	if fset == nil {
 		return nil, fmt.Errorf("fset cannot be nil")
 	}
@@ -46,6 +48,8 @@ func New(fset *token.FileSet, overrides ExternalTypeOverride, overlay Overlay, m
 		modulePath:            modulePath,
 		moduleRootDir:         moduleRootDir,
 		resolver:              resolver,
+		inspect:               inspect,
+		logger:                logger,
 	}, nil
 }
 
@@ -358,6 +362,9 @@ func (s *Scanner) parseTypeSpec(ctx context.Context, sp *ast.TypeSpec, info *Pac
 		FilePath: absFilePath,
 		Doc:      commentText(sp.Doc),
 		Node:     sp,
+		Inspect:  s.inspect,
+		Logger:   s.logger,
+		Fset:     info.Fset,
 	}
 
 	if sp.TypeParams != nil {

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -23,7 +23,7 @@ func (m *MockResolver) ScanPackageByImport(ctx context.Context, importPath strin
 func newTestScanner(t *testing.T, modulePath, rootDir string) *Scanner {
 	t.Helper()
 	fset := token.NewFileSet()
-	s, err := New(fset, nil, nil, modulePath, rootDir, &MockResolver{})
+	s, err := New(fset, nil, nil, modulePath, rootDir, &MockResolver{}, false, nil)
 	if err != nil {
 		t.Fatalf("scanner.New failed: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestNewScanner(t *testing.T) {
 	resolver := &MockResolver{}
 
 	t.Run("nil_fset", func(t *testing.T) {
-		_, err := New(nil, nil, nil, modulePath, rootDir, resolver)
+		_, err := New(nil, nil, nil, modulePath, rootDir, resolver, false, nil)
 		if err == nil {
 			t.Error("Expected error when creating scanner with nil fset, got nil")
 		}
@@ -44,7 +44,7 @@ func TestNewScanner(t *testing.T) {
 
 	t.Run("valid_fset", func(t *testing.T) {
 		fset := token.NewFileSet()
-		s, err := New(fset, nil, nil, modulePath, rootDir, resolver)
+		s, err := New(fset, nil, nil, modulePath, rootDir, resolver, false, nil)
 		if err != nil {
 			t.Errorf("Expected no error when creating scanner with valid fset, got %v", err)
 		}
@@ -57,7 +57,7 @@ func TestNewScanner(t *testing.T) {
 
 	t.Run("nil_resolver", func(t *testing.T) {
 		fset := token.NewFileSet()
-		_, err := New(fset, nil, nil, modulePath, rootDir, nil)
+		_, err := New(fset, nil, nil, modulePath, rootDir, nil, false, nil)
 		if err == nil {
 			t.Error("Expected error when creating scanner with nil resolver, got nil")
 		}
@@ -297,7 +297,7 @@ func TestResolve_DirectRecursion(t *testing.T) {
 	absTestDir, _ := filepath.Abs(testDir)
 
 	// Create scanner with a mock resolver that can return the package being scanned.
-	s, err := New(fset, nil, nil, "example.com/test/recursion/direct", absTestDir, &MockResolver{})
+	s, err := New(fset, nil, nil, "example.com/test/recursion/direct", absTestDir, &MockResolver{}, false, nil)
 	if err != nil {
 		t.Fatalf("scanner.New failed: %v", err)
 	}
@@ -359,7 +359,7 @@ func TestResolve_MutualRecursion(t *testing.T) {
 	absRootDir, _ := filepath.Abs(rootDir)
 
 	// This scanner will be used by the MockResolver to perform actual scanning.
-	s, err := New(fset, nil, nil, "example.com/recursion/mutual", absRootDir, &MockResolver{})
+	s, err := New(fset, nil, nil, "example.com/recursion/mutual", absRootDir, &MockResolver{}, false, nil)
 	if err != nil {
 		t.Fatalf("scanner.New failed: %v", err)
 	}
@@ -466,7 +466,7 @@ func TestScanWithOverlay(t *testing.T) {
 	}
 
 	// Here, we provide an absolute path for moduleRootDir
-	s, err := New(fset, nil, overlay, modulePath, absTestDir, &MockResolver{})
+	s, err := New(fset, nil, overlay, modulePath, absTestDir, &MockResolver{}, false, nil)
 	if err != nil {
 		t.Fatalf("scanner.New with overlay failed: %v", err)
 	}


### PR DESCRIPTION
This commit introduces two new features to improve the debuggability and testability of the go-scan library and its associated tools.

**Inspect Mode:**
- A new `--inspect` flag has been added to the `derivingjson`, `derivingbind`, and `convert` example CLIs.
- When enabled, the scanner will produce detailed structured logs about the annotation detection process.
- It logs at the `DEBUG` level for every annotation check (hit or miss) and at the `INFO` level for successful hits.
- This allows you to easily see why a specific type is or is not being processed by a generator.

**Dry-Run Mode:**
- A new `--dry-run` flag has been added to the example CLIs.
- When enabled, the tools will perform the full scanning and generation pipeline but will not write any files to disk. Instead, the generated code is printed to standard output.
- This is useful for previewing changes or for use in testing environments.

**Implementation Details:**
- Added `WithInspect()`, `WithLogger()`, and `WithDryRun()` options to the `goscan.Scanner`.
- The `inspect` flag and `logger` instance are propagated down to the `scanner.TypeInfo` to be used during annotation parsing.
- Added a new integration test using the `scantest` library to verify the functionality of both modes.
- Updated existing tests to accommodate the new scanner configuration.