### PR TITLE
feat(scanner): Add resolution_path to inspect logs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -137,6 +137,6 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
             -   [x] `examples/deriving-all`
             -   [x] `examples/deps-walk`
         -   [x] **Integration Tests**: Added tests using the `scantest` library to verify the functionality of the new inspect and dry-run modes.
-        -   [ ] **`resolution_path` Logging**: Implement the `resolution_path` field in structured logs to trace how a type was resolved.
+        -   [x] **`resolution_path` Logging**: Implement the `resolution_path` field in structured logs to trace how a type was resolved.
 
 ## To Be Implemented

--- a/goscan.go
+++ b/goscan.go
@@ -287,14 +287,21 @@ func (s *Scanner) SetExternalTypeOverrides(ctx context.Context, overrides scanne
 }
 
 // ResolveType starts the type resolution process for a given field type.
-// It's the public entry point for resolving types, handling circular dependencies
-// by creating a new resolution tracker for each call.
+// It's the public entry point for resolving types. It prepares the context
+// with necessary loggers and flags for the entire resolution chain.
 func (s *Scanner) ResolveType(ctx context.Context, fieldType *scanner.FieldType) (*scanner.TypeInfo, error) {
 	if s.scanner == nil {
 		return nil, fmt.Errorf("internal scanner is not initialized")
 	}
-	// This delegates to the internal scanner's ResolveType, which in turn
-	// calls the recursive FieldType.Resolve with an initial empty map.
+
+	// Prepare the context for the entire resolution chain starting from this call.
+	if s.Logger != nil {
+		ctx = context.WithValue(ctx, scanner.LoggerKey, s.Logger)
+	}
+	ctx = context.WithValue(ctx, scanner.InspectKey, s.Inspect)
+
+	// This delegates to the internal scanner's ResolveType, which now handles
+	// the creation of the initial resolution path.
 	return s.scanner.ResolveType(ctx, fieldType)
 }
 

--- a/goscan_crosspkg_test.go
+++ b/goscan_crosspkg_test.go
@@ -54,9 +54,9 @@ type Handler struct {
 
 		// --- Act ---
 		// Resolve the type of the 'User' field.
-		resolvedType, err := userField.Type.Resolve(ctx, make(map[string]struct{}))
+		resolvedType, err := s.ResolveType(ctx, userField.Type)
 		if err != nil {
-			return fmt.Errorf("Resolve() failed: %w", err)
+			return fmt.Errorf("ResolveType() failed: %w", err)
 		}
 
 		// --- Assert ---
@@ -72,9 +72,9 @@ type Handler struct {
 		}
 
 		// Test for idempotency: resolve again.
-		resolvedType2, err := userField.Type.Resolve(ctx, make(map[string]struct{}))
+		resolvedType2, err := s.ResolveType(ctx, userField.Type)
 		if err != nil {
-			return fmt.Errorf("second Resolve() failed: %w", err)
+			return fmt.Errorf("second ResolveType() failed: %w", err)
 		}
 		if resolvedType2 == nil {
 			return fmt.Errorf("second Resolve() returned nil")
@@ -168,7 +168,7 @@ type User struct {
 
 		// --- Act & Assert ---
 		// 1. Resolve the source profile type
-		srcProfileResolved, err := srcProfileField.Type.Resolve(ctx, make(map[string]struct{}))
+		srcProfileResolved, err := s.ResolveType(ctx, srcProfileField.Type)
 		if err != nil {
 			return fmt.Errorf("resolving source Profile failed: %w", err)
 		}
@@ -183,7 +183,7 @@ type User struct {
 		}
 
 		// 2. Resolve the destination profile type
-		dstProfileResolved, err := dstProfileField.Type.Resolve(ctx, make(map[string]struct{}))
+		dstProfileResolved, err := s.ResolveType(ctx, dstProfileField.Type)
 		if err != nil {
 			return fmt.Errorf("resolving destination Profile failed: %w", err)
 		}

--- a/goscan_test.go
+++ b/goscan_test.go
@@ -88,7 +88,7 @@ func TestLazyResolution_Integration(t *testing.T) {
 	}
 
 	// Trigger lazy resolution
-	userDef, err := userField.Type.Resolve(context.Background(), make(map[string]struct{}))
+	userDef, err := s.ResolveType(context.Background(), userField.Type)
 	if err != nil {
 		t.Fatalf("Failed to resolve User field type: %v", err)
 	}
@@ -405,12 +405,12 @@ func TestScannerWithExternalTypeOverrides(t *testing.T) {
 					if !field.Type.IsResolvedByConfig {
 						t.Errorf("Expected field ID of ObjectWithUUID to have IsResolvedByConfig=true")
 					}
-					resolvedType, errResolve := field.Type.Resolve(context.Background(), make(map[string]struct{}))
+					resolvedType, errResolve := s.ResolveType(context.Background(), field.Type)
 					if errResolve != nil {
-						t.Errorf("field.Type.Resolve() for overridden type should not error, got %v", errResolve)
+						t.Errorf("s.ResolveType() for overridden type should not error, got %v", errResolve)
 					}
 					if resolvedType == nil {
-						t.Errorf("field.Type.Resolve() for overridden type should return the synthetic TypeInfo, got nil")
+						t.Errorf("s.ResolveType() for overridden type should return the synthetic TypeInfo, got nil")
 					} else if resolvedType.Name != "UUID" {
 						t.Errorf("Resolved type has wrong name: got %s, want UUID", resolvedType.Name)
 					}

--- a/scanner/enum_test.go
+++ b/scanner/enum_test.go
@@ -127,9 +127,9 @@ func TestEnumScanning_LazyLoaded(t *testing.T) {
 	}
 
 	// 3. Resolve the field's type. This should trigger the lazy-loading of the 'models' package.
-	resolvedType, err := statusField.Type.Resolve(ctx, make(map[string]struct{}))
+	resolvedType, err := s.ResolveType(ctx, statusField.Type)
 	if err != nil {
-		t.Fatalf("Resolve() for models.Status failed: %v", err)
+		t.Fatalf("ResolveType() for models.Status failed: %v", err)
 	}
 
 	// 4. Assert that the resolved type has the correct enum information.


### PR DESCRIPTION
This commit completes the work on the 'Inspect and Dry-Run Modes' feature. It introduces logging for the type resolution path when inspect mode is enabled.

Key changes:
- Modified `FieldType.Resolve` to be context-aware for tracking the resolution path and accessing the logger.
- The resolution path is now passed via `context.Context`, allowing for accurate tracking of how a type dependency was discovered.
- Cycle detection is now based on this context-managed path.
- Added a `ResolutionContext` to `TypeInfo` to allow consumers to correctly continue a resolution chain for nested types.
- Updated all internal call sites of `Resolve` to use the new context-based approach.
- Added a new test case `TestInspectResolutionPath` to `goscan_inspect_test.go` to verify that the `resolution_path` is correctly logged.
- Updated `TODO.md` to mark the feature as complete.