### PR TITLE
feat(minigo2): Implement core eval loop and literal evaluation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -144,8 +144,8 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
 ### [-] minigo2 Implementation ([docs/plan-minigo2.md](./docs/plan-minigo2.md))
 - [x] Set up the project structure (`minigo2/`, `minigo2/object/`, `minigo2/evaluator/`, etc.).
 - [x] Define the `object.Object` interface and basic types: `Integer`, `String`, `Boolean`, `Null`.
-- [ ] Implement the core `eval` loop for expression evaluation.
-- [ ] Support basic literals (`123`, `"hello"`).
+- [x] Implement the core `eval` loop for expression evaluation.
+- [x] Support basic literals (`123`, `"hello"`).
 - [ ] Support binary expressions (`+`, `-`, `*`, `/`, `==`, `!=`, `<`, `>`).
 - [ ] Support unary expressions (`-`, `!`).
 - [ ] Write unit tests for all expression evaluations.

--- a/minigo2/evaluator/evaluator.go
+++ b/minigo2/evaluator/evaluator.go
@@ -1,1 +1,42 @@
 package evaluator
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+
+	"github.com/podhmo/go-scan/minigo2/object"
+)
+
+// Eval is the central function of the evaluator. It traverses the AST
+// and returns the result of the evaluation as an object.Object.
+func Eval(node ast.Node) object.Object {
+	switch n := node.(type) {
+	// Statements
+	case *ast.ExprStmt:
+		// For an expression statement, we evaluate the underlying expression.
+		return Eval(n.X)
+
+	// Literals
+	case *ast.BasicLit:
+		switch n.Kind {
+		case token.INT:
+			i, err := strconv.ParseInt(n.Value, 0, 64)
+			if err != nil {
+				// In a real interpreter, we'd return an error object.
+				// For now, we return nil.
+				return nil
+			}
+			return &object.Integer{Value: i}
+		case token.STRING:
+			s, err := strconv.Unquote(n.Value)
+			if err != nil {
+				// Return nil on error for now.
+				return nil
+			}
+			return &object.String{Value: s}
+		}
+	}
+
+	return nil
+}

--- a/minigo2/evaluator/evaluator_test.go
+++ b/minigo2/evaluator/evaluator_test.go
@@ -1,0 +1,90 @@
+package evaluator_test
+
+import (
+	"go/parser"
+	"testing"
+
+	"github.com/podhmo/go-scan/minigo2/evaluator"
+	"github.com/podhmo/go-scan/minigo2/object"
+)
+
+// testEval is a helper that parses the input string as a Go expression
+// and runs the evaluator on the resulting AST node.
+func testEval(input string) object.Object {
+	expr, err := parser.ParseExpr(input)
+	if err != nil {
+		// This simplifies testing; we assume valid input for successful eval tests.
+		// A test that expects a parse error would be structured differently.
+		return nil
+	}
+	return evaluator.Eval(expr)
+}
+
+// testIntegerObject is a helper to check if an object is an Integer
+// with the expected value.
+func testIntegerObject(t *testing.T, obj object.Object, expected int64) bool {
+	t.Helper()
+	result, ok := obj.(*object.Integer)
+	if !ok {
+		t.Errorf("object is not Integer. got=%T (%+v)", obj, obj)
+		return false
+	}
+	if result.Value != expected {
+		t.Errorf("object has wrong value. got=%d, want=%d", result.Value, expected)
+		return false
+	}
+	return true
+}
+
+// testStringObject is a helper to check if an object is a String
+// with the expected value.
+func testStringObject(t *testing.T, obj object.Object, expected string) bool {
+	t.Helper()
+	result, ok := obj.(*object.String)
+	if !ok {
+		t.Errorf("object is not String. got=%T (%+v)", obj, obj)
+		return false
+	}
+	if result.Value != expected {
+		t.Errorf("object has wrong value. got=%q, want=%q", result.Value, expected)
+		return false
+	}
+	return true
+}
+
+func TestEvalIntegerExpression(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int64
+	}{
+		{"5", 5},
+		{"10", 10},
+		{"0", 0},
+		{"999", 999},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			evaluated := testEval(tt.input)
+			testIntegerObject(t, evaluated, tt.expected)
+		})
+	}
+}
+
+func TestEvalStringExpression(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`"hello"`, "hello"},
+		{`"minigo"`, "minigo"},
+		{`"hello world!"`, "hello world!"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			evaluated := testEval(tt.input)
+			testStringObject(t, evaluated, tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
This commit introduces the initial implementation of the `minigo2` evaluator.

Key changes:
- Created the core `Eval` function in `minigo2/evaluator`.
- Implemented evaluation for integer and string literals (`*ast.BasicLit`).
- Added a new test suite (`minigo2/evaluator_test.go`) with tests for the literal evaluation.
- Fixed Go module import paths to use the full module path.
- Updated `TODO.md` to reflect the progress made on the `minigo2` implementation.

The evaluator can now correctly process simple literal expressions, and the groundwork is laid for supporting more complex expressions and statements.