### PR TITLE
feat(minigo2): implement const declarations

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -152,7 +152,7 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
 - [x] Implement the `object.Environment` for managing lexical scopes.
 - [x] Add support for `var` declarations (e.g., `var x = 10`) and assignments (`x = 20`).
 - [x] Add support for short variable declarations (`x := 10`).
-- [ ] **Implement `const` declarations**, including typed (`const C int = 1`), untyped (`const C = 1`), and `iota`.
+- [x] **Implement `const` declarations**, including typed (`const C int = 1`), untyped (`const C = 1`), and `iota`.
 - [ ] Implement `if/else` statements.
 - [ ] Implement standard `for` loops (`for i := 0; i < 10; i++`).
 - [ ] Implement `break` and `continue` statements.


### PR DESCRIPTION
Implements `const` declarations in the minigo2 interpreter.

- Adds support for `iota`, including value carry-over in `const` blocks as per the Go specification.
- Extends the `object.Environment` to distinguish between mutable (`var`) and immutable (`const`) bindings, preventing reassignment of constants.
- Adds bitwise operators (`<<`, `>>`, `&`, `|`, `^`) to the integer expression evaluator to support common `const` patterns.
- Includes comprehensive tests for `const` declarations, reassignment prevention, and `iota` behavior.