### PR TITLE
feat(minigo2): implement switch statements

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -156,11 +156,11 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
 - [x] Implement `if/else` statements.
 - [x] Implement standard `for` loops (`for i := 0; i < 10; i++`).
 - [x] Implement `break` and `continue` statements.
-- [ ] **Implement `switch` statements**:
-- [ ] Support `switch` with an expression (`switch x { ... }`).
-- [ ] Support expressionless `switch` (`switch { ... }`).
-- [ ] Support `case` clauses with single or multiple expressions.
-- [ ] Support the `default` clause.
+- [x] **Implement `switch` statements**:
+- [x] Support `switch` with an expression (`switch x { ... }`).
+- [x] Support expressionless `switch` (`switch { ... }`).
+- [x] Support `case` clauses with single or multiple expressions.
+- [x] Support the `default` clause.
 - [ ] Implement user-defined functions (`func` declarations).
 - [ ] Implement the call stack mechanism for tracking function calls.
 - [ ] Implement `return` statements (including returning `nil`).

--- a/minigo2/evaluator/evaluator_test.go
+++ b/minigo2/evaluator/evaluator_test.go
@@ -135,6 +135,50 @@ func TestConstDeclarations(t *testing.T) {
 	}
 }
 
+func TestSwitchStatements(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected any // int64 or "nil"
+	}{
+		// Basic switch with tag
+		{"x := 2; switch x { case 1: 10; case 2: 20; case 3: 30; };", int64(20)},
+		// Tag evaluation
+		{"switch 1 + 1 { case 1: 10; case 2: 20; };", int64(20)},
+		// Default case
+		{"x := 4; switch x { case 1: 10; case 2: 20; default: 99; };", int64(99)},
+		// No matching case, no default
+		{"x := 4; switch x { case 1: 10; case 2: 20; };", "nil"},
+		// Expressionless switch (switch true)
+		{"x := 10; switch { case x > 5: 100; case x < 5: 200; };", int64(100)},
+		{"x := 1; switch { case x > 5: 100; case x < 5: 200; };", int64(200)},
+		// Case with multiple expressions
+		{"x := 3; switch x { case 1, 2, 3: 30; default: 99; };", int64(30)},
+		{"x := 4; switch x { case 1, 2, 3: 30; default: 99; };", int64(99)},
+		// Switch with init statement
+		{"switch x := 2; x { case 2: 20; };", int64(20)},
+		// Init statement shadowing
+		{"x := 10; switch x := 2; x { case 2: 20; }; x", int64(10)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			evaluated := testEval(t, tt.input)
+			switch expected := tt.expected.(type) {
+			case int64:
+				testIntegerObject(t, evaluated, expected)
+			case string:
+				if expected == "nil" {
+					testNullObject(t, evaluated)
+				} else {
+					t.Fatalf("unsupported expected type for test: %T", expected)
+				}
+			default:
+				t.Fatalf("unsupported expected type for test: %T", expected)
+			}
+		})
+	}
+}
+
 func TestForStatements(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
This commit implements support for `switch` statements in the minigo2 interpreter.

The implementation includes:
- Support for `switch` with a tag expression (e.g., `switch x { ... }`).
- Support for expressionless `switch` (e.g., `switch { ... }`), which behaves like `switch true`.
- Support for `case` clauses with single or multiple expressions.
- Support for the `default` clause.
- Support for `init` statements within the `switch`.

The implementation follows the existing structure for control flow statements like `if` and `for`. Added comprehensive tests to cover the new functionality.