### PR TITLE
feat(minigo2): Implement array, slice, and map literals

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -168,8 +168,8 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
 - [x] Add support for `type ... struct` declarations.
 - [x] Support struct literal instantiation (e.g., `MyStruct{...}`), including both keyed and unkeyed fields.
 - [x] Support field access (`myStruct.Field`) and assignment (`myStruct.Field = ...`).
-- [ ] Support slice and array literals (`[]int{1, 2}`, `[2]int{1, 2}`).
-- [ ] Support map literals (`map[string]int{"a": 1}`).
+- [x] Support slice and array literals (`[]int{1, 2}`, `[2]int{1, 2}`).
+- [x] Support map literals (`map[string]int{"a": 1}`).
 - [ ] Support indexing for slices, arrays, and maps (`arr[0]`, `m["key"]`).
 - [ ] **Implement `for...range` loops** for iterating over slices, arrays, and maps.
 - [ ] **Implement pointer support**:

--- a/minigo2/evaluator/evaluator_test.go
+++ b/minigo2/evaluator/evaluator_test.go
@@ -190,6 +190,59 @@ func TestFunctionApplication(t *testing.T) {
 	}
 }
 
+func TestArrayLiterals(t *testing.T) {
+	input := "[]int{1, 2 * 2, 3 + 3}"
+
+	evaluated := testEval(t, input)
+	result, ok := evaluated.(*object.Array)
+	if !ok {
+		t.Fatalf("object is not Array. got=%T (%+v)", evaluated, evaluated)
+	}
+
+	if len(result.Elements) != 3 {
+		t.Fatalf("array has wrong num of elements. got=%d", len(result.Elements))
+	}
+
+	testIntegerObject(t, result.Elements[0], 1)
+	testIntegerObject(t, result.Elements[1], 4)
+	testIntegerObject(t, result.Elements[2], 6)
+}
+
+func TestMapLiterals(t *testing.T) {
+	input := `
+		map[string]int{
+			"one": 10 - 9,
+			"two": 2,
+			"three": 6 / 2,
+		}
+	`
+	evaluated := testEval(t, input)
+	result, ok := evaluated.(*object.Map)
+	if !ok {
+		t.Fatalf("object is not Map. got=%T (%+v)", evaluated, evaluated)
+	}
+
+	expected := map[object.HashKey]int64{
+		(&object.String{Value: "one"}).HashKey():   1,
+		(&object.String{Value: "two"}).HashKey():   2,
+		(&object.String{Value: "three"}).HashKey(): 3,
+	}
+
+	if len(result.Pairs) != len(expected) {
+		t.Fatalf("map has wrong num of pairs. got=%d", len(result.Pairs))
+	}
+
+	for expectedKey, expectedValue := range expected {
+		pair, ok := result.Pairs[expectedKey]
+		if !ok {
+			t.Errorf("no pair for given key in Pairs")
+			continue
+		}
+
+		testIntegerObject(t, pair.Value, expectedValue)
+	}
+}
+
 func TestErrorHandling(t *testing.T) {
 	tests := []struct {
 		input           string


### PR DESCRIPTION
This commit introduces support for array, slice, and map literals in the minigo2 interpreter, fulfilling the next items on the TODO list.

Key changes:
- Added `Array` and `Map` object types to `minigo2/object/object.go`, along with a `Hashable` interface for map keys.
- Extended the evaluator in `minigo2/evaluator/evaluator.go` to parse and evaluate `ast.CompositeLit` nodes for arrays, slices, and maps.
- Added comprehensive unit tests in `minigo2/evaluator/evaluator_test.go` to verify the correct behavior of the new literal types.
- Updated `TODO.md` to reflect the completion of these features.