### PR TITLE
feat(minigo2): Implement support for multiple return values

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -180,7 +180,7 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
 - [x] Support `new()` built-in function.
 - [x] **Support for variadic arguments** in function definitions and calls.
 - [x] **Support for struct embedding**.
-- [ ] **Support for multiple return values** from functions.
+- [x] **Support for multiple return values** from functions.
 - [ ] Create the main `Interpreter` struct that holds a `goscan.Scanner`.
 - [ ] Implement the logic to handle `import` statements and load symbols from external Go packages.
 - [ ] Implement the `object.GoValue` to wrap `reflect.Value`, allowing Go values to be injected into the script.

--- a/minigo2/object/object.go
+++ b/minigo2/object/object.go
@@ -30,6 +30,7 @@ const (
 	POINTER_OBJ           ObjectType = "POINTER"
 	ARRAY_OBJ             ObjectType = "ARRAY"
 	MAP_OBJ               ObjectType = "MAP"
+	TUPLE_OBJ             ObjectType = "TUPLE"
 	ERROR_OBJ             ObjectType = "ERROR"
 )
 
@@ -366,6 +367,32 @@ func (m *Map) Inspect() string {
 	out.WriteString("{")
 	out.WriteString(strings.Join(pairs, ", "))
 	out.WriteString("}")
+
+	return out.String()
+}
+
+// --- Tuple Object ---
+
+// Tuple represents a tuple of objects, used for multiple return values.
+type Tuple struct {
+	Elements []Object
+}
+
+// Type returns the type of the Tuple object.
+func (t *Tuple) Type() ObjectType { return TUPLE_OBJ }
+
+// Inspect returns a string representation of the Tuple's elements.
+func (t *Tuple) Inspect() string {
+	var out bytes.Buffer
+
+	elements := []string{}
+	for _, e := range t.Elements {
+		elements = append(elements, e.Inspect())
+	}
+
+	out.WriteString("(")
+	out.WriteString(strings.Join(elements, ", "))
+	out.WriteString(")")
 
 	return out.String()
 }


### PR DESCRIPTION
This commit introduces support for functions returning multiple values and corresponding multi-value assignments (`a, b := f()`) in the minigo2 interpreter.

Key changes:
- **object**: Added a new `Tuple` object to represent multiple return values.
- **evaluator**:
  - Updated `return` statement evaluation to create `Tuple` objects for multi-value returns.
  - Reworked `evalAssignStmt` to handle multi-value assignments for both `:=` and `=` operations. It now correctly unpacks `Tuple` objects into variables.
  - Added error handling for assignment count mismatches and for calling multi-return functions in a single-value context.
  - Fixed a bug in `evalGenDecl` where `var` declarations without initial values caused an error. They now correctly initialize to `NULL`.
- **test**: Added a comprehensive test suite for the new multi-return functionality, covering success and error cases.