### PR TITLE
I've implemented Go value injection via Globals.

### DIFF
--- a/minigo2/evaluator/evaluator.go
+++ b/minigo2/evaluator/evaluator.go
@@ -819,6 +819,7 @@ func (e *Evaluator) Eval(node ast.Node, env *object.Environment) object.Object {
 }
 
 func (e *Evaluator) evalGenDecl(n *ast.GenDecl, env *object.Environment) object.Object {
+	var lastVal object.Object
 	switch n.Tok {
 	case token.IMPORT:
 		for _, spec := range n.Specs {
@@ -891,9 +892,10 @@ func (e *Evaluator) evalGenDecl(n *ast.GenDecl, env *object.Environment) object.
 					}
 					env.Set(name.Name, val)
 				}
+				lastVal = val
 			}
 		}
-		return nil
+		return lastVal
 
 	case token.TYPE:
 		for _, spec := range n.Specs {

--- a/minigo2/minigo2_interop_test.go
+++ b/minigo2/minigo2_interop_test.go
@@ -1,0 +1,80 @@
+package minigo2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/podhmo/go-scan/minigo2/object"
+)
+
+func TestGoInterop_InjectGlobals(t *testing.T) {
+	tests := []struct {
+		name         string
+		script       string
+		globals      map[string]any
+		expectedType object.ObjectType
+		expectedVal  any
+	}{
+		{
+			name:         "inject integer",
+			script:       "package main\n\nvar result = myVar",
+			globals:      map[string]any{"myVar": 42},
+			expectedType: object.GO_VALUE_OBJ,
+			expectedVal:  42,
+		},
+		{
+			name:         "inject string",
+			script:       "package main\n\nvar result = myStr",
+			globals:      map[string]any{"myStr": "hello world"},
+			expectedType: object.GO_VALUE_OBJ,
+			expectedVal:  "hello world",
+		},
+		{
+			name: "inject struct",
+			script: `package main
+var result = myStruct
+`,
+			globals: map[string]any{
+				"myStruct": struct{ Name string }{Name: "test"},
+			},
+			expectedType: object.GO_VALUE_OBJ,
+			expectedVal:  struct{ Name string }{Name: "test"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interpreter, err := NewInterpreter()
+			if err != nil {
+				t.Fatalf("NewInterpreter() failed: %v", err)
+			}
+
+			res, err := interpreter.Eval(context.Background(), Options{
+				Source:   []byte(tt.script),
+				Filename: "test.mgo",
+				Globals:  tt.globals,
+			})
+
+			if err != nil {
+				t.Fatalf("Eval() returned an error: %v", err)
+			}
+
+			if res.Value == nil {
+				t.Fatalf("Eval() result value is nil")
+			}
+
+			if res.Value.Type() != tt.expectedType {
+				t.Errorf("wrong object type. got=%q, want=%q", res.Value.Type(), tt.expectedType)
+			}
+
+			goVal, ok := res.Value.(*object.GoValue)
+			if !ok {
+				t.Fatalf("result is not a GoValue, but a %T", res.Value)
+			}
+
+			if goVal.Value.Interface() != tt.expectedVal {
+				t.Errorf("wrong value. got=%v, want=%v", goVal.Value.Interface(), tt.expectedVal)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I introduced the foundational mechanism for Go interoperability in the minigo2 interpreter. This allows native Go values to be injected into the script's global environment.

Here are the key changes:

1.  **`object.GoValue`**: I added a new object type (`GO_VALUE_OBJ`) to wrap a `reflect.Value`. This allows any Go variable to be represented within the minigo2 object system.

2.  **`Options.Globals`**: The `minigo2.Options` struct now includes a `Globals map[string]any` field. This provides a clean API for you to pass Go variables into the interpreter.

3.  **Injection Logic**: The `minigo2.Interpreter.Eval` method now processes the `Globals` map, converting each Go variable into an `object.GoValue` and setting it in the root environment before script execution begins.

4.  **Evaluator Enhancement**: I updated the `evalGenDecl` function in the evaluator to return the value from a `var` declaration, making its behavior consistent with assignment expressions and enabling easier testing.

5.  **Tests**: I added a new test file, `minigo2_interop_test.go`, to verify that Go variables (integers, strings, structs) can be successfully injected and retrieved within a minigo2 script.