### PR TITLE
feat(minigo): implement support for generic type aliases

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -214,7 +214,7 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
 - [x] **Generics Support (Simplified)**:
     - [x] Implement support for generic structs (definition, instantiation, method calls).
     - [x] Implement support for generic functions and types, assuming calls are correct (no type checking).
-- [ ] **Support for Generic Type Aliases**: Implement support for generic type aliases (e.g., `type List[T any] = []T`). This requires updating the type declaration logic in the evaluator to handle `ast.TypeSpec` nodes where the `Assign` field is non-nil.
+- [x] **Support for Generic Type Aliases**: Implement support for generic type aliases (e.g., `type List[T any] = []T`). This requires updating the type declaration logic in the evaluator to handle `ast.TypeSpec` nodes where the `Assign` field is non-nil.
 - [ ] **Built-in Functions**:
     - [x] `append`
     - [ ] `copy`


### PR DESCRIPTION
This commit introduces support for type aliases in the minigo interpreter, including both generic and non-generic forms, as tracked in TODO.md.

Key changes:
- Added a new `object.TypeAlias` to represent alias declarations.
- Implemented caching for resolved types on the `TypeAlias` object to ensure that a single underlying struct definition is used for all references, preserving method sets.
- Extended the `Eval` function to evaluate type expressions (`*ast.ArrayType`, `*ast.MapType`, `*ast.StructType`) into corresponding type objects.
- Refactored `evalCompositeLit` to evaluate the type expression first, allowing it to correctly create literals from aliases.
- Updated `evalGenDecl` to resolve receiver type aliases, allowing methods to be defined on types declared via an alias.
- Added a comprehensive test suite in `evaluator_test.go` to validate the new functionality for various alias forms.