### PR TITLE
feat(minigo): implement delete built-in function

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,7 +39,7 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
 ### `minigo` Refinements ([docs/plan-minigo.md](./docs/plan-minigo.md))
 - [ ] **Implement Remaining Built-in Functions**:
     - [x] `copy`
-    - [ ] `delete`
+    - [x] `delete`
     - [ ] `cap`
     - [ ] `make`
     - [ ] `new`

--- a/minigo/evaluator/evaluator.go
+++ b/minigo/evaluator/evaluator.go
@@ -88,6 +88,23 @@ var builtins = map[string]*object.Builtin{
 			return &object.Integer{Value: int64(n)}
 		},
 	},
+	"delete": {
+		Fn: func(ctx *object.BuiltinContext, pos token.Pos, args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return ctx.NewError(pos, "wrong number of arguments. got=%d, want=2", len(args))
+			}
+			m, ok := args[0].(*object.Map)
+			if !ok {
+				return ctx.NewError(pos, "argument to `delete` must be a map, got %s", args[0].Type())
+			}
+			key, ok := args[1].(object.Hashable)
+			if !ok {
+				return ctx.NewError(pos, "unusable as map key: %s", args[1].Type())
+			}
+			delete(m.Pairs, key.HashKey())
+			return object.NIL
+		},
+	},
 	"append": {
 		Fn: func(ctx *object.BuiltinContext, pos token.Pos, args ...object.Object) object.Object {
 			if len(args) < 2 {


### PR DESCRIPTION
This commit implements the `delete` built-in function for maps in the `minigo` interpreter.

The following changes are included:
- Added the `delete` function to the `builtins` map in `minigo/evaluator/evaluator.go`.
- Added `TestDeleteFunction` and `TestDeleteFunction_Errors` to `minigo/evaluator/evaluator_test.go` to test the new functionality.
- Updated `TODO.md` to reflect the completion of this task.