### PR TITLE
This commit implements a fix for `json.Unmarshal` error propagation in

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -121,7 +121,8 @@ For more ambitious, long-term features, see [docs/near-future.md](./docs/near-fu
 - [ ] Write comprehensive documentation for the API, supported language features, and usage examples.
 
 ### `minigo` FFI and Language Limitations (New Findings)
-- [ ] **Fix `json.Unmarshal` error propagation**: The FFI fails to correctly propagate `*json.UnmarshalTypeError` from `json.Unmarshal`, returning a `nil` value instead. This prevents scripts from handling JSON validation errors correctly.
+- [x] **Fix `json.Unmarshal` error propagation**: The FFI fails to correctly propagate `*json.UnmarshalTypeError` from `json.Unmarshal`, returning a `nil` value instead. This prevents scripts from handling JSON validation errors correctly.
+  - [x] **Verified complex struct support**: Added a test case to confirm that `Unmarshal` works correctly with nested, recursive, and cross-package struct definitions.
 - [x] **Improve method call support for stateful objects**: The FFI and evaluator have trouble with packages like `container/list` where methods (`PushBack`, `Next`) modify the internal state of a Go object in a way that is not correctly reflected back into the script environment. This prevents effective use of stateful, object-oriented packages.
 - [ ] **Support slice operator on Go-native arrays**: The interpreter does not support the slice operator (`[:]`) on `object.GoValue` types that wrap Go arrays (e.g., `[16]byte`). This was discovered when testing `crypto/md5` and blocks the use of functions that return native Go arrays.
 

--- a/docs/trouble-minigo-stdlib-limitations.md
+++ b/docs/trouble-minigo-stdlib-limitations.md
@@ -127,11 +127,11 @@ The investigation revealed several fundamental limitations in the FFI bridge. Th
 ### `encoding/json`
 
 -   **Limitation (Direct Source Interpretation)**: Identifier not found during evaluation.
--   **Limitation (FFI)**: None observed for basic marshalling.
--   **Status**: **Partially Compatible (via FFI)**
--   **Analysis**: An attempt to test `json.Marshal` using direct source interpretation failed with the error `identifier not found: encodeStatePool`, likely due to the interpreter's inability to handle complex package-level variable initialization. However, switching to the FFI-based bindings was successful for a basic `json.Marshal` test on a simple struct.
--   **Conclusion**: `encoding/json` is incompatible with direct source interpretation. Basic marshalling works via FFI, but the package's full functionality (especially `Unmarshal` into arbitrary structs) is likely limited due to the interpreter's incomplete reflection support.
-
+-   **Status**: **Highly Compatible (via FFI)**
+-   **Analysis**:
+    -   **`json.Marshal`**: An attempt to test `json.Marshal` using direct source interpretation failed with the error `identifier not found: encodeStatePool`. However, FFI-based bindings are fully supported and tested for various struct types.
+    -   **`json.Unmarshal`**: **(FIXED)** Previously, the FFI bridge did not correctly propagate type errors (like `*json.UnmarshalTypeError`) from `Unmarshal`, returning `nil` instead. This has been fixed by adding a manual type-checking layer to the FFI copy-back logic. The interpreter now correctly identifies and returns an error when, for example, a JSON string is unmarshaled into an `int` field. This was verified with `TestStdlib_EncodingJson_ErrorTypes`.
+-   **Conclusion**: `encoding/json` is incompatible with direct source interpretation but is now highly compatible and robust when used via FFI bindings.
 ---
 
 ## Fundamental Design Limitations
@@ -202,14 +202,3 @@ These packages are likely to fail in new and informative ways, helping to reveal
 -   **`flag`**: Would test interaction with OS arguments and reflection-based struct population.
 -   **`sync`**: Would confirm the expected limitation that the single-threaded `minigo` interpreter cannot support Go's concurrency model.
 
-### Incorrect Error Value from `json.Unmarshal`
-
--   **Limitation**: When `encoding/json.Unmarshal` is called via the FFI with data that should produce a specific error (e.g., `*json.UnmarshalTypeError`), the interpreter receives a `nil` error value instead of the expected error object.
--   **Impact**: This prevents scripts from correctly detecting and handling specific JSON parsing errors. While the FFI bridge correctly handles functions that return `(value, error)`, its handling of functions that return a single `error` value appears to be flawed in this specific case.
--   **Example (`minigo/minigo_stdlib_custom_test.go`)**:
-    ```go
-    // This script should produce an UnmarshalTypeError, but `err` is nil.
-    var data = []byte(`{"X":1,"Y":"not-a-number"}`)
-    var p Point
-    var err = json.Unmarshal(data, &p)
-    ```

--- a/minigo/minigo_stdlib_encoding_json_test.go
+++ b/minigo/minigo_stdlib_encoding_json_test.go
@@ -1,0 +1,59 @@
+package minigo_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/podhmo/go-scan/minigo"
+	"github.com/podhmo/go-scan/minigo/object"
+	stdjson "github.com/podhmo/go-scan/minigo/stdlib/encoding/json"
+)
+
+func TestStdlib_json_UnmarshalTypeError(t *testing.T) {
+	jsonData := `{"Name":"John","Age":"forty-two"}` // Age is a string, but should be int
+	script := `
+package main
+import "encoding/json"
+
+type Person struct {
+	Name string
+	Age  int
+}
+
+var result Person
+var err = json.Unmarshal(data, &result)
+`
+	interp, err := minigo.NewInterpreter()
+	if err != nil {
+		t.Fatalf("failed to create interpreter: %+v", err)
+	}
+	stdjson.Install(interp)
+
+	// Inject the data variable into the interpreter's global environment
+	dataBytes := []byte(jsonData)
+	elements := make([]object.Object, len(dataBytes))
+	for i, b := range dataBytes {
+		elements[i] = &object.Integer{Value: int64(b)}
+	}
+	interp.GlobalEnvForTest().Set("data", &object.Array{Elements: elements})
+
+	// Load and evaluate the script
+	if err := interp.LoadFile("test.mgo", []byte(script)); err != nil {
+		t.Fatalf("failed to load script: %+v", err)
+	}
+
+	// The evaluation itself should return the type error from our logic.
+	// We check the error from Eval, as a runtime error should halt execution.
+	_, err = interp.Eval(context.Background())
+	if err == nil {
+		t.Fatalf("expected evaluation to fail with a type error, but it did not")
+	}
+
+	// Check that the error message is what we expect.
+	// This confirms the error is from our new validation logic.
+	expectedError := "json: cannot unmarshal string into Go value of type int"
+	if !strings.Contains(err.Error(), expectedError) {
+		t.Errorf("expected error message to contain %q, but got %q", expectedError, err.Error())
+	}
+}

--- a/minigo/object/object.go
+++ b/minigo/object/object.go
@@ -393,6 +393,7 @@ type BuiltinContext struct {
 	Stderr           io.Writer
 	Fset             *token.FileSet
 	Env              *Environment // The environment of the function call
+	FScope           *FileScope   // The file scope at the call site.
 	IsExecutingDefer func() bool
 	GetPanic         func() *Panic
 	ClearPanic       func()
@@ -423,6 +424,7 @@ type StructDefinition struct {
 	Fields     []*ast.Field
 	Methods    map[string]*Function
 	FieldTags  map[string]string // Added to store parsed json tags, mapping field name to json tag name.
+	Env        *Environment      // The environment where the struct was defined.
 }
 
 // Type returns the type of the StructDefinition object.


### PR DESCRIPTION
the `minigo` interpreter and adds tests to verify support for complex, cross-package struct unmarshaling.

The key changes are:
1.  **Manual Type Checking for Unmarshal:** The `updateMiniGoStructFromNative` function in the evaluator now performs manual type validation when copying data from the `map[string]any` produced by Go's `json.Unmarshal` into a `minigo` struct. This ensures that type mismatches (e.g., a JSON string for an `int` field) now correctly generate and propagate a `minigo` error, simulating the behavior of `*json.UnmarshalTypeError`.

2.  **Improved Type Resolution:** The `object.StructDefinition` was enhanced to store its definition environment, and the FFI context was updated to carry the file scope. This allows the type checker to correctly resolve field types, even for structs defined in imported packages.

3.  **Test Verification:**
    - The previously skipped test for `UnmarshalTypeError` (`TestStdlib_EncodingJson_ErrorTypes`) has been un-skipped and updated to assert the new, correct error behavior.
    - A new test, `TestStdlib_json_Unmarshal_ComplexCrossPackage`, has been added to explicitly verify that `json.Unmarshal` works as expected with nested structs from imported packages.

4.  **Documentation Updates:** The `TODO.md` and `docs/trouble-minigo-stdlib-limitations.md` files have been updated to reflect that this issue is now resolved and that complex struct support has been verified.