### PR TITLE
Refactor rename scanner methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ func main() {
 	// Replace with an actual import path from your project or testdata.
 	// The example below uses testdata included in this repository.
 	pkgImportPath := "github.com/podhmo/go-scan/testdata/multipkg/api"
-	pkgInfo, err := scanner.ScanPackageByImport(pkgImportPath)
+	pkgInfo, err := scanner.ScanPackageFromImportPath(pkgImportPath)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to scan package", slog.String("package", pkgImportPath), slog.Any("error", err))
 		os.Exit(1)

--- a/docs/analysis-minigo-repl.md
+++ b/docs/analysis-minigo-repl.md
@@ -127,7 +127,7 @@ In addition to the `EvalString()` method needed for the simple REPL, a rich REPL
 *   **For contextual completion (struct fields, package members)**:
     *   **`minigo.Interpreter` needs a type analysis method**: This is the most complex requirement. For the REPL to suggest struct fields (e.g., after a user types `myVar.`), it must be able to determine the type of `myVar`. This requires a new, advanced method on the interpreter, such as `GetTypeInfoOf(expression string) (*TypeInfo, error)`.
     *   This method would need to parse the partial input string (the expression), evaluate it in a temporary/analytical context to get the resulting `object.Object`, and then inspect that object's type definition to return a list of its members (fields and methods). This is a non-trivial feature that turns the interpreter into a static analysis tool on the fly.
-    *   The `go-scan` changes proposed in Approach 3 (i.e., `ScanPackage`) would also be essential for completing members of imported packages.
+    *   The `go-scan` changes proposed in Approach 3 (i.e., `ScanPackageFromFilePath`) would also be essential for completing members of imported packages.
 
 ## 5. Approach 3: Interpreter-Specific Features
 
@@ -163,7 +163,7 @@ This approach requires the most significant changes to the underlying libraries,
 
 *   **For package symbol listing (`:ls some/pkg`)**:
     *   **`go-scan` needs a way to list all package members**: The current `goscan.Scanner` is designed to find specific symbols on demand (`FindSymbolInPackage`). It does not have a public method to simply scan an entire package and return all of its members.
-    *   A new method on `goscan.Scanner`, such as `ScanPackage(path string) (*goscan.Package, error)`, would be required. This method would proactively parse all files in a package and return a complete `Package` object containing lists of all its `Constants`, `Vars`, `Funcs`, and `Types`. This is a fundamental addition to `go-scan`'s capabilities.
+    *   A new method on `goscan.Scanner`, such as `ScanPackageFromFilePath(path string) (*goscan.Package, error)`, would be required. This method would proactively parse all files in a package and return a complete `Package` object containing lists of all its `Constants`, `Vars`, `Funcs`, and `Types`. This is a fundamental addition to `go-scan`'s capabilities.
 
 ### 5.4. Analysis of Dynamic Imports
 

--- a/docs/analysis-profiling-find-orphans.md
+++ b/docs/analysis-profiling-find-orphans.md
@@ -38,7 +38,7 @@ Showing nodes accounting for 9378.78kB, 100% of 9378.78kB total
   512.03kB  5.46% 83.62%  1024.04kB 10.92%  go/parser.(*parser).parseLiteralValue
   512.03kB  5.46% 89.08%   512.03kB  5.46%  go/parser.(*parser).parseParameterList.func1 (inline)
   512.03kB  5.46% 94.54%  1024.05kB 10.92%  go/parser.(*parser).parseSimpleStmt
-  512.02kB  5.46%   100%   512.02kB  5.46%  github.com/podhmo/go-scan/scanner.(*Scanner).ScanPackageImports
+  512.02kB  5.46%   100%   512.02kB  5.46%  github.com/podhmo/go-scan/scanner.(*Scanner).ScanPackageFromFilePathImports
 ```
 
 ## Analysis and Conclusion
@@ -47,7 +47,7 @@ The profiling results clearly indicate that the majority of memory is consumed d
 
 -   **Primary Cause**: The `go/parser` package and its functions (`parseIdent`, `parseSelector`, etc.) are the top direct (`flat`) allocators.
 -   **Cumulative Impact**: The cumulative (`cum`) allocations show that functions like `go/parser.ParseFile` (60.06% of cumulative memory) are the main drivers of memory usage. This function is responsible for parsing Go source files into Abstract Syntax Trees (ASTs).
--   **Architectural Bottleneck**: The core issue lies in the `analyzer`'s architecture. The `analyzer.Visit` method is called for every package in the dependency graph. Inside this method, `a.s.ScanPackageByImport` is called, which parses the entire package and returns a `*scanner.PackageInfo` object. This object, which contains the memory-intensive ASTs for all files in the package, is then stored in the `a.pacakges` map.
+-   **Architectural Bottleneck**: The core issue lies in the `analyzer`'s architecture. The `analyzer.Visit` method is called for every package in the dependency graph. Inside this method, `a.s.ScanPackageFromImportPath` is called, which parses the entire package and returns a `*scanner.PackageInfo` object. This object, which contains the memory-intensive ASTs for all files in the package, is then stored in the `a.pacakges` map.
 
 This approach leads to **all packages and their full ASTs being held in memory for the entire duration of the program**. While the memory usage for the tool's own repository was manageable (~9.4 MB), this design will not scale well to larger monorepos, where it could easily consume gigabytes of memory.
 

--- a/docs/ja/from-derivingjson.md
+++ b/docs/ja/from-derivingjson.md
@@ -27,7 +27,7 @@
 
     ```go
     // 提案するAPIのイメージ
-    // pkgInfo, err := gscn.ScanPackage(pkgPath, goscan.WithDocAnnotation(unmarshalAnnotation))
+    // pkgInfo, err := gscn.ScanPackageFromFilePath(pkgPath, goscan.WithDocAnnotation(unmarshalAnnotation))
     // or
     // filteredTypes := pkgInfo.FilterTypes(goscan.WithDocAnnotation(unmarshalAnnotation))
     ```
@@ -117,7 +117,7 @@
 
 *   **現状の `derivingjson`**:
     フィールドの型情報を扱う際、その型がプリミティブ型か、ローカルパッケージで定義された型か、外部パッケージの型かを判別するために、`field.Type.PkgName == ""` や `field.Type.Resolve()` の結果を組み合わせて複雑な条件分岐を行っています。また、ポインタ、スライス、マップといった複合型の完全な型名を文字列として再構築するロジックも自前で実装しています。
-    さらに、型が定義されているパッケージの正確なインポートパスを取得するために、`TypeInfo.FilePath` からディレクトリパスを算出し、再度 `ScanPackage` を呼び出すといった間接的な方法を取る必要がありました。
+    さらに、型が定義されているパッケージの正確なインポートパスを取得するために、`TypeInfo.FilePath` からディレクトリパスを算出し、再度 `ScanPackageFromFilePath` を呼び出すといった間接的な方法を取る必要がありました。
 
     ```go
     // examples/derivingjson/generator.go より抜粋
@@ -130,7 +130,7 @@
     // ImportPath取得の複雑さ (イメージ)
     // if oneOfInterfaceDef.FilePath != "" {
     //     interfaceDir := filepath.Dir(oneOfInterfaceDef.FilePath)
-    //     tempInterfacePkgInfo, _ := gscn.ScanPackage(interfaceDir)
+    //     tempInterfacePkgInfo, _ := gscn.ScanPackageFromFilePath(interfaceDir)
     //     if tempInterfacePkgInfo != nil {
     //          importPath = tempInterfacePkgInfo.ImportPath
     //     }

--- a/docs/ja/from-minigo.md
+++ b/docs/ja/from-minigo.md
@@ -54,7 +54,7 @@
 ### 主な統合ステップ
 
 1.  **初期化**: `minigo` の `Interpreter` が `go-scan` の `Scanner` インスタンスを生成（`token.FileSet` を共有）。
-2.  **スキャン**: `minigo` のソースファイルを `Scanner.ScanFiles()` または `Scanner.ScanPackage()` でスキャンし、`PackageInfo` を取得。
+2.  **スキャン**: `minigo` のソースファイルを `Scanner.ScanFiles()` または `Scanner.ScanPackageFromFilePath()` でスキャンし、`PackageInfo` を取得。
 3.  **シンボル登録**:
     *   `PackageInfo.Functions` を元に、各 `FunctionInfo.AstDecl (*ast.FuncDecl)` を `minigo` の環境に登録。
     *   `PackageInfo.AstFiles` から各 `*ast.File` を取得し、トップレベルの `ast.GenDecl` (VAR) を見つけてグローバル変数を評価・登録。`PackageInfo.Constants` も活用。

--- a/docs/ja/llm-history.md
+++ b/docs/ja/llm-history.md
@@ -520,7 +520,7 @@ func main() {
 	}
 
 	// Scan a package located at a specific path.
-	pkgInfo, err := scanner.ScanPackage("./path/to/your/package")
+	pkgInfo, err := scanner.ScanPackageFromFilePath("./path/to/your/package")
 	if err != nil {
 		log.Fatalf("Failed to scan package: %v", err)
 	}
@@ -847,8 +847,8 @@ func New() *Scanner {
 	return &Scanner{}
 }
 
-// ScanPackage parses all .go files in a given directory and returns PackageInfo.
-func (s *Scanner) ScanPackage(dirPath string) (*PackageInfo, error) {
+// ScanPackageFromFilePath parses all .go files in a given directory and returns PackageInfo.
+func (s *Scanner) ScanPackageFromFilePath(dirPath string) (*PackageInfo, error) {
 	pkgs, err := parser.ParseDir(token.NewFileSet(), dirPath, func(fi os.FileInfo) bool {
 		return !strings.HasSuffix(fi.Name(), "_test.go")
 	}, parser.ParseComments)
@@ -1058,11 +1058,11 @@ import (
 	"testing"
 )
 
-func TestScanPackageBasic(t *testing.T) {
+func TestScanPackageFromFilePathBasic(t *testing.T) {
 	s := New()
-	pkgInfo, err := s.ScanPackage(filepath.Join("..", "testdata", "basic"))
+	pkgInfo, err := s.ScanPackageFromFilePath(filepath.Join("..", "testdata", "basic"))
 	if err != nil {
-		t.Fatalf("ScanPackage failed: %v", err)
+		t.Fatalf("ScanPackageFromFilePath failed: %v", err)
 	}
 
 	if pkgInfo.Name != "basic" {
@@ -1108,11 +1108,11 @@ func TestScanPackageBasic(t *testing.T) {
 	}
 }
 
-func TestScanPackageComplex(t *testing.T) {
+func TestScanPackageFromFilePathComplex(t *testing.T) {
 	s := New()
-	pkgInfo, err := s.ScanPackage(filepath.Join("..", "testdata", "complex"))
+	pkgInfo, err := s.ScanPackageFromFilePath(filepath.Join("..", "testdata", "complex"))
 	if err != nil {
-		t.Fatalf("ScanPackage failed: %v", err)
+		t.Fatalf("ScanPackageFromFilePath failed: %v", err)
 	}
 
 	var profileStruct *TypeInfo
@@ -1190,9 +1190,9 @@ func New(startPath string) (*Scanner, error) {
 	}, nil
 }
 
-// ScanPackage scans a single package at a given directory path.
+// ScanPackageFromFilePath scans a single package at a given directory path.
 // The path should be relative to the project root or an absolute path.
-func (s *Scanner) ScanPackage(pkgPath string) (*scanner.PackageInfo, error) {
+func (s *Scanner) ScanPackageFromFilePath(pkgPath string) (*scanner.PackageInfo, error) {
 	info, err := os.Stat(pkgPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not stat path %s: %w", pkgPath, err)
@@ -1202,17 +1202,17 @@ func (s *Scanner) ScanPackage(pkgPath string) (*scanner.PackageInfo, error) {
 		return nil, fmt.Errorf("path %s is not a directory", pkgPath)
 	}
 
-	return s.scanner.ScanPackage(pkgPath, nil) // Pass nil resolver for old tests
+	return s.scanner.ScanPackageFromFilePath(pkgPath, nil) // Pass nil resolver for old tests
 }
 
-// ScanPackageByImport scans a single package using its Go import path.
+// ScanPackageFromImportPath scans a single package using its Go import path.
 // e.g., "github.com/your/project/models"
-func (s *Scanner) ScanPackageByImport(importPath string) (*scanner.PackageInfo, error) {
+func (s *Scanner) ScanPackageFromImportPath(importPath string) (*scanner.PackageInfo, error) {
 	dirPath, err := s.locator.FindPackageDir(importPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not find directory for import path %s: %w", importPath, err)
 	}
-	return s.ScanPackage(dirPath)
+	return s.ScanPackageFromFilePath(dirPath)
 }
 ````
 
@@ -1245,16 +1245,16 @@ func TestNew_Integration(t *testing.T) {
 	}
 }
 
-// TestScanPackage_Integration tests the full scanning process on the basic testdata.
-func TestScanPackage_Integration(t *testing.T) {
+// TestScanPackageFromFilePath_Integration tests the full scanning process on the basic testdata.
+func TestScanPackageFromFilePath_Integration(t *testing.T) {
 	s, err := New(".")
 	if err != nil {
 		t.Fatalf("New() failed: %v", err)
 	}
 
-	pkgInfo, err := s.ScanPackage("./testdata/basic")
+	pkgInfo, err := s.ScanPackageFromFilePath("./testdata/basic")
 	if err != nil {
-		t.Fatalf("ScanPackage() failed: %v", err)
+		t.Fatalf("ScanPackageFromFilePath() failed: %v", err)
 	}
 
 	if pkgInfo.Name != "basic" {
@@ -1265,17 +1265,17 @@ func TestScanPackage_Integration(t *testing.T) {
 	}
 }
 
-// TestScanPackageByImport_Integration tests scanning using a Go-style import path.
-func TestScanPackageByImport_Integration(t *testing.T) {
+// TestScanPackageFromImportPath_Integration tests scanning using a Go-style import path.
+func TestScanPackageFromImportPath_Integration(t *testing.T) {
 	s, err := New(".")
 	if err != nil {
 		t.Fatalf("New() failed: %v", err)
 	}
 
 	importPath := "github.com/vvakame/goscan/testdata/multipkg/models"
-	pkgInfo, err := s.ScanPackageByImport(importPath)
+	pkgInfo, err := s.ScanPackageFromImportPath(importPath)
 	if err != nil {
-		t.Fatalf("ScanPackageByImport() failed: %v", err)
+		t.Fatalf("ScanPackageFromImportPath() failed: %v", err)
 	}
 
 	if pkgInfo.Name != "models" {
@@ -1293,9 +1293,9 @@ func TestMultiPackageReference(t *testing.T) {
 		t.Fatalf("New() failed: %v", err)
 	}
 
-	pkgInfo, err := s.ScanPackage(filepath.Join("testdata", "multipkg", "api"))
+	pkgInfo, err := s.ScanPackageFromFilePath(filepath.Join("testdata", "multipkg", "api"))
 	if err != nil {
-		t.Fatalf("ScanPackage() failed: %v", err)
+		t.Fatalf("ScanPackageFromFilePath() failed: %v", err)
 	}
 
 	var handlerStruct *scanner.TypeInfo
@@ -1619,7 +1619,7 @@ func main() {
 	}
 
 	// Scan a package located at a specific path.
-	pkgInfo, err := scanner.ScanPackage("./path/to/your/package")
+	pkgInfo, err := scanner.ScanPackageFromFilePath("./path/to/your/package")
 	if err != nil {
 		log.Fatalf("Failed to scan package: %v", err)
 	}
@@ -1964,8 +1964,8 @@ func New() *Scanner {
 	return &Scanner{}
 }
 
-// ScanPackage parses all .go files in a given directory and returns PackageInfo.
-func (s *Scanner) ScanPackage(dirPath string) (*PackageInfo, error) {
+// ScanPackageFromFilePath parses all .go files in a given directory and returns PackageInfo.
+func (s *Scanner) ScanPackageFromFilePath(dirPath string) (*PackageInfo, error) {
 	pkgs, err := parser.ParseDir(token.NewFileSet(), dirPath, func(fi os.FileInfo) bool {
 		return !strings.HasSuffix(fi.Name(), "_test.go")
 	}, parser.ParseComments)
@@ -2202,11 +2202,11 @@ import (
 	"testing"
 )
 
-func TestScanPackageBasic(t *testing.T) {
+func TestScanPackageFromFilePathBasic(t *testing.T) {
 	s := New()
-	pkgInfo, err := s.ScanPackage(filepath.Join("..", "testdata", "basic"))
+	pkgInfo, err := s.ScanPackageFromFilePath(filepath.Join("..", "testdata", "basic"))
 	if err != nil {
-		t.Fatalf("ScanPackage failed: %v", err)
+		t.Fatalf("ScanPackageFromFilePath failed: %v", err)
 	}
 
 	if pkgInfo.Name != "basic" {
@@ -2252,11 +2252,11 @@ func TestScanPackageBasic(t *testing.T) {
 	}
 }
 
-func TestScanPackageComplex(t *testing.T) {
+func TestScanPackageFromFilePathComplex(t *testing.T) {
 	s := New()
-	pkgInfo, err := s.ScanPackage(filepath.Join("..", "testdata", "complex"))
+	pkgInfo, err := s.ScanPackageFromFilePath(filepath.Join("..", "testdata", "complex"))
 	if err != nil {
-		t.Fatalf("ScanPackage failed: %v", err)
+		t.Fatalf("ScanPackageFromFilePath failed: %v", err)
 	}
 
 	var profileStruct *TypeInfo
@@ -2302,11 +2302,11 @@ func TestScanPackageComplex(t *testing.T) {
 	}
 }
 
-func TestScanPackageFeatures(t *testing.T) {
+func TestScanPackageFromFilePathFeatures(t *testing.T) {
 	s := New()
-	pkgInfo, err := s.ScanPackage(filepath.Join("..", "testdata", "features"))
+	pkgInfo, err := s.ScanPackageFromFilePath(filepath.Join("..", "testdata", "features"))
 	if err != nil {
-		t.Fatalf("ScanPackage failed: %v", err)
+		t.Fatalf("ScanPackageFromFilePath failed: %v", err)
 	}
 
 	types := make(map[string]*TypeInfo)
@@ -2408,9 +2408,9 @@ func New(startPath string) (*Scanner, error) {
 	}, nil
 }
 
-// ScanPackage scans a single package at a given directory path.
+// ScanPackageFromFilePath scans a single package at a given directory path.
 // The path should be relative to the project root or an absolute path.
-func (s *Scanner) ScanPackage(pkgPath string) (*scanner.PackageInfo, error) {
+func (s *Scanner) ScanPackageFromFilePath(pkgPath string) (*scanner.PackageInfo, error) {
 	info, err := os.Stat(pkgPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not stat path %s: %w", pkgPath, err)
@@ -2420,17 +2420,17 @@ func (s *Scanner) ScanPackage(pkgPath string) (*scanner.PackageInfo, error) {
 		return nil, fmt.Errorf("path %s is not a directory", pkgPath)
 	}
 
-	return s.scanner.ScanPackage(pkgPath)
+	return s.scanner.ScanPackageFromFilePath(pkgPath)
 }
 
-// ScanPackageByImport scans a single package using its Go import path.
+// ScanPackageFromImportPath scans a single package using its Go import path.
 // e.g., "github.com/your/project/models"
-func (s *Scanner) ScanPackageByImport(importPath string) (*scanner.PackageInfo, error) {
+func (s *Scanner) ScanPackageFromImportPath(importPath string) (*scanner.PackageInfo, error) {
 	dirPath, err := s.locator.FindPackageDir(importPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not find directory for import path %s: %w", importPath, err)
 	}
-	return s.ScanPackage(dirPath)
+	return s.ScanPackageFromFilePath(dirPath)
 }
 ````
 
@@ -2463,16 +2463,16 @@ func TestNew_Integration(t *testing.T) {
 	}
 }
 
-// TestScanPackage_Integration tests the full scanning process on the basic testdata.
-func TestScanPackage_Integration(t *testing.T) {
+// TestScanPackageFromFilePath_Integration tests the full scanning process on the basic testdata.
+func TestScanPackageFromFilePath_Integration(t *testing.T) {
 	s, err := New(".")
 	if err != nil {
 		t.Fatalf("New() failed: %v", err)
 	}
 
-	pkgInfo, err := s.ScanPackage("./testdata/basic")
+	pkgInfo, err := s.ScanPackageFromFilePath("./testdata/basic")
 	if err != nil {
-		t.Fatalf("ScanPackage() failed: %v", err)
+		t.Fatalf("ScanPackageFromFilePath() failed: %v", err)
 	}
 
 	if pkgInfo.Name != "basic" {
@@ -2483,17 +2483,17 @@ func TestScanPackage_Integration(t *testing.T) {
 	}
 }
 
-// TestScanPackageByImport_Integration tests scanning using a Go-style import path.
-func TestScanPackageByImport_Integration(t *testing.T) {
+// TestScanPackageFromImportPath_Integration tests scanning using a Go-style import path.
+func TestScanPackageFromImportPath_Integration(t *testing.T) {
 	s, err := New(".")
 	if err != nil {
 		t.Fatalf("New() failed: %v", err)
 	}
 
 	importPath := "github.com/podhmo/go-scan/testdata/multipkg/models"
-	pkgInfo, err := s.ScanPackageByImport(importPath)
+	pkgInfo, err := s.ScanPackageFromImportPath(importPath)
 	if err != nil {
-		t.Fatalf("ScanPackageByImport() failed: %v", err)
+		t.Fatalf("ScanPackageFromImportPath() failed: %v", err)
 	}
 
 	if pkgInfo.Name != "models" {
@@ -2511,9 +2511,9 @@ func TestMultiPackageReference(t *testing.T) {
 		t.Fatalf("New() failed: %v", err)
 	}
 
-	pkgInfo, err := s.ScanPackage(filepath.Join("testdata", "multipkg", "api"))
+	pkgInfo, err := s.ScanPackageFromFilePath(filepath.Join("testdata", "multipkg", "api"))
 	if err != nil {
-		t.Fatalf("ScanPackage() failed: %v", err)
+		t.Fatalf("ScanPackageFromFilePath() failed: %v", err)
 	}
 
 	var handlerStruct *scanner.TypeInfo
@@ -2996,7 +2996,7 @@ func main() {
 		log.Fatalf("Failed to create scanner: %v", err)
 	}
 
-	pkgInfo, err := scanner.ScanPackageByImport("github.com/vvakame/goscan/testdata/multipkg/api")
+	pkgInfo, err := scanner.ScanPackageFromImportPath("github.com/vvakame/goscan/testdata/multipkg/api")
 	if err != nil {
 		log.Fatalf("Failed to scan package: %v", err)
 	}
@@ -3269,7 +3269,7 @@ const (
 // PackageResolver is an interface that can resolve an import path to a package definition.
 // It is implemented by the top-level typescanner.Scanner to enable lazy, cached lookups.
 type PackageResolver interface {
-	ScanPackageByImport(importPath string) (*PackageInfo, error)
+	ScanPackageFromImportPath(importPath string) (*PackageInfo, error)
 }
 
 // PackageInfo holds all the extracted information from a single package.
@@ -3331,7 +3331,7 @@ func (ft *FieldType) Resolve() (*TypeInfo, error) {
 		return nil, fmt.Errorf("type %q cannot be resolved: no resolver or import path available", ft.Name)
 	}
 
-	pkgInfo, err := ft.resolver.ScanPackageByImport(ft.fullImportPath)
+	pkgInfo, err := ft.resolver.ScanPackageFromImportPath(ft.fullImportPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan package %q for type %q: %w", ft.fullImportPath, ft.typeName, err)
 	}
@@ -3388,8 +3388,8 @@ func New() *Scanner {
 	return &Scanner{}
 }
 
-// ScanPackage parses all .go files in a given directory and returns PackageInfo.
-func (s *Scanner) ScanPackage(dirPath string, resolver PackageResolver) (*PackageInfo, error) {
+// ScanPackageFromFilePath parses all .go files in a given directory and returns PackageInfo.
+func (s *Scanner) ScanPackageFromFilePath(dirPath string, resolver PackageResolver) (*PackageInfo, error) {
 	s.resolver = resolver
 	pkgs, err := parser.ParseDir(token.NewFileSet(), dirPath, func(fi os.FileInfo) bool {
 		return !strings.HasSuffix(fi.Name(), "_test.go")
@@ -3639,21 +3639,21 @@ import (
 
 // MockResolver is a mock implementation of PackageResolver for tests.
 type MockResolver struct {
-	ScanPackageByImportFunc func(importPath string) (*PackageInfo, error)
+	ScanPackageFromImportPathFunc func(importPath string) (*PackageInfo, error)
 }
 
-func (m *MockResolver) ScanPackageByImport(importPath string) (*PackageInfo, error) {
-	if m.ScanPackageByImportFunc != nil {
-		return m.ScanPackageByImportFunc(importPath)
+func (m *MockResolver) ScanPackageFromImportPath(importPath string) (*PackageInfo, error) {
+	if m.ScanPackageFromImportPathFunc != nil {
+		return m.ScanPackageFromImportPathFunc(importPath)
 	}
 	return nil, nil
 }
 
-func TestScanPackageFeatures(t *testing.T) {
+func TestScanPackageFromFilePathFeatures(t *testing.T) {
 	s := New()
-	pkgInfo, err := s.ScanPackage(filepath.Join("..", "testdata", "features"), &MockResolver{})
+	pkgInfo, err := s.ScanPackageFromFilePath(filepath.Join("..", "testdata", "features"), &MockResolver{})
 	if err != nil {
-		t.Fatalf("ScanPackage failed: %v", err)
+		t.Fatalf("ScanPackageFromFilePath failed: %v", err)
 	}
 
 	types := make(map[string]*TypeInfo)
@@ -3705,7 +3705,7 @@ func TestScanPackageFeatures(t *testing.T) {
 func TestFieldType_Resolve(t *testing.T) {
 	// Setup a mock resolver that returns a predefined package info
 	resolver := &MockResolver{
-		ScanPackageByImportFunc: func(importPath string) (*PackageInfo, error) {
+		ScanPackageFromImportPathFunc: func(importPath string) (*PackageInfo, error) {
 			if importPath == "example.com/models" {
 				return &PackageInfo{
 					Types: []*TypeInfo{
@@ -3738,7 +3738,7 @@ func TestFieldType_Resolve(t *testing.T) {
 	}
 
 	// Second call should use the cache (we can't easily test this, but we can nil out the func)
-	resolver.ScanPackageByImportFunc = nil
+	resolver.ScanPackageFromImportPathFunc = nil
 	def2, err := ft.Resolve()
 	if err != nil {
 		t.Fatalf("Second Resolve() call failed: %v", err)
@@ -3791,9 +3791,9 @@ func New(startPath string) (*Scanner, error) {
 	}, nil
 }
 
-// ScanPackage scans a single package at a given directory path.
+// ScanPackageFromFilePath scans a single package at a given directory path.
 // The path should be relative to the project root or an absolute path.
-func (s *Scanner) ScanPackage(pkgPath string) (*scanner.PackageInfo, error) {
+func (s *Scanner) ScanPackageFromFilePath(pkgPath string) (*scanner.PackageInfo, error) {
 	info, err := os.Stat(pkgPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not stat path %s: %w", pkgPath, err)
@@ -3803,12 +3803,12 @@ func (s *Scanner) ScanPackage(pkgPath string) (*scanner.PackageInfo, error) {
 		return nil, fmt.Errorf("path %s is not a directory", pkgPath)
 	}
 
-	return s.scanner.ScanPackage(pkgPath, s)
+	return s.scanner.ScanPackageFromFilePath(pkgPath, s)
 }
 
-// ScanPackageByImport scans a single package using its Go import path.
+// ScanPackageFromImportPath scans a single package using its Go import path.
 // It uses a cache to avoid re-scanning the same package multiple times.
-func (s *Scanner) ScanPackageByImport(importPath string) (*scanner.PackageInfo, error) {
+func (s *Scanner) ScanPackageFromImportPath(importPath string) (*scanner.PackageInfo, error) {
 	// Check cache first
 	s.mu.RLock()
 	cachedPkg, found := s.packageCache[importPath]
@@ -3823,7 +3823,7 @@ func (s *Scanner) ScanPackageByImport(importPath string) (*scanner.PackageInfo, 
 		return nil, fmt.Errorf("could not find directory for import path %s: %w", importPath, err)
 	}
 
-	pkgInfo, err := s.ScanPackage(dirPath)
+	pkgInfo, err := s.ScanPackageFromFilePath(dirPath)
 	if err != nil {
 		return nil, err
 	}
@@ -3874,9 +3874,9 @@ func TestLazyResolution_Integration(t *testing.T) {
 
 	// Scan the 'api' package, which depends on the 'models' package.
 	apiImportPath := "example.com/multipkg-test/api"
-	pkgInfo, err := s.ScanPackageByImport(apiImportPath)
+	pkgInfo, err := s.ScanPackageFromImportPath(apiImportPath)
 	if err != nil {
-		t.Fatalf("ScanPackageByImport() failed: %v", err)
+		t.Fatalf("ScanPackageFromImportPath() failed: %v", err)
 	}
 
 	// Find the Handler struct

--- a/docs/near-future.md
+++ b/docs/near-future.md
@@ -107,10 +107,10 @@ This `todo.md` will focus on the more immediate and concrete enhancements listed
     -   *Full, robust resolution of complex `go.mod` scenarios (including inter-module replacements) is a significant challenge, further discussed in [./dream2.md](./dream2.md).*
 -   **Complexity of `ImportManager.Add`:**
     -   The alias generation logic in `ImportManager.Add` has several checks and fallback mechanisms. While aiming for correctness, its complexity might indicate potential edge cases that need thorough testing.
--   **Clarity of Scanner Method Behaviors (`ScanFiles`, `ScanPackage`, `ScanPackageByImport`):**
-    -   The interaction between the instance-level `visitedFiles` set, the instance-level `packageCache` (for `ScanPackageByImport` and `ScanPackage`), and the persistent `symbolCache` can be intricate.
+-   **Clarity of Scanner Method Behaviors (`ScanFiles`, `ScanPackageFromFilePath`, `ScanPackageFromImportPath`):**
+    -   The interaction between the instance-level `visitedFiles` set, the instance-level `packageCache` (for `ScanPackageFromImportPath` and `ScanPackageFromFilePath`), and the persistent `symbolCache` can be intricate.
     -   The design choice for `ScanFiles` not to update the `packageCache` (as it represents partial information) should be clearly documented for users.
-    -   The "no merge" principle for `PackageInfo` objects returned by different scan calls means that obtaining a "complete" or "fully merged" view of a package might require a specific final scan (e.g., `ScanPackageByImport` after other partial scans) or careful orchestration by the user.
+    -   The "no merge" principle for `PackageInfo` objects returned by different scan calls means that obtaining a "complete" or "fully merged" view of a package might require a specific final scan (e.g., `ScanPackageFromImportPath` after other partial scans) or careful orchestration by the user.
 -   **Scanning and Resolution of External Dependencies:**
     -   The current `ExternalTypeOverride` mechanism allows treating external types as other Go types. A more advanced (and potentially optional) feature would be to fully scan and resolve types from external dependencies (via `go.mod`).
     -   *This is a significant feature, with performance and complexity implications, further explored in [./dream2.md](./dream2.md).*

--- a/docs/plan-minigo.md
+++ b/docs/plan-minigo.md
@@ -99,7 +99,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 
 - A `minigo.Interpreter` struct will hold a `goscan.Scanner` instance.
 - When `Run` is called, it will first use `go/parser.ParseFile` to get the AST for the user's script (`.mgo` file).
-- The interpreter will walk the declarations of the script AST. When it encounters an `import` statement, it will use its internal `goscan.Scanner` to lazily `ScanPackageByImport` when a symbol from that package is first accessed (e.g., `fmt.Println`).
+- The interpreter will walk the declarations of the script AST. When it encounters an `import` statement, it will use its internal `goscan.Scanner` to lazily `ScanPackageFromImportPath` when a symbol from that package is first accessed (e.g., `fmt.Println`).
 - `go-scan` will handle finding the package, parsing it, and returning its exported symbols (`PackageInfo`), which the interpreter will then load into its environment.
 
 ### 3.2.1. Lazy Loading of Imports and Symbols

--- a/docs/plan-multi-package-handling.md
+++ b/docs/plan-multi-package-handling.md
@@ -16,7 +16,7 @@ This plan outlines an approach to solve this by creating a robust, lazy-loading 
 The main `goscan.Scanner` instance will be treated as the single source of truth. It will maintain a cache of all packages that have been scanned during its lifecycle.
 
 -   **Role**: To manage the global `packageCache` (`map[string]*scanner.PackageInfo`).
--   **Functionality**: All package scanning operations, like `ScanPackageByImport`, will be idempotent. They will first check the cache and only perform a file scan if the package has not been previously loaded.
+-   **Functionality**: All package scanning operations, like `ScanPackageFromImportPath`, will be idempotent. They will first check the cache and only perform a file scan if the package has not been previously loaded.
 
 ### 2.2. Lazy Scanning via `FieldType.Resolve()`
 

--- a/docs/plan-overlay.md
+++ b/docs/plan-overlay.md
@@ -164,8 +164,8 @@ func main() {
         log.Fatal(err)
     }
 
-    // ScanPackage would start from "./my-project"
-    pkg, err := s.ScanPackage("./my-project")
+    // ScanPackageFromFilePath would start from "./my-project"
+    pkg, err := s.ScanPackageFromFilePath("./my-project")
     if err != nil {
         log.Fatal(err)
     }

--- a/docs/plan-scan-improvement.md
+++ b/docs/plan-scan-improvement.md
@@ -7,7 +7,7 @@ This document outlines a proposal to improve the scanning behavior of tools buil
 
 ## Current Behavior
 
-Currently, the example tools treat all command-line arguments as file paths, but immediately convert them to directory paths. They then proceed to scan the entire package within that directory using `go-scan.ScanPackage()`. This approach has two main drawbacks:
+Currently, the example tools treat all command-line arguments as file paths, but immediately convert them to directory paths. They then proceed to scan the entire package within that directory using `go-scan.ScanPackageFromFilePath()`. This approach has two main drawbacks:
 
 1.  **Inefficiency**: If a user specifies a single file, the tool scans all `.go` files in its directory, which is unnecessary and inefficient.
 2.  **Inconsistency**: The behavior is inconsistent with the library's core feature of lazy type resolution. The library is designed to parse only what is necessary and resolve dependencies as they are encountered.
@@ -23,7 +23,7 @@ The proposed change is to make the scanning behavior dependent on the arguments 
     -   Rely on the `FieldType.Resolve()` method to lazily scan any imported packages for type definitions as needed. This handles single-file and multi-file cases efficiently.
 
 3.  **Directory-based Scanning**: If an argument is a directory, the tool should:
-    -   Scan **all `.go` files** within that directory (excluding `_test.go` files) using `go-scan.ScanPackage()`.
+    -   Scan **all `.go` files** within that directory (excluding `_test.go` files) using `go-scan.ScanPackageFromFilePath()`.
     -   This preserves the existing functionality for users who want to process an entire package at once.
 
 This approach provides users with more granular control over the scanning process, leading to better performance and a more intuitive user experience.
@@ -37,7 +37,7 @@ The `go-scan` library already provides the necessary APIs to implement this beha
 The `main.go` file of the example tools should be modified to first classify all command-line arguments into two categories: directories to be scanned fully, and files to be grouped by package.
 
 1.  Iterate through the arguments.
-2.  If an argument is a directory, add it to a list of directories to be scanned with `ScanPackage()`.
+2.  If an argument is a directory, add it to a list of directories to be scanned with `ScanPackageFromFilePath()`.
 3.  If an argument is a file, add it to a map where keys are directory paths (packages) and values are lists of file paths.
 4.  Process the directories and the file groups.
 
@@ -75,7 +75,7 @@ for _, path := range os.Args[1:] {
 // 2. Process directories
 for _, dirPath := range dirsToScan {
     slog.InfoContext(ctx, "Scanning directory", "path", dirPath)
-    pkgInfo, err := gscn.ScanPackage(ctx, dirPath)
+    pkgInfo, err := gscn.ScanPackageFromFilePath(ctx, dirPath)
     if err != nil {
         // handle error
         continue

--- a/docs/plan-support-recursive-definition.md
+++ b/docs/plan-support-recursive-definition.md
@@ -58,7 +58,7 @@ The logic within `Resolve` is as follows:
 
 3.  **Defer Cleanup:** A `defer` statement ensures the identifier is removed from the `resolving` map before the function returns, cleaning up the state for the next independent resolution task.
 
-4.  **Proceed with Resolution:** It continues with the standard resolution logic (checking cache, calling `ScanPackageByImport`, etc.).
+4.  **Proceed with Resolution:** It continues with the standard resolution logic (checking cache, calling `ScanPackageFromImportPath`, etc.).
 
 5.  **Cache Result:** Upon successfully finding a `TypeInfo`, it caches it in `ft.Definition` before returning. This is crucial for subsequent lookups, including those that break cycles.
 

--- a/docs/plan-symgo-refine.md
+++ b/docs/plan-symgo-refine.md
@@ -88,7 +88,7 @@ time=2025-09-03T02:30:22.458Z level=ERROR msg="invalid indirect of <Symbolic: re
 time=2025-09-03T02:30:22.458Z level=ERROR msg="symbolic execution failed for entry point" function=github.com/podhmo/go-scan/examples/convert-define.main error="symgo runtime error: invalid indirect of <Symbolic: result of external call to String> (type *object.SymbolicPlaceholder)\n\t/app/examples/convert-define/main.go:63:5:\n\t\tif *defineFile == \"\" {\n\t/app/examples/convert-define/main.go:48:1:\tin main\n\t\tfunc main() {\n"
 
 # Example of "could not scan package" and related warnings/errors
-time=2025-09-03T02:30:22.480Z level=WARN msg="could not scan package, treating as external" in_func=discoverModules in_func_pos=/app/examples/find-orphans/main.go:80:1 package=golang.org/x/mod/modfile error="ScanPackageByImport: could not find a module responsible for import path \"golang.org/x/mod/modfile\" in workspace"
+time=2025-09-03T02:30:22.480Z level=WARN msg="could not scan package, treating as external" in_func=discoverModules in_func_pos=/app/examples/find-orphans/main.go:80:1 package=golang.org/x/mod/modfile error="ScanPackageFromImportPath: could not find a module responsible for import path \"golang.org/x/mod/modfile\" in workspace"
 time=2025-09-03T02:30:22.481Z level=WARN msg="expected multi-return value on RHS of assignment" in_func=discoverModules in_func_pos=/app/examples/find-orphans/main.go:80:1 got_type=SYMBOLIC_PLACEHOLDER
 time=2025-09-03T02:30:22.481Z level=ERROR msg="unsupported assignment target: expected an identifier or selector, but got *ast.IndexExpr" in_func=discoverModules in_func_pos=/app/examples/find-orphans/main.go:80:1 pos=802529
 

--- a/docs/plan-walk-once.md
+++ b/docs/plan-walk-once.md
@@ -14,7 +14,7 @@ The key requirement is that this new tool must parse the target Go source files 
 Both `examples/derivingjson/main.go` and `examples/derivingbind/main.go` follow an identical pattern:
 
 1.  **Initialization**: Parse command-line arguments (file or directory paths) and instantiate a `goscan.Scanner`.
-2.  **Scanning**: Call `ScanPackage` or `ScanFiles` on the scanner instance to obtain a `scanner.PackageInfo`. This `PackageInfo` object is a complete representation of the parsed code for the target package.
+2.  **Scanning**: Call `ScanPackageFromFilePath` or `ScanFiles` on the scanner instance to obtain a `scanner.PackageInfo`. This `PackageInfo` object is a complete representation of the parsed code for the target package.
 3.  **Generation**: Pass the `goscan.Scanner` instance and the `scanner.PackageInfo` object to a dedicated `Generate` function. This function contains the core logic for that tool, iterating through the types in the `PackageInfo` and generating code based on specific annotations.
 4.  **Output**: The `Generate` function is responsible for creating and writing the final `_deriving.go` file, including managing imports.
 
@@ -57,7 +57,7 @@ The `Generate` functions in both `derivingjson` and `derivingbind` will be modif
 A new `main` package will be created (e.g., `examples/deriving-all/main.go`). This tool will:
 
 1.  **Setup**: Initialize a single `goscan.Scanner`.
-2.  **Scan**: For each target package specified in the command-line arguments, call `gscn.ScanPackage` or `gscn.ScanFiles` **once**.
+2.  **Scan**: For each target package specified in the command-line arguments, call `gscn.ScanPackageFromFilePath` or `gscn.ScanFiles` **once**.
 3.  **Define Generators**: Create a list of the refactored `Generate` functions to be executed.
     ```go
     generators := []func(context.Context, *goscan.Scanner, *scanner.PackageInfo) (*generator.GeneratedCode, error){

--- a/docs/trouble-symgo-identifier-not-found.md
+++ b/docs/trouble-symgo-identifier-not-found.md
@@ -77,7 +77,7 @@ func (e *Evaluator) getOrLoadPackage(ctx context.Context, path string) (*object.
 		return pkg, nil
 	}
 
-	scannedPkg, err := e.scanner.ScanPackageByImport(ctx, path)
+	scannedPkg, err := e.scanner.ScanPackageFromImportPath(ctx, path)
 	if err != nil {
 		// Even if scanning fails, we create a placeholder package object to cache the failure
 		// and avoid re-scanning. The ScannedInfo will be nil.
@@ -254,7 +254,7 @@ func (e *Evaluator) findDirectMethodOnType(ctx context.Context, typeInfo *scanne
 
 A critical aspect of the fix was to correctly handle packages that are outside the defined `scanPolicy`. For these packages, the evaluator should not have access to internal details like unexported constants.
 
-The `getOrLoadPackage` function still uses `ScanPackageByImport` to get package metadata (like the correct package name), but the subsequent population of the environment respects the policy.
+The `getOrLoadPackage` function still uses `ScanPackageFromImportPath` to get package metadata (like the correct package name), but the subsequent population of the environment respects the policy.
 
 ### Step 3.1: Modify `ensurePackageEnvPopulated`
 
@@ -383,9 +383,9 @@ func FuncB() string {
 	if err != nil {
 		t.Fatalf("NewInterpreter failed: %v", err)
 	}
-	loglibPkg, err := goscanner.ScanPackage(ctx, loglibModuleDir)
+	loglibPkg, err := goscanner.ScanPackageFromFilePath(ctx, loglibModuleDir)
 	if err != nil {
-		t.Fatalf("ScanPackage failed: %v", err)
+		t.Fatalf("ScanPackageFromFilePath failed: %v", err)
 	}
 	loglibFile := findFile(t, loglibPkg, "context.go")
 	if _, err := interp.Eval(ctx, loglibFile, loglibPkg); err != nil {
@@ -463,9 +463,9 @@ func (c *Client) GetValue() string {
 	if err != nil {
 		t.Fatalf("NewInterpreter failed: %v", err)
 	}
-	mainPkg, err := goscanner.ScanPackage(ctx, mainModuleDir)
+	mainPkg, err := goscanner.ScanPackageFromFilePath(ctx, mainModuleDir)
 	if err != nil {
-		t.Fatalf("ScanPackage failed: %v", err)
+		t.Fatalf("ScanPackageFromFilePath failed: %v", err)
 	}
 	mainFile := findFile(t, mainPkg, "main.go")
 	if _, err := interp.Eval(ctx, mainFile, mainPkg); err != nil {

--- a/docs/trouble-symgo.md
+++ b/docs/trouble-symgo.md
@@ -27,7 +27,7 @@ The verbose log file (`find-orphans-verbose-head.log`) is filled with a rapidly 
 
 - `getOrLoadPackage: requesting package`
 - `ResolvePackage: checking policy`
-- `ScanPackageByImport CACHE HIT`
+- `ScanPackageFromImportPath CACHE HIT`
 - `ensurePackageEnvPopulated: checking package`
 
 This pattern indicates that the evaluator is continuously trying to load and initialize packages it has already processed. The call stack is not correctly tracking which packages are currently under analysis, leading to a recursive reentry. For example, while analyzing package `A` which imports `B`, the evaluator starts analyzing `B`. If `B` (or a dependency of `B`) in turn imports `A`, the evaluator re-enters the analysis for `A` without realizing it's already in progress, leading to an infinite loop.

--- a/examples/convert-define/internal/interpreter.go
+++ b/examples/convert-define/internal/interpreter.go
@@ -206,7 +206,7 @@ func (r *Runner) resolveTypeFromExpr(e *evaluator.Evaluator, fscope *object.File
 		return nil, fmt.Errorf("package alias %q not found in imports", pkgIdent.Name)
 	}
 
-	pkgInfo, err := e.Scanner().ScanPackageByImport(context.Background(), pkgPath)
+	pkgInfo, err := e.Scanner().ScanPackageFromImportPath(context.Background(), pkgPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not scan package %q: %w", pkgPath, err)
 	}
@@ -238,7 +238,7 @@ func (r *Runner) handleRule(e *evaluator.Evaluator, fscope *object.FileScope, po
 	}
 
 	ctx := context.Background()
-	pkgInfo, err := e.Scanner().ScanPackageByImport(ctx, pkgPath)
+	pkgInfo, err := e.Scanner().ScanPackageFromImportPath(ctx, pkgPath)
 	if err != nil {
 		return e.NewError(pos, "could not scan package %q: %v", pkgPath, err)
 	}

--- a/examples/convert/main.go
+++ b/examples/convert/main.go
@@ -111,8 +111,8 @@ func run(ctx context.Context, pkgpath, workdir, output, pkgname, outputPkgPath s
 		return fmt.Errorf("failed to create scanner: %w", err)
 	}
 
-	// Use ScanPackageByImport to leverage the scanner's configured locator.
-	scannedPkg, err := s.ScanPackageByImport(ctx, pkgpath)
+	// Use ScanPackageFromImportPath to leverage the scanner's configured locator.
+	scannedPkg, err := s.ScanPackageFromImportPath(ctx, pkgpath)
 	if err != nil {
 		return fmt.Errorf("failed to scan package %q: %w", pkgpath, err)
 	}

--- a/examples/convert/parser/parser.go
+++ b/examples/convert/parser/parser.go
@@ -263,7 +263,7 @@ func resolveType(ctx context.Context, s *goscan.Scanner, info *model.ParsedInfo,
 	}
 
 	if resolvedTypeInfo != nil && resolvedTypeInfo.PkgPath != "" && resolvedTypeInfo.PkgPath != p.ImportPath {
-		resolvedPkgInfo, err := s.ScanPackageByImport(ctx, resolvedTypeInfo.PkgPath)
+		resolvedPkgInfo, err := s.ScanPackageFromImportPath(ctx, resolvedTypeInfo.PkgPath)
 		if err != nil {
 			return nil, fmt.Errorf("could not scan package %q for resolved type %s: %w", resolvedTypeInfo.PkgPath, resolvedTypeInfo.Name, err)
 		}
@@ -297,7 +297,7 @@ func collectFields(ctx context.Context, s *goscan.Scanner, info *model.ParsedInf
 			}
 
 			if fieldTypeInfo != nil && fieldTypeInfo.PkgPath != "" && fieldTypeInfo.PkgPath != p.ImportPath && !f.Type.IsResolvedByConfig {
-				fieldPkgInfo, err := s.ScanPackageByImport(ctx, fieldTypeInfo.PkgPath)
+				fieldPkgInfo, err := s.ScanPackageFromImportPath(ctx, fieldTypeInfo.PkgPath)
 				if err != nil {
 					return nil, fmt.Errorf("could not scan package for field type %s: %w", fieldTypeInfo.Name, err)
 				}
@@ -317,7 +317,7 @@ func collectFields(ctx context.Context, s *goscan.Scanner, info *model.ParsedInf
 				slog.WarnContext(ctx, "Resolved embedded type is not a struct, skipping", "type", f.Type.String())
 				continue
 			}
-			embeddedPkgInfo, err := s.ScanPackageByImport(ctx, fieldTypeInfo.PkgPath)
+			embeddedPkgInfo, err := s.ScanPackageFromImportPath(ctx, fieldTypeInfo.PkgPath)
 			if err != nil {
 				return nil, fmt.Errorf("could not scan package for embedded struct %s: %w", fieldTypeInfo.Name, err)
 			}

--- a/examples/convert/parser/parser_test.go
+++ b/examples/convert/parser/parser_test.go
@@ -17,12 +17,12 @@ import (
 
 // MockResolver is a mock implementation of PackageResolver for tests.
 type MockResolver struct {
-	ScanPackageByImportFunc func(ctx context.Context, importPath string) (*scanner.PackageInfo, error)
+	ScanPackageFromImportPathFunc func(ctx context.Context, importPath string) (*scanner.PackageInfo, error)
 }
 
-func (m *MockResolver) ScanPackageByImport(ctx context.Context, importPath string) (*scanner.PackageInfo, error) {
-	if m.ScanPackageByImportFunc != nil {
-		return m.ScanPackageByImportFunc(ctx, importPath)
+func (m *MockResolver) ScanPackageFromImportPath(ctx context.Context, importPath string) (*scanner.PackageInfo, error) {
+	if m.ScanPackageFromImportPathFunc != nil {
+		return m.ScanPackageFromImportPathFunc(ctx, importPath)
 	}
 	return nil, nil // Default mock behavior
 }
@@ -96,9 +96,9 @@ type MyTime time.Time
 		t.Fatalf("goscan.New() failed: %v", err)
 	}
 
-	pkg, err := s.ScanPackage(context.Background(), tmpdir)
+	pkg, err := s.ScanPackageFromFilePath(context.Background(), tmpdir)
 	if err != nil {
-		t.Fatalf("ScanPackage() failed: %v", err)
+		t.Fatalf("ScanPackageFromFilePath() failed: %v", err)
 	}
 
 	got, err := Parse(context.Background(), s, pkg)

--- a/examples/deriving-all/main.go
+++ b/examples/deriving-all/main.go
@@ -201,7 +201,7 @@ func main() {
 	// Process directories
 	for _, dirPath := range dirsToScan {
 		slog.InfoContext(ctx, "Scanning directory", "path", dirPath)
-		pkgInfo, err := gscn.ScanPackage(ctx, dirPath)
+		pkgInfo, err := gscn.ScanPackageFromFilePath(ctx, dirPath)
 		if err != nil {
 			slog.ErrorContext(ctx, "Error scanning package", "path", dirPath, slog.Any("error", err))
 			errorCount++

--- a/examples/derivingbind/main.go
+++ b/examples/derivingbind/main.go
@@ -182,7 +182,7 @@ func main() {
 	// Process directories
 	for _, dirPath := range dirsToScan {
 		slog.InfoContext(ctx, "Scanning directory", "path", dirPath)
-		pkgInfo, err := gscn.ScanPackage(ctx, dirPath)
+		pkgInfo, err := gscn.ScanPackageFromFilePath(ctx, dirPath)
 		if err != nil {
 			slog.ErrorContext(ctx, "Error scanning package", "path", dirPath, slog.Any("error", err))
 			errorCount++

--- a/examples/derivingjson/gen/generate.go
+++ b/examples/derivingjson/gen/generate.go
@@ -113,7 +113,7 @@ func Generate(ctx context.Context, gscn *goscan.Scanner, pkgInfo *scanner.Packag
 						interfaceDefiningPkgImportPath = field.Type.FullImportPath
 					} else if interfaceDef.FilePath != "" {
 						interfaceDir := filepath.Dir(interfaceDef.FilePath)
-						scannedPkgForInterfaceFile, errPkgScan := gscn.ScanPackage(ctx, interfaceDir)
+						scannedPkgForInterfaceFile, errPkgScan := gscn.ScanPackageFromFilePath(ctx, interfaceDir)
 						if errPkgScan == nil && scannedPkgForInterfaceFile != nil && scannedPkgForInterfaceFile.ImportPath != "" {
 							interfaceDefiningPkgImportPath = scannedPkgForInterfaceFile.ImportPath
 						} else {
@@ -139,7 +139,7 @@ func Generate(ctx context.Context, gscn *goscan.Scanner, pkgInfo *scanner.Packag
 
 				searchPkgs := []*scanner.PackageInfo{pkgInfo}
 				if interfaceDefiningPkgImportPath != "" && interfaceDefiningPkgImportPath != pkgInfo.ImportPath {
-					scannedInterfacePkg, errScan := gscn.ScanPackageByImport(ctx, interfaceDefiningPkgImportPath)
+					scannedInterfacePkg, errScan := gscn.ScanPackageFromImportPath(ctx, interfaceDefiningPkgImportPath)
 					if errScan == nil && scannedInterfacePkg != nil {
 						if !isPackageInSlice(searchPkgs, scannedInterfacePkg.ImportPath) {
 							searchPkgs = append(searchPkgs, scannedInterfacePkg)
@@ -190,7 +190,7 @@ func Generate(ctx context.Context, gscn *goscan.Scanner, pkgInfo *scanner.Packag
 					definingPkgPath := pkgInfo.ImportPath
 					if resolvedFieldType.FilePath != "" {
 						dir := filepath.Dir(resolvedFieldType.FilePath)
-						definingActualPkg, errScan := gscn.ScanPackage(ctx, dir)
+						definingActualPkg, errScan := gscn.ScanPackageFromFilePath(ctx, dir)
 						if errScan == nil && definingActualPkg != nil && definingActualPkg.ImportPath != "" {
 							definingPkgPath = definingActualPkg.ImportPath
 						} else if errScan != nil {

--- a/examples/derivingjson/main.go
+++ b/examples/derivingjson/main.go
@@ -182,7 +182,7 @@ func main() {
 	// Process directories
 	for _, dirPath := range dirsToScan {
 		slog.InfoContext(ctx, "Scanning directory", "path", dirPath)
-		pkgInfo, err := gscn.ScanPackage(ctx, dirPath)
+		pkgInfo, err := gscn.ScanPackageFromFilePath(ctx, dirPath)
 		if err != nil {
 			slog.ErrorContext(ctx, "Error scanning package", "path", dirPath, slog.Any("error", err))
 			errorCount++

--- a/examples/docgen/analyzer.go
+++ b/examples/docgen/analyzer.go
@@ -143,7 +143,7 @@ func (a *Analyzer) analyzeTopLevelHandleFunc(ctx context.Context, interp *symgo.
 
 // Analyze analyzes the package starting from a specific entrypoint function.
 func (a *Analyzer) Analyze(ctx context.Context, importPath string, entrypoint string) error {
-	pkg, err := a.Scanner.ScanPackageByImport(ctx, importPath)
+	pkg, err := a.Scanner.ScanPackageFromImportPath(ctx, importPath)
 	if err != nil {
 		return fmt.Errorf("failed to load sample API package: %w", err)
 	}
@@ -370,8 +370,8 @@ func (a *Analyzer) analyzeHandlerBody(ctx context.Context, handler *symgo.Functi
 	a.operationStack = append(a.operationStack, op)
 
 	// The handler's package is already available on the symgo.Function object.
-	// We can use ScanPackageByImport, which is more robust and fits the new design.
-	pkg, err := a.Scanner.ScanPackageByImport(ctx, handler.Package.ImportPath)
+	// We can use ScanPackageFromImportPath, which is more robust and fits the new design.
+	pkg, err := a.Scanner.ScanPackageFromImportPath(ctx, handler.Package.ImportPath)
 	if err != nil {
 		a.logger.WarnContext(ctx, "failed to get package for handler",
 			"handler", handler.Name.Name,

--- a/examples/docgen/main_test.go
+++ b/examples/docgen/main_test.go
@@ -298,7 +298,7 @@ func TestDocgen_fullParameters(t *testing.T) {
 
 	// Assert that the tracer visited all nodes in the target handler.
 	// This confirms the symbolic execution engine is not skipping parts of the function.
-	scannedPkg, err := s.ScanPackageByImport(ctx, apiPath)
+	scannedPkg, err := s.ScanPackageFromImportPath(ctx, apiPath)
 	if err != nil {
 		t.Fatalf("Could not re-scan package to find handler AST: %v", err)
 	}

--- a/examples/docgen/patterns/patterns.go
+++ b/examples/docgen/patterns/patterns.go
@@ -460,7 +460,7 @@ func NewSymbolicInstance(interp *symgo.Interpreter, fqtn string) symgo.Object {
 	pkgPath := fqtn[:lastDot]
 	typeName := fqtn[lastDot+1:]
 
-	pkg, err := interp.Scanner().ScanPackageByImport(context.Background(), pkgPath)
+	pkg, err := interp.Scanner().ScanPackageFromImportPath(context.Background(), pkgPath)
 	if err != nil {
 		return &symgo.Error{Message: fmt.Sprintf("could not load package %s: %v", pkgPath, err)}
 	}

--- a/examples/find-orphans/main.go
+++ b/examples/find-orphans/main.go
@@ -646,7 +646,7 @@ func (a *analyzer) analyze(ctx context.Context, asJSON bool) error {
 		if !isAppMode && a.includeTests && isTestFunction(ep.Def) {
 			// Lazily load the type info for *testing.T once.
 			if testingT_FieldType == nil {
-				testingPkg, err := a.s.ScanPackageByImport(ctx, "testing")
+				testingPkg, err := a.s.ScanPackageFromImportPath(ctx, "testing")
 				if err != nil {
 					slog.WarnContext(ctx, "could not scan 'testing' package, cannot create symbolic *testing.T", "error", err)
 				} else {
@@ -835,7 +835,7 @@ func (a *analyzer) Visit(pkg *goscan.PackageImports) ([]string, error) {
 	if pkg.ImportPath == "C" {
 		return nil, nil
 	}
-	fullPkg, err := a.s.ScanPackageByImport(a.ctx, pkg.ImportPath)
+	fullPkg, err := a.s.ScanPackageFromImportPath(a.ctx, pkg.ImportPath)
 	if err != nil {
 		slog.WarnContext(a.ctx, "could not scan package", "package", pkg.ImportPath, "error", err)
 		return nil, nil // Continue even if a package fails to scan

--- a/examples/minigo/gen_bindings.go
+++ b/examples/minigo/gen_bindings.go
@@ -87,9 +87,9 @@ func generate(ctx context.Context, s *goscan.Scanner, outputDir, pkgPath string)
 	var pkgInfo *goscan.Package
 	var err error
 	if strings.HasPrefix(pkgPath, "./") || strings.HasPrefix(pkgPath, "/") {
-		pkgInfo, err = s.ScanPackage(ctx, pkgPath)
+		pkgInfo, err = s.ScanPackageFromFilePath(ctx, pkgPath)
 	} else {
-		pkgInfo, err = s.ScanPackageByImport(ctx, pkgPath)
+		pkgInfo, err = s.ScanPackageFromImportPath(ctx, pkgPath)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to scan package %s: %w", pkgPath, err)

--- a/goscan.go
+++ b/goscan.go
@@ -162,12 +162,6 @@ func (s *Scanner) TypeInfoFromExpr(ctx context.Context, expr ast.Expr, currentTy
 	return s.scanner.TypeInfoFromExpr(ctx, expr, currentTypeParams, info, importLookup)
 }
 
-// ScannerForSymgo is a temporary helper for tests to access the internal scanner.
-// TODO: Refactor evaluator to use the top-level goscan.Scanner instead.
-func (s *Scanner) ScannerForSymgo() (*scanner.Scanner, error) {
-	return s.scanner, nil
-}
-
 // ModulePath returns the module path from the scanner's locator.
 func (s *Scanner) ModulePath() string {
 	if s.locator == nil {

--- a/goscan.go
+++ b/goscan.go
@@ -49,7 +49,7 @@ const (
 // Scanner instances are stateful regarding which files have been visited (parsed).
 type Scanner struct {
 	*Config
-	packageCache          map[string]*Package // Cache for PackageInfo from ScanPackage/ScanPackageByImport, key is import path
+	packageCache          map[string]*Package // Cache for PackageInfo from ScanPackageFromFilePath/ScanPackageFromImportPath, key is import path
 	visitedFiles          map[string]struct{} // Set of visited (parsed) file absolute paths for this Scanner instance.
 	mu                    sync.RWMutex
 	CachePath             string
@@ -240,7 +240,7 @@ func (s *Scanner) Scan(ctx context.Context, patterns ...string) ([]*Package, err
 				}
 
 				if hasGoFiles {
-					pkg, err := s.ScanPackage(ctx, path)
+					pkg, err := s.ScanPackageFromFilePath(ctx, path)
 					if err != nil {
 						// Log error but continue walking
 						slog.WarnContext(ctx, "failed to scan package during wildcard walk", "path", path, "error", err)
@@ -270,7 +270,7 @@ func (s *Scanner) Scan(ctx context.Context, patterns ...string) ([]*Package, err
 
 			var pkg *Package
 			if info.IsDir() {
-				pkg, err = s.ScanPackage(ctx, absPath)
+				pkg, err = s.ScanPackageFromFilePath(ctx, absPath)
 			} else {
 				pkg, err = s.ScanFiles(ctx, []string{absPath})
 			}
@@ -657,8 +657,8 @@ func (s *Scanner) privateScan(ctx context.Context, pkgDirAbs string, importPath 
 	return pkgInfo, nil
 }
 
-// ScanPackage scans a single package at a given directory path.
-func (s *Scanner) ScanPackage(ctx context.Context, pkgPath string) (*scanner.PackageInfo, error) {
+// ScanPackageFromFilePath scans a single package at a given directory path.
+func (s *Scanner) ScanPackageFromFilePath(ctx context.Context, pkgPath string) (*scanner.PackageInfo, error) {
 	var pkgDirAbs string
 	var err error
 	if filepath.IsAbs(pkgPath) {
@@ -929,11 +929,11 @@ func isDir(path string) bool {
 	return info.IsDir()
 }
 
-// ScanPackageByImport scans a single Go package identified by its import path.
-func (s *Scanner) ScanPackageByImport(ctx context.Context, importPath string) (*scanner.PackageInfo, error) {
+// ScanPackageFromImportPath scans a single Go package identified by its import path.
+func (s *Scanner) ScanPackageFromImportPath(ctx context.Context, importPath string) (*scanner.PackageInfo, error) {
 	loc, err := s.locatorForImportPath(importPath)
 	if err != nil {
-		return nil, fmt.Errorf("ScanPackageByImport: %w", err)
+		return nil, fmt.Errorf("ScanPackageFromImportPath: %w", err)
 	}
 	pkgDirAbs, err := loc.FindPackageDir(importPath)
 	if err != nil {
@@ -1057,7 +1057,7 @@ func (s *Scanner) SaveSymbolCache(ctx context.Context) error {
 // ListExportedSymbols scans a package by its import path and returns a list of all
 // its exported top-level symbol names (functions, types, and constants).
 func (s *Scanner) ListExportedSymbols(ctx context.Context, pkgPath string) ([]string, error) {
-	pkgInfo, err := s.ScanPackageByImport(ctx, pkgPath)
+	pkgInfo, err := s.ScanPackageFromImportPath(ctx, pkgPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan package %s: %w", pkgPath, err)
 	}
@@ -1094,7 +1094,7 @@ func (s *Scanner) ListExportedSymbols(ctx context.Context, pkgPath string) ([]st
 //
 // It first checks the persistent symbol cache (if enabled and loaded).
 // If not found in the cache, it triggers a scan of the relevant package
-// (using `ScanPackageByImport`) to populate caches and then re-checks.
+// (using `ScanPackageFromImportPath`) to populate caches and then re-checks.
 // Finally, it inspects the `PackageInfo` obtained from the scan.
 func (s *Scanner) FindSymbolDefinitionLocation(ctx context.Context, symbolFullName string) (string, error) {
 	lastDot := strings.LastIndex(symbolFullName, ".")
@@ -1117,7 +1117,7 @@ func (s *Scanner) FindSymbolDefinitionLocation(ctx context.Context, symbolFullNa
 		}
 	}
 	// If symbol not found in cache, try to scan the package.
-	pkgInfo, err := s.ScanPackageByImport(ctx, importPath) // This will parse unvisited files and update caches
+	pkgInfo, err := s.ScanPackageFromImportPath(ctx, importPath) // This will parse unvisited files and update caches
 	if err != nil {
 		return "", fmt.Errorf("scan for package %s (for symbol %s) failed: %w", importPath, symbolName, err)
 	}
@@ -1135,7 +1135,7 @@ func (s *Scanner) FindSymbolDefinitionLocation(ctx context.Context, symbolFullNa
 		}
 	}
 
-	// If still not found via cache, check the pkgInfo returned by the ScanPackageByImport call.
+	// If still not found via cache, check the pkgInfo returned by the ScanPackageFromImportPath call.
 	// This pkgInfo contains symbols from files *parsed in that specific call*.
 	if pkgInfo != nil {
 		targetFilePath := ""

--- a/goscan_crosspkg_test.go
+++ b/goscan_crosspkg_test.go
@@ -65,9 +65,9 @@ type C struct {
 	}
 
 	// 5. We start by scanning package 'a' to find type 'A'.
-	pkgA, err := s.ScanPackageByImport(context.Background(), testModulePath+"/a")
+	pkgA, err := s.ScanPackageFromImportPath(context.Background(), testModulePath+"/a")
 	if err != nil {
-		t.Fatalf("ScanPackageByImport('a') failed: %v", err)
+		t.Fatalf("ScanPackageFromImportPath('a') failed: %v", err)
 	}
 
 	typeA := pkgA.Lookup("A")

--- a/goscan_id_test.go
+++ b/goscan_id_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/podhmo/go-scan"
+	goscan "github.com/podhmo/go-scan"
 	"github.com/podhmo/go-scan/scanner"
 	"github.com/podhmo/go-scan/scantest"
 )

--- a/goscan_id_test.go
+++ b/goscan_id_test.go
@@ -31,9 +31,9 @@ func TestPackageID_SimpleModule(t *testing.T) {
 	}
 
 	t.Run("standard library package", func(t *testing.T) {
-		pkg, err := s.ScanPackageByImport(context.Background(), "example.com/simple/lib")
+		pkg, err := s.ScanPackageFromImportPath(context.Background(), "example.com/simple/lib")
 		if err != nil {
-			t.Fatalf("ScanPackageByImport failed: %v", err)
+			t.Fatalf("ScanPackageFromImportPath failed: %v", err)
 		}
 		const expectedID = "example.com/simple/lib"
 		if pkg.ID != expectedID {
@@ -45,9 +45,9 @@ func TestPackageID_SimpleModule(t *testing.T) {
 	})
 
 	t.Run("main package", func(t *testing.T) {
-		pkg, err := s.ScanPackageByImport(context.Background(), "example.com/simple/cmd/app")
+		pkg, err := s.ScanPackageFromImportPath(context.Background(), "example.com/simple/cmd/app")
 		if err != nil {
-			t.Fatalf("ScanPackageByImport failed: %v", err)
+			t.Fatalf("ScanPackageFromImportPath failed: %v", err)
 		}
 		const expectedID = "example.com/simple/cmd/app.main"
 		const expectedImportPath = "example.com/simple/cmd/app"
@@ -97,9 +97,9 @@ func TestPackageID_Workspace(t *testing.T) {
 	}
 
 	t.Run("first main package", func(t *testing.T) {
-		pkg, err := s.ScanPackageByImport(context.Background(), "example.com/workspace/app1")
+		pkg, err := s.ScanPackageFromImportPath(context.Background(), "example.com/workspace/app1")
 		if err != nil {
-			t.Fatalf("ScanPackageByImport for app1 failed: %v", err)
+			t.Fatalf("ScanPackageFromImportPath for app1 failed: %v", err)
 		}
 		const expectedID = "example.com/workspace/app1.main"
 		if pkg.ID != expectedID {
@@ -108,9 +108,9 @@ func TestPackageID_Workspace(t *testing.T) {
 	})
 
 	t.Run("second main package", func(t *testing.T) {
-		pkg, err := s.ScanPackageByImport(context.Background(), "example.com/workspace/app2")
+		pkg, err := s.ScanPackageFromImportPath(context.Background(), "example.com/workspace/app2")
 		if err != nil {
-			t.Fatalf("ScanPackageByImport for app2 failed: %v", err)
+			t.Fatalf("ScanPackageFromImportPath for app2 failed: %v", err)
 		}
 		const expectedID = "example.com/workspace/app2.main"
 		if pkg.ID != expectedID {
@@ -168,9 +168,9 @@ replace example.com/util => ` + utilModuleDir + `
 		t.Fatalf("New() failed: %v", err)
 	}
 
-	pkg, err := s.ScanPackageByImport(context.Background(), "example.com/util/helper")
+	pkg, err := s.ScanPackageFromImportPath(context.Background(), "example.com/util/helper")
 	if err != nil {
-		t.Fatalf("ScanPackageByImport failed: %v", err)
+		t.Fatalf("ScanPackageFromImportPath failed: %v", err)
 	}
 	const expectedID = "example.com/util/helper"
 	if pkg.ID != expectedID {

--- a/goscan_stdlib_test.go
+++ b/goscan_stdlib_test.go
@@ -18,7 +18,7 @@ func TestScanStdlib_SucceedsWithoutOverride(t *testing.T) {
 		t.Fatalf("New() failed: %+v", err)
 	}
 
-	pkg, err := s.ScanPackageByImport(ctx, "time")
+	pkg, err := s.ScanPackageFromImportPath(ctx, "time")
 	if err != nil {
 		t.Fatalf("expected no error when scanning stdlib package 'time', but got: %v", err)
 	}

--- a/goscan_walk_test.go
+++ b/goscan_walk_test.go
@@ -8,15 +8,15 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestScanPackageImports(t *testing.T) {
+func TestScanPackageFromFilePathImports(t *testing.T) {
 	s, err := New(WithWorkDir("./testdata/walk"))
 	if err != nil {
 		t.Fatalf("New() failed: %v", err)
 	}
 
-	pkg, err := s.Walker.ScanPackageImports(context.Background(), "github.com/podhmo/go-scan/testdata/walk/a")
+	pkg, err := s.Walker.ScanPackageFromFilePathImports(context.Background(), "github.com/podhmo/go-scan/testdata/walk/a")
 	if err != nil {
-		t.Fatalf("ScanPackageImports failed: %v", err)
+		t.Fatalf("ScanPackageFromFilePathImports failed: %v", err)
 	}
 
 	if pkg.Name != "a" {

--- a/scanner/enum_test.go
+++ b/scanner/enum_test.go
@@ -82,7 +82,7 @@ func TestEnumScanning_LazyLoaded(t *testing.T) {
 
 	pkgCache := make(map[string]*PackageInfo)
 	mockResolver := &MockResolver{
-		ScanPackageByImportFunc: func(ctx context.Context, importPath string) (*PackageInfo, error) {
+		ScanPackageFromImportPathFunc: func(ctx context.Context, importPath string) (*PackageInfo, error) {
 			if pkg, found := pkgCache[importPath]; found {
 				return pkg, nil
 			}

--- a/scanner/models.go
+++ b/scanner/models.go
@@ -46,7 +46,7 @@ const (
 // PackageResolver is an interface that can resolve an import path to a package definition.
 // It is implemented by the top-level typescanner.Scanner to enable lazy, cached lookups.
 type PackageResolver interface {
-	ScanPackageByImport(ctx context.Context, importPath string) (*PackageInfo, error)
+	ScanPackageFromImportPath(ctx context.Context, importPath string) (*PackageInfo, error)
 }
 
 // PackageInfo holds all the extracted information from a single package.
@@ -454,7 +454,7 @@ func (ft *FieldType) Resolve(ctx context.Context) (*TypeInfo, error) {
 	}
 
 	// --- Resolve the package ---
-	pkgInfo, err := ft.Resolver.ScanPackageByImport(ctx, ft.FullImportPath)
+	pkgInfo, err := ft.Resolver.ScanPackageFromImportPath(ctx, ft.FullImportPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan package %q for type %q: %w", ft.FullImportPath, ft.TypeName, err)
 	}

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -83,12 +83,12 @@ func (s *Scanner) ResolveType(ctx context.Context, fieldType *FieldType) (*TypeI
 	return fieldType.Resolve(ctxWithPath)
 }
 
-// ScanPackageByImport makes scanner.Scanner implement the PackageResolver interface.
-func (s *Scanner) ScanPackageByImport(ctx context.Context, importPath string) (*PackageInfo, error) {
+// ScanPackageFromImportPath makes scanner.Scanner implement the PackageResolver interface.
+func (s *Scanner) ScanPackageFromImportPath(ctx context.Context, importPath string) (*PackageInfo, error) {
 	if s.resolver == nil {
 		return nil, fmt.Errorf("scanner's internal resolver is not set, cannot scan by import path %q", importPath)
 	}
-	return s.resolver.ScanPackageByImport(ctx, importPath)
+	return s.resolver.ScanPackageFromImportPath(ctx, importPath)
 }
 
 // ScanFiles parses a specific list of .go files and returns PackageInfo.
@@ -118,8 +118,8 @@ func (s *Scanner) ScanFilesWithKnownImportPath(ctx context.Context, filePaths []
 	return s.scanGoFiles(ctx, filePaths, pkgDirPath, canonicalImportPath)
 }
 
-// ScanPackageImports parses only the import declarations from a set of Go files.
-func (s *Scanner) ScanPackageImports(ctx context.Context, filePaths []string, pkgDirPath string, canonicalImportPath string) (*PackageImports, error) {
+// ScanPackageFromFilePathImports parses only the import declarations from a set of Go files.
+func (s *Scanner) ScanPackageFromFilePathImports(ctx context.Context, filePaths []string, pkgDirPath string, canonicalImportPath string) (*PackageImports, error) {
 	info := &PackageImports{
 		ImportPath:  canonicalImportPath,
 		FileImports: make(map[string][]string),

--- a/symgo/README.md
+++ b/symgo/README.md
@@ -165,7 +165,7 @@ func main() {
 	}
 
 	// 3. Scan the package. This parses the files and populates type information.
-	pkg, err := s.ScanPackageByImport(context.Background(), "myapp")
+	pkg, err := s.ScanPackageFromImportPath(context.Background(), "myapp")
 	if err != nil {
 		panic(err)
 	}

--- a/symgo/evaluator/evaluator_call_test.go
+++ b/symgo/evaluator/evaluator_call_test.go
@@ -695,7 +695,7 @@ func main() {
 
 		// Manually create the placeholder for the external function call
 		// This simulates what would happen inside the evaluator when it encounters helper.GetPair
-		helperPkg, err := s.ScanPackageByImport(ctx, "example.com/me/helper")
+		helperPkg, err := s.ScanPackageFromImportPath(ctx, "example.com/me/helper")
 		if err != nil {
 			return fmt.Errorf("failed to scan helper package: %w", err)
 		}

--- a/symgo/evaluator/resolver.go
+++ b/symgo/evaluator/resolver.go
@@ -164,5 +164,5 @@ func (r *Resolver) ResolvePackage(ctx context.Context, path string) (*scanner.Pa
 
 // resolvePackageWithoutPolicyCheck resolves a package without enforcing the scan policy.
 func (r *Resolver) resolvePackageWithoutPolicyCheck(ctx context.Context, path string) (*scanner.PackageInfo, error) {
-	return r.scanner.ScanPackageByImport(ctx, path)
+	return r.scanner.ScanPackageFromImportPath(ctx, path)
 }

--- a/symgo/symgo.go
+++ b/symgo/symgo.go
@@ -229,7 +229,7 @@ func (i *Interpreter) BindInterface(ctx context.Context, ifaceTypeName string, c
 		return fmt.Errorf("concrete type name must be fully qualified (e.g., 'bytes.Buffer'), got %s", concreteTypeName)
 	}
 
-	pkg, err := i.scanner.ScanPackageByImport(ctx, pkgPath)
+	pkg, err := i.scanner.ScanPackageFromImportPath(ctx, pkgPath)
 	if err != nil {
 		return fmt.Errorf("could not scan package %q for concrete type: %w", pkgPath, err)
 	}
@@ -259,7 +259,7 @@ func (i *Interpreter) NewSymbolic(ctx context.Context, name string, typeName str
 		return nil, fmt.Errorf("type name must be fully qualified (e.g., 'io.Writer'), got %s", typeName)
 	}
 
-	pkg, err := i.scanner.ScanPackageByImport(ctx, pkgPath)
+	pkg, err := i.scanner.ScanPackageFromImportPath(ctx, pkgPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not scan package %q for symbolic var type: %w", pkgPath, err)
 	}
@@ -304,7 +304,7 @@ func splitQualifiedName(name string) (pkgPath, typeName string) {
 	// For "bytes.Buffer", the import path is "bytes".
 	// For "mypackage.MyType" in the current module, it might be "mymodule/mypackage".
 	// The scanner handles resolving this. We just need to provide the parts.
-	// The logic in BindInterface and NewSymbolic which calls scanner.ScanPackageByImport
+	// The logic in BindInterface and NewSymbolic which calls scanner.ScanPackageFromImportPath
 	// with the pkgCandidate works correctly for both "bytes" and "github.com/foo/bar".
 	return pkgCandidate, typeName
 }

--- a/symgo/symgo_interface_resolution_test.go
+++ b/symgo/symgo_interface_resolution_test.go
@@ -110,12 +110,12 @@ func TestInterfaceResolution(t *testing.T) {
 
 			ctx := t.Context()
 			for _, pkgPath := range p {
-				if _, err := s.ScanPackageByImport(ctx, pkgPath); err != nil {
+				if _, err := s.ScanPackageFromImportPath(ctx, pkgPath); err != nil {
 					t.Fatalf("could not scan package %s: %v", pkgPath, err)
 				}
 			}
 
-			mainPkgInfo, err := s.ScanPackageByImport(ctx, "example.com/me")
+			mainPkgInfo, err := s.ScanPackageFromImportPath(ctx, "example.com/me")
 			if err != nil {
 				t.Fatalf("could not get main package: %v", err)
 			}
@@ -239,12 +239,12 @@ func TestInterfaceResolutionWithPointerReceiver(t *testing.T) {
 
 			ctx := t.Context()
 			for _, pkgPath := range p {
-				if _, err := s.ScanPackageByImport(ctx, pkgPath); err != nil {
+				if _, err := s.ScanPackageFromImportPath(ctx, pkgPath); err != nil {
 					t.Fatalf("could not scan package %s: %v", pkgPath, err)
 				}
 			}
 
-			mainPkgInfo, err := s.ScanPackageByImport(ctx, "example.com/me")
+			mainPkgInfo, err := s.ScanPackageFromImportPath(ctx, "example.com/me")
 			if err != nil {
 				t.Fatalf("could not get main package: %v", err)
 			}
@@ -369,12 +369,12 @@ func TestInterfaceResolutionWithValueReceiver(t *testing.T) {
 
 			ctx := t.Context()
 			for _, pkgPath := range p {
-				if _, err := s.ScanPackageByImport(ctx, pkgPath); err != nil {
+				if _, err := s.ScanPackageFromImportPath(ctx, pkgPath); err != nil {
 					t.Fatalf("could not scan package %s: %v", pkgPath, err)
 				}
 			}
 
-			mainPkgInfo, err := s.ScanPackageByImport(ctx, "example.com/me")
+			mainPkgInfo, err := s.ScanPackageFromImportPath(ctx, "example.com/me")
 			if err != nil {
 				t.Fatalf("could not get main package: %v", err)
 			}
@@ -498,12 +498,12 @@ func TestInterfaceResolutionWithEmbeddedInterfaces(t *testing.T) {
 
 	ctx := t.Context()
 	for _, pkgPath := range []string{"example.com/me/def", "example.com/me/impl", "example.com/me"} {
-		if _, err := s.ScanPackageByImport(ctx, pkgPath); err != nil {
+		if _, err := s.ScanPackageFromImportPath(ctx, pkgPath); err != nil {
 			t.Fatalf("could not scan package %s: %v", pkgPath, err)
 		}
 	}
 
-	mainPkgInfo, err := s.ScanPackageByImport(ctx, "example.com/me")
+	mainPkgInfo, err := s.ScanPackageFromImportPath(ctx, "example.com/me")
 	if err != nil {
 		t.Fatalf("could not get main package: %v", err)
 	}

--- a/symgo/symgo_scope_test.go
+++ b/symgo/symgo_scope_test.go
@@ -46,9 +46,9 @@ func DoSomething() {}
 		t.Fatalf("NewInterpreter failed: %v", err)
 	}
 
-	libPkg, err := interp.Scanner().ScanPackageByImport(ctx, "example.com/myapp/lib")
+	libPkg, err := interp.Scanner().ScanPackageFromImportPath(ctx, "example.com/myapp/lib")
 	if err != nil {
-		t.Fatalf("ScanPackageByImport for lib failed: %v", err)
+		t.Fatalf("ScanPackageFromImportPath for lib failed: %v", err)
 	}
 
 	doSomethingFunc := findFunc(t, libPkg, "DoSomething")

--- a/type_relation.go
+++ b/type_relation.go
@@ -189,7 +189,7 @@ func (s *Scanner) findDirectMethodInfoOnType(ctx context.Context, typeInfo *scan
 	if !exists {
 		// If not in cache, use the scanner to get the package info.
 		var err error
-		methodPkg, err = s.ScanPackage(ctx, typeInfo.PkgPath)
+		methodPkg, err = s.ScanPackageFromFilePath(ctx, typeInfo.PkgPath)
 		if err != nil {
 			// Suppress errors that are expected for certain types (e.g., built-ins, unresolved packages).
 			if strings.Contains(err.Error(), "cannot find package") || strings.Contains(err.Error(), "no such file or directory") {

--- a/type_relation_test.go
+++ b/type_relation_test.go
@@ -22,13 +22,13 @@ func TestImplements_New(t *testing.T) {
 	ifacesPath := filepath.Join(s.locator.RootDir(), "ifaces")
 	implsPath := filepath.Join(s.locator.RootDir(), "impls")
 
-	_, err = s.ScanPackage(ctx, ifacesPath)
+	_, err = s.ScanPackageFromFilePath(ctx, ifacesPath)
 	if err != nil {
-		t.Fatalf("ScanPackage(%q) failed: %v", ifacesPath, err)
+		t.Fatalf("ScanPackageFromFilePath(%q) failed: %v", ifacesPath, err)
 	}
-	_, err = s.ScanPackage(ctx, implsPath)
+	_, err = s.ScanPackageFromFilePath(ctx, implsPath)
 	if err != nil {
-		t.Fatalf("ScanPackage(%q) failed: %v", implsPath, err)
+		t.Fatalf("ScanPackageFromFilePath(%q) failed: %v", implsPath, err)
 	}
 
 	// Helper to get a TypeInfo from a fully qualified name


### PR DESCRIPTION
This pull request refactors the API for scanning Go packages throughout the documentation and code samples, standardizing the naming and usage of package scanning methods. The main change is the replacement of the ambiguous `ScanPackage` and `ScanPackageByImport` methods with more explicit `ScanPackageFromFilePath` and `ScanPackageFromImportPath` methods, improving clarity and consistency in both function names and documentation. This affects example code, test cases, and explanatory comments in multiple files.

### API renaming and standardization

* Renamed all instances of `ScanPackage` to `ScanPackageFromFilePath` and `ScanPackageByImport` to `ScanPackageFromImportPath` in documentation, example code, and comments to clarify intent and usage. This change is reflected in Go code samples, integration tests, and explanatory markdown files.