### PR TITLE
fix: improve error handling and logging in method resolution

### DIFF
--- a/symgo/evaluator/accessor.go
+++ b/symgo/evaluator/accessor.go
@@ -240,10 +240,14 @@ func (a *accessor) findDirectMethodInfoOnType(ctx context.Context, typeInfo *sca
 
 	pkgObj, err := a.eval.getOrLoadPackage(ctx, typeInfo.PkgPath)
 	if err != nil || pkgObj.ScannedInfo == nil {
+		if pkgObj.ScannedInfo == nil {
+			a.eval.logc(ctx, slog.LevelDebug, "could not get or load package for method resolution", "package", typeInfo.PkgPath)
+			return nil, nil
+		}
 		if err != nil && strings.Contains(err.Error(), "cannot find package") {
 			return nil, nil
 		}
-		a.eval.logc(ctx, slog.LevelWarn, "could not get or load package for method resolution", "package", typeInfo.PkgPath, "error", err)
+		a.eval.logc(ctx, slog.LevelWarn, "unexpected error for method resolution", "package", typeInfo.PkgPath, "error", err)
 		return nil, nil
 	}
 	methodPkg := pkgObj.ScannedInfo


### PR DESCRIPTION
- Add explicit check for nil ScannedInfo in package loading
- Use debug level logging when package info is unavailable
- Clarify warning message for unexpected errors during method resolution